### PR TITLE
Expose generic pieceio.GeneratePieceCommitment(Reader, size)

### DIFF
--- a/pieceio/padreader/padreader.go
+++ b/pieceio/padreader/padreader.go
@@ -5,18 +5,10 @@ import (
 	"math/bits"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-fil-markets/pieceio"
 )
 
-type padReader struct {
-}
-
-func NewPadReader() pieceio.PadReader {
-	return &padReader{}
-}
-
 // Functions bellow copied from lotus/lib/padreader/padreader.go
-func (p padReader) PaddedSize(size uint64) uint64 {
+func PaddedSize(size uint64) uint64 {
 	logv := 64 - bits.LeadingZeros64(size)
 
 	sectSize := uint64(1 << logv)
@@ -38,7 +30,7 @@ func (nr nullReader) Read(b []byte) (int, error) {
 }
 
 func NewPaddedReader(r io.Reader, size uint64) (io.Reader, uint64) {
-	padSize := NewPadReader().PaddedSize(size)
+	padSize := PaddedSize(size)
 
 	return io.MultiReader(
 		io.LimitReader(r, int64(size)),

--- a/pieceio/pieceio.go
+++ b/pieceio/pieceio.go
@@ -2,7 +2,6 @@ package pieceio
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -10,13 +9,9 @@ import (
 	"github.com/ipld/go-ipld-prime"
 
 	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-sectorbuilder"
 )
-
-type PadReader interface {
-	// PaddedSize returns the expected size of a piece after it's been padded
-	PaddedSize(size uint64) uint64
-}
 
 type CarIO interface {
 	// WriteCar writes a given payload to a CAR file and into the passed IO stream
@@ -26,20 +21,19 @@ type CarIO interface {
 }
 
 type pieceIO struct {
-	padReader PadReader
-	carIO     CarIO
-	store     filestore.FileStore
-	bs        blockstore.Blockstore
+	carIO CarIO
+	store filestore.FileStore
+	bs    blockstore.Blockstore
 }
 
-func NewPieceIO(padReader PadReader, carIO CarIO, store filestore.FileStore, bs blockstore.Blockstore) PieceIO {
-	return &pieceIO{padReader, carIO, store, bs}
+func NewPieceIO(carIO CarIO, store filestore.FileStore, bs blockstore.Blockstore) PieceIO {
+	return &pieceIO{carIO, store, bs}
 }
 
-func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error) {
+func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, uint64, error) {
 	f, err := pio.store.CreateTemp()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	cleanup := func() {
 		f.Close()
@@ -48,33 +42,29 @@ func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.No
 	err = pio.carIO.WriteCar(context.Background(), pio.bs, payloadCid, selector, f)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	size := f.Size()
-	pieceSize := uint64(size)
-	paddedSize := pio.padReader.PaddedSize(pieceSize)
-	remaining := paddedSize - pieceSize
-	padbuf := make([]byte, remaining)
-	padded, err := f.Write(padbuf)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	if uint64(padded) != remaining {
-		cleanup()
-		return nil, nil, fmt.Errorf("wrote %d byte of padding while expecting %d to be written", padded, remaining)
-	}
+	pieceSize := uint64(f.Size())
 	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	commitment, err := sectorbuilder.GeneratePieceCommitment(f, paddedSize)
+	commitment, paddedSize, err := GeneratePieceCommitment(f, pieceSize)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	return commitment[:], f, nil
+	return commitment, f, paddedSize, nil
+}
+
+func GeneratePieceCommitment(rd io.Reader, pieceSize uint64) ([]byte, uint64, error) {
+	paddedReader, paddedSize := padreader.NewPaddedReader(rd, pieceSize)
+	commitment, err := sectorbuilder.GeneratePieceCommitment(paddedReader, paddedSize)
+	if err != nil {
+		return nil, 0, err
+	}
+	return commitment[:], paddedSize, nil
 }
 
 func (pio *pieceIO) ReadPiece(r io.Reader) (cid.Cid, error) {

--- a/pieceio/pieceio_test.go
+++ b/pieceio/pieceio_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	fsmocks "github.com/filecoin-project/go-fil-markets/filestore/mocks"
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	pmocks "github.com/filecoin-project/go-fil-markets/pieceio/mocks"
-	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-sectorbuilder"
 	dag "github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
@@ -24,7 +24,6 @@ import (
 
 func Test_ThereAndBackAgain(t *testing.T) {
 	tempDir := filestore.Path("./tempDir")
-	pr := padreader.NewPadReader()
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -33,7 +32,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 	sourceBserv := dstest.Bserv()
 	sourceBs := sourceBserv.Blockstore()
 
-	pio := pieceio.NewPieceIO(pr, cio, store, sourceBs)
+	pio := pieceio.NewPieceIO(cio, store, sourceBs)
 	require.NoError(t, err)
 
 	dserv := dag.NewDAGService(sourceBserv)
@@ -66,7 +65,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	bytes, tmpFile, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	bytes, tmpFile, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -115,7 +114,6 @@ func Test_ThereAndBackAgain(t *testing.T) {
 
 func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 	tempDir := filestore.Path("./tempDir")
-	pr := padreader.NewPadReader()
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -123,7 +121,7 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 
 	sourceBserv := dstest.Bserv()
 	sourceBs := sourceBserv.Blockstore()
-	pio := pieceio.NewPieceIO(pr, cio, store, sourceBs)
+	pio := pieceio.NewPieceIO(cio, store, sourceBs)
 
 	dserv := dag.NewDAGService(sourceBserv)
 	a := dag.NewRawNode([]byte("aaaa"))
@@ -155,7 +153,7 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	commitment, tmpFile, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	commitment, tmpFile, paddedSize, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -169,11 +167,11 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 	for _, b := range commitment {
 		require.NotEqual(t, 0, b)
 	}
-	buf := make([]byte, tmpFile.Size())
+	buf := make([]byte, paddedSize)
 	_, err = tmpFile.Read(buf)
 	require.NoError(t, err)
 	buffer := bytes.NewBuffer(buf)
-	secondCommitment, err := sectorbuilder.GeneratePieceCommitment(buffer, uint64(tmpFile.Size()))
+	secondCommitment, err := sectorbuilder.GeneratePieceCommitment(buffer, paddedSize)
 	require.NoError(t, err)
 	require.Equal(t, commitment, secondCommitment[:])
 }
@@ -214,79 +212,23 @@ func Test_Failures(t *testing.T) {
 	t.Run("create temp file fails", func(t *testing.T) {
 		fsmock := fsmocks.FileStore{}
 		fsmock.On("CreateTemp").Return(nil, fmt.Errorf("Failed"))
-		pio := pieceio.NewPieceIO(nil, nil, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(nil, &fsmock, sourceBs)
+		_, _, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 	t.Run("write CAR fails", func(t *testing.T) {
 		tempDir := filestore.Path("./tempDir")
-		pr := padreader.NewPadReader()
 		store, err := filestore.NewLocalFileStore(tempDir)
 		require.NoError(t, err)
 
 		ciomock := pmocks.CarIO{}
 		any := mock.Anything
 		ciomock.On("WriteCar", any, any, any, any, any).Return(fmt.Errorf("failed to write car"))
-		pio := pieceio.NewPieceIO(pr, &ciomock, store, sourceBs)
-		_, _, err = pio.GeneratePieceCommitment(nd3.Cid(), node)
-		require.Error(t, err)
-	})
-	t.Run("padding fails", func(t *testing.T) {
-		pr := padreader.NewPadReader()
-		cio := cario.NewCarIO()
-
-		fsmock := fsmocks.FileStore{}
-		mockfile := fsmocks.File{}
-
-		fsmock.On("CreateTemp").Return(&mockfile, nil).Once()
-		fsmock.On("Delete", mock.Anything).Return(nil).Once()
-
-		counter := 0
-		size := 0
-		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
-			arg := args[0]
-			buf := arg.([]byte)
-			size := len(buf)
-			counter += size
-		}).Return(size, nil).Times(17)
-		mockfile.On("Size").Return(int64(484))
-		mockfile.On("Write", mock.Anything).Return(0, fmt.Errorf("write failed")).Once()
-		mockfile.On("Close").Return(nil).Once()
-		mockfile.On("Path").Return(filestore.Path("mock")).Once()
-
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
-		require.Error(t, err)
-	})
-	t.Run("incorrect padding", func(t *testing.T) {
-		pr := padreader.NewPadReader()
-		cio := cario.NewCarIO()
-
-		fsmock := fsmocks.FileStore{}
-		mockfile := fsmocks.File{}
-
-		fsmock.On("CreateTemp").Return(&mockfile, nil).Once()
-		fsmock.On("Delete", mock.Anything).Return(nil).Once()
-
-		counter := 0
-		size := 0
-		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
-			arg := args[0]
-			buf := arg.([]byte)
-			size := len(buf)
-			counter += size
-		}).Return(size, nil).Times(17)
-		mockfile.On("Size").Return(int64(484))
-		mockfile.On("Write", mock.Anything).Return(16, nil).Once()
-		mockfile.On("Close").Return(nil).Once()
-		mockfile.On("Path").Return(filestore.Path("mock")).Once()
-
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(&ciomock, store, sourceBs)
+		_, _, _, err = pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 	t.Run("seek fails", func(t *testing.T) {
-		pr := padreader.NewPadReader()
 		cio := cario.NewCarIO()
 
 		fsmock := fsmocks.FileStore{}
@@ -309,8 +251,8 @@ func Test_Failures(t *testing.T) {
 		mockfile.On("Path").Return(filestore.Path("mock")).Once()
 		mockfile.On("Seek", mock.Anything, mock.Anything).Return(int64(0), fmt.Errorf("seek failed"))
 
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(cio, &fsmock, sourceBs)
+		_, _, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 }

--- a/pieceio/types.go
+++ b/pieceio/types.go
@@ -19,6 +19,6 @@ type ReadStore interface {
 
 // PieceIO converts between payloads and pieces
 type PieceIO interface {
-	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error)
+	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, uint64, error)
 	ReadPiece(r io.Reader) (cid.Cid, error)
 }

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
-	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 
 	"github.com/ipfs/go-cid"
@@ -75,13 +74,12 @@ type clientDealUpdate struct {
 }
 
 func NewClient(h host.Host, bs blockstore.Blockstore, dataTransfer datatransfer.Manager, discovery *discovery.Local, deals *statestore.StateStore, scn storagemarket.StorageClientNode) (*Client, error) {
-	pr := padreader.NewPadReader()
 	carIO := cario.NewCarIO()
 	fs, err := filestore.NewLocalFileStore("")
 	if err != nil {
 		return nil, err
 	}
-	pio := pieceio.NewPieceIO(pr, carIO, fs, bs)
+	pio := pieceio.NewPieceIO(carIO, fs, bs)
 
 	c := &Client{
 		h:            h,

--- a/storagemarket/impl/client_utils.go
+++ b/storagemarket/impl/client_utils.go
@@ -41,11 +41,10 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, tmpFile, err := c.pio.GeneratePieceCommitment(root, allSelector)
+	commp, tmpFile, paddedSize, err := c.pio.GeneratePieceCommitment(root, allSelector)
 	if err != nil {
 		return nil, 0, xerrors.Errorf("generating CommP: %w", err)
 	}
-	size := tmpFile.Size()
 
 	err = tmpFile.Close()
 	if err != nil {
@@ -57,7 +56,7 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 		return nil, 0, xerrors.Errorf("error deleting temp file from filestore: %w", err)
 	}
 
-	return commp[:], uint64(size), nil
+	return commp[:], paddedSize, nil
 }
 
 func (c *Client) readStorageDealResp(deal ClientDeal) (*Response, error) {

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -107,7 +107,7 @@ func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerD
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, file, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
+	commp, file, _, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Testing the waters a bit here, let me know if this isn't worth pursuing. Happy to do more cleanup, tests, whatever else, I just need some guidance.

* Adds a static `func GeneratePieceCommitment(rd io.Reader, pieceSize uint64) ([]byte, uint64, error)` that's called by `PieceIO#GeneratePieceCommitment()`.
* Refactor use of PadReader
* Don't pad internal CAR files, wrap in PadReader and pass around paddedSize rather than using car.Size()

Ultimately it would allow us to externally generate CommP for an arbitrary `Reader` .. so, for example, we could run this in Lambda across pre-formed CAR files streamed from S3.