### PR TITLE
Feat/find providers

### DIFF
--- a/pieceio/cario/cario.go
+++ b/pieceio/cario/cario.go
@@ -3,12 +3,14 @@ package cario
 import (
 	"context"
 	"fmt"
-	"github.com/filecoin-project/go-fil-markets/pieceio"
+	"io"
+
 	"github.com/ipfs/go-car"
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"io"
+
+	"github.com/filecoin-project/go-fil-markets/pieceio"
 )
 
 type carIO struct {

--- a/retrievalmarket/discovery/local.go
+++ b/retrievalmarket/discovery/local.go
@@ -35,8 +35,9 @@ func (l *Local) AddPeer(cid cid.Cid, peer retrievalmarket.RetrievalPeer) error {
 	return l.ds.Put(dshelp.CidToDsKey(cid), entry)
 }
 
-func (l *Local) GetPeers(data cid.Cid) ([]retrievalmarket.RetrievalPeer, error) {
-	entry, err := l.ds.Get(dshelp.CidToDsKey(data))
+func (l *Local) GetPeers(pieceCID []byte) ([]retrievalmarket.RetrievalPeer, error) {
+	key := string(pieceCID[:])
+	entry, err := l.ds.Get(datastore.NewKey(key))
 	if err == datastore.ErrNotFound {
 		return []retrievalmarket.RetrievalPeer{}, nil
 	}

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -2,7 +2,6 @@ package retrievalimpl
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"sync"
 
@@ -37,7 +36,11 @@ type client struct {
 }
 
 // NewClient creates a new retrieval client
-func NewClient(network rmnet.RetrievalMarketNetwork, bs blockstore.Blockstore, node retrievalmarket.RetrievalClientNode, resolver retrievalmarket.PeerResolver) retrievalmarket.RetrievalClient {
+func NewClient(
+	network rmnet.RetrievalMarketNetwork,
+	bs blockstore.Blockstore,
+	node retrievalmarket.RetrievalClientNode,
+	resolver retrievalmarket.PeerResolver) retrievalmarket.RetrievalClient {
 	return &client{
 		network:  network,
 		bs:       bs,
@@ -51,13 +54,9 @@ func NewClient(network rmnet.RetrievalMarketNetwork, bs blockstore.Blockstore, n
 // TODO: Implement for retrieval provider V0 epic
 // https://github.com/filecoin-project/go-retrieval-market-project/issues/12
 func (c *client) FindProviders(pieceCIDBytes []byte) []retrievalmarket.RetrievalPeer {
-	cidLen, pieceCid, err := cid.CidFromBytes(pieceCIDBytes)
+	_, pieceCid, err := cid.CidFromBytes(pieceCIDBytes)
 	if err != nil {
 		log.Error(err)
-		return []retrievalmarket.RetrievalPeer{}
-	}
-	if cidLen == 0 {
-		log.Error(errors.New("zero-length CID"))
 		return []retrievalmarket.RetrievalPeer{}
 	}
 	peers, err := c.resolver.GetPeers(pieceCid)

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -5,16 +5,16 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
-
 	"github.com/filecoin-project/go-address"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 )
@@ -53,13 +53,8 @@ func NewClient(
 
 // TODO: Implement for retrieval provider V0 epic
 // https://github.com/filecoin-project/go-retrieval-market-project/issues/12
-func (c *client) FindProviders(pieceCIDBytes []byte) []retrievalmarket.RetrievalPeer {
-	_, pieceCid, err := cid.CidFromBytes(pieceCIDBytes)
-	if err != nil {
-		log.Error(err)
-		return []retrievalmarket.RetrievalPeer{}
-	}
-	peers, err := c.resolver.GetPeers(pieceCid)
+func (c *client) FindProviders(pieceCID []byte) []retrievalmarket.RetrievalPeer {
+	peers, err := c.resolver.GetPeers(pieceCID)
 	if err != nil {
 		log.Error(err)
 		return []retrievalmarket.RetrievalPeer{}
@@ -153,7 +148,7 @@ func (c *client) handleDeal(ctx context.Context, dealState retrievalmarket.Clien
 		case retrievalmarket.DealStatusFundsNeeded, retrievalmarket.DealStatusFundsNeededLastPayment:
 			handler = clientstates.ProcessNextResponse
 		default:
-			c.failDeal(&dealState, errors.New("unexpected deal state"))
+			c.failDeal(&dealState, xerrors.New("unexpected deal state"))
 			return
 		}
 		dealModifier := handler(ctx, environment, dealState)

--- a/retrievalmarket/impl/client_test.go
+++ b/retrievalmarket/impl/client_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
-	"github.com/filecoin-project/go-fil-markets/shared/types"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -139,39 +138,24 @@ func TestClient_FindProviders(t *testing.T) {
 		peers := tut.RequireGenerateRetrievalPeers(t, 3)
 		testResolver := testPeerResolver{peers: peers}
 
-		c := retrievalimpl.NewClient(net, bs, &testRetrievalNode{}, &testResolver)
+		c := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver)
 		testCid := []byte("somePieceCID")
 		assert.Len(t, c.FindProviders(testCid), 3)
 	})
 
 	t.Run("when there is an error, returns empty provider list", func(t *testing.T) {
 		testResolver := testPeerResolver{peers: []retrievalmarket.RetrievalPeer{}, resolverError: errors.New("boom")}
-		c := retrievalimpl.NewClient(net, bs, &testRetrievalNode{}, &testResolver)
+		c := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver)
 		badCid := []byte("doesn't matter")
 		assert.Len(t, c.FindProviders(badCid), 0)
 	})
 
 	t.Run("when there are no providers", func(t *testing.T) {
 		testResolver := testPeerResolver{peers: []retrievalmarket.RetrievalPeer{}}
-		c := retrievalimpl.NewClient(net, bs, &testRetrievalNode{}, &testResolver)
+		c := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver)
 		testCid := []byte("unimportant")
 		assert.Len(t, c.FindProviders(testCid), 0)
 	})
-}
-
-type testRetrievalNode struct {
-}
-
-func (t *testRetrievalNode) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable tokenamount.TokenAmount) (address.Address, error) {
-	return address.Address{}, nil
-}
-
-func (t *testRetrievalNode) AllocateLane(paymentChannel address.Address) (uint64, error) {
-	return 0, nil
-}
-
-func (t *testRetrievalNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount tokenamount.TokenAmount, lane uint64) (*types.SignedVoucher, error) {
-	return nil, nil
 }
 
 type testPeerResolver struct {

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -200,7 +200,7 @@ type RetrievalProviderNode interface {
 
 // PeerResolver is an interface for looking up providers that may have a piece
 type PeerResolver interface {
-	GetPeers(data cid.Cid) ([]RetrievalPeer, error) // TODO: channel
+	GetPeers(pieceCID []byte) ([]RetrievalPeer, error) // TODO: channel
 }
 
 // RetrievalPeer is a provider address/peer.ID pair (everything needed to make

--- a/shared_testutil/test_types.go
+++ b/shared_testutil/test_types.go
@@ -3,9 +3,12 @@ package shared_testutil
 import (
 	"math/big"
 	"math/rand"
+	"testing"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-data-transfer/testutil"
+	"github.com/libp2p/go-libp2p-core/test"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
@@ -106,4 +109,19 @@ func MakeTestDealPayment() retrievalmarket.DealPayment {
 		PaymentChannel: address.TestAddress,
 		PaymentVoucher: MakeTestSignedVoucher(),
 	}
+}
+
+func RequireGenerateRetrievalPeers(t *testing.T, numPeers int) []retrievalmarket.RetrievalPeer {
+	peers := make([]retrievalmarket.RetrievalPeer, numPeers)
+	for i := range peers {
+		pid, err := test.RandPeerID()
+		require.NoError(t, err)
+		addr, err := address.NewIDAddress(rand.Uint64())
+		require.NoError(t, err)
+		peers[i] = retrievalmarket.RetrievalPeer{
+			Address: addr,
+			ID:      pid,
+		}
+	}
+	return peers
 }


### PR DESCRIPTION
Closes [Zenhub Retrieval Market Project Issue #12](https://app.zenhub.com/workspaces/retrieval-market-5de558a85ea8f94a5e0882c1/issues/filecoin-project/go-retrieval-market-project/12)

Implement client.FindProviders method which just calls PeerResolver.GetPeers with the desired PieceCID; unit test with test PeerResolver