### PR TITLE
Use CAR and padding for piece data

### DIFF
--- a/pieceio/pieceio.go
+++ b/pieceio/pieceio.go
@@ -3,10 +3,13 @@ package pieceio
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-fil-markets/filestore"
+	"io"
+
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-ipld-prime"
+
+	"github.com/filecoin-project/go-fil-markets/filestore"
 )
 
 type SectorCalculator interface {

--- a/pieceio/pieceio.go
+++ b/pieceio/pieceio.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-ipld-prime"
-	"io"
 )
 
 type SectorCalculator interface {
@@ -31,13 +31,14 @@ type pieceIO struct {
 	carIO            CarIO
 	sectorCalculator SectorCalculator
 	store            filestore.FileStore
+	bs               blockstore.Blockstore
 }
 
-func NewPieceIO(padReader PadReader, carIO CarIO, sectorCalculator SectorCalculator, store filestore.FileStore) PieceIO {
-	return &pieceIO{padReader, carIO, sectorCalculator, store}
+func NewPieceIO(padReader PadReader, carIO CarIO, sectorCalculator SectorCalculator, store filestore.FileStore, bs blockstore.Blockstore) PieceIO {
+	return &pieceIO{padReader, carIO, sectorCalculator, store, bs}
 }
 
-func (pio *pieceIO) GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error) {
+func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error) {
 	f, err := pio.store.CreateTemp()
 	if err != nil {
 		return nil, nil, err
@@ -46,7 +47,7 @@ func (pio *pieceIO) GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, se
 		f.Close()
 		_ = pio.store.Delete(f.Path())
 	}
-	err = pio.carIO.WriteCar(context.Background(), bs, payloadCid, selector, f)
+	err = pio.carIO.WriteCar(context.Background(), pio.bs, payloadCid, selector, f)
 	if err != nil {
 		cleanup()
 		return nil, nil, err
@@ -78,6 +79,6 @@ func (pio *pieceIO) GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, se
 	return commitment, f, nil
 }
 
-func (pio *pieceIO) ReadPiece(r io.Reader, bs WriteStore) (cid.Cid, error) {
-	return pio.carIO.LoadCar(bs, r)
+func (pio *pieceIO) ReadPiece(r io.Reader) (cid.Cid, error) {
+	return pio.carIO.LoadCar(pio.bs, r)
 }

--- a/pieceio/types.go
+++ b/pieceio/types.go
@@ -19,6 +19,6 @@ type ReadStore interface {
 
 // PieceIO converts between payloads and pieces
 type PieceIO interface {
-	GeneratePieceCommitment(bs ReadStore, payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error)
-	ReadPiece(r io.Reader, bs WriteStore) (cid.Cid, error)
+	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error)
+	ReadPiece(r io.Reader) (cid.Cid, error)
 }

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -83,7 +83,7 @@ func NewClient(h host.Host, bs blockstore.Blockstore, dataTransfer datatransfer.
 	if err != nil {
 		return nil, err
 	}
-	pio := pieceio.NewPieceIO(pr, carIO, sectorCalculator, fs)
+	pio := pieceio.NewPieceIO(pr, carIO, sectorCalculator, fs, bs)
 
 	c := &Client{
 		h:            h,

--- a/storagemarket/impl/client_utils.go
+++ b/storagemarket/impl/client_utils.go
@@ -41,7 +41,7 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, tmpFile, err := c.pio.GeneratePieceCommitment(c.bs, root, allSelector)
+	commp, tmpFile, err := c.pio.GeneratePieceCommitment(root, allSelector)
 	if err != nil {
 		return nil, 0, xerrors.Errorf("generating CommP: %w", err)
 	}

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
-	ipld "github.com/ipfs/go-ipld-format"
 	"github.com/libp2p/go-libp2p-core/host"
 	inet "github.com/libp2p/go-libp2p-core/network"
 	"golang.org/x/xerrors"
@@ -40,9 +39,7 @@ type Provider struct {
 
 	spn storagemarket.StorageProviderNode
 
-	// TODO: This will go away once storage market module + CAR
-	// is implemented
-	dag ipld.DAGService
+	pio pieceio.PieceIO
 
 	// dataTransfer is the manager of data transfers used by this storage provider
 	dataTransfer datatransfer.Manager
@@ -72,7 +69,7 @@ var (
 	ErrDataTransferFailed = errors.New("deal data transfer failed")
 )
 
-func NewProvider(ds datastore.Batching, dag ipld.DAGService, dataTransfer datatransfer.Manager, spn storagemarket.StorageProviderNode) (storagemarket.StorageProvider, error) {
+func NewProvider(ds datastore.Batching, pio pieceio.PieceIO, dataTransfer datatransfer.Manager, spn storagemarket.StorageProviderNode) (storagemarket.StorageProvider, error) {
 	addr, err := ds.Get(datastore.NewKey("miner-address"))
 	if err != nil {
 		return nil, err
@@ -83,7 +80,7 @@ func NewProvider(ds datastore.Batching, dag ipld.DAGService, dataTransfer datatr
 	}
 
 	h := &Provider{
-		dag:          dag,
+		pio:          pio,
 		dataTransfer: dataTransfer,
 		spn:          spn,
 

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	"github.com/filecoin-project/go-fil-markets/shared/types"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -140,7 +140,7 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, path, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
+	commp, file, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 
 	return func(deal *MinerDeal) {
 		deal.SectorID = sectorID
-		deal.Path = path
+		deal.PiecePath = file.Path()
 	}, nil
 }
 

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -160,7 +160,7 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 			Ref:         deal.Ref,
 			DealID:      deal.DealID,
 		},
-		"",
+		string(deal.PiecePath),
 	)
 
 	if err != nil {

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -1,6 +1,7 @@
 package storageimpl
 
 import (
+	"bytes"
 	"context"
 
 	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
@@ -134,6 +135,21 @@ func (p *Provider) accept(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 // STAGED
 
 func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
+	// entire DAG selector
+	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
+	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
+		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+
+	commp, path, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify CommP matches
+	if !bytes.Equal(commp, deal.Proposal.PieceRef) {
+		return nil, xerrors.Errorf("proposal CommP doesn't match calculated CommP")
+	}
+
 	sectorID, err := p.spn.OnDealComplete(
 		ctx,
 		storagemarket.MinerDeal{
@@ -153,6 +169,7 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 
 	return func(deal *MinerDeal) {
 		deal.SectorID = sectorID
+		deal.Path = path
 	}, nil
 }
 

--- a/storagemarket/impl/provider_utils.go
+++ b/storagemarket/impl/provider_utils.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/ipld/go-ipld-prime"
 
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-data-transfer"
+
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 
 	"github.com/filecoin-project/go-cbor-util"
@@ -58,7 +58,7 @@ func (p *Provider) readProposal(s inet.Stream) (proposal Proposal, err error) {
 		return proposal, xerrors.Errorf("incoming deal proposal has no signature")
 	}
 
-	if err := proposal.DealProposal.Verify(address.Undef); err != nil {
+	if err := proposal.DealProposal.Verify(); err != nil {
 		return proposal, xerrors.Errorf("verifying StorageDealProposal: %w", err)
 	}
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -104,21 +104,15 @@ func (sdp *StorageDealProposal) Cid() (cid.Cid, error) {
 	return nd.Cid(), nil
 }
 
-func (sdp *StorageDealProposal) Verify(worker address.Address) error {
-	if sdp.Client != worker || worker == address.Undef {
-		unsigned := *sdp
-		unsigned.ProposerSignature = nil
-		var buf bytes.Buffer
-		if err := unsigned.MarshalCBOR(&buf); err != nil {
-			return err
-		}
-
-		if err := sdp.ProposerSignature.Verify(sdp.Client, buf.Bytes()); err != nil {
-			return err
-		}
+func (sdp *StorageDealProposal) Verify() error {
+	unsigned := *sdp
+	unsigned.ProposerSignature = nil
+	var buf bytes.Buffer
+	if err := unsigned.MarshalCBOR(&buf); err != nil {
+		return err
 	}
 
-	return nil
+	return sdp.ProposerSignature.Verify(sdp.Client, buf.Bytes())
 }
 
 type StorageDeal struct {

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -143,6 +143,7 @@ type MinerDeal struct {
 	Miner       peer.ID
 	Client      peer.ID
 	State       DealState
+	PiecePath   filestore.Path
 
 	Ref cid.Cid
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
+	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	"github.com/filecoin-project/go-fil-markets/shared/types"
 )


### PR DESCRIPTION
## Summary
The Provider now writes out a padded CAR file of the graph fetched from the client.  It uses this file to calculate `CommP` and verify that it matches the `CommP` in the proposal.  It then saves the path to this file in the `MinerDeal`, so the node can pass this information on to the mining/binpacking module.

Resolves https://github.com/filecoin-project/go-storage-market/issues/15