### PR TITLE
Remove filestore as a go between with StorageMiner, pass direct io.reader to StorageMiner

### DIFF
--- a/filestore/file.go
+++ b/filestore/file.go
@@ -11,7 +11,7 @@ type fd struct {
 	basepath string
 }
 
-func newFile(basepath, filename Path) (File, error) {
+func newFile(basepath OsPath, filename Path) (File, error) {
 	var err error
 	result := fd{filename: string(filename), basepath: string(basepath)}
 	full := path.Join(string(basepath), string(filename))
@@ -23,7 +23,11 @@ func newFile(basepath, filename Path) (File, error) {
 }
 
 func (f fd) Path() Path {
-	return Path(f.Name())
+	return Path(f.filename)
+}
+
+func (f fd) OsPath() OsPath {
+	return OsPath(f.Name())
 }
 
 func (f fd) Size() int64 {

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -58,7 +58,7 @@ func Test_OpenFileFails(t *testing.T) {
 	base := "_test/a/b/c/d/e"
 	err := os.MkdirAll(base, 0755)
 	require.NoError(t, err)
-	store, err := NewLocalFileStore(Path(base))
+	store, err := NewLocalFileStore(OsPath(base))
 	require.NoError(t, err)
 	err = os.Remove(base)
 	require.NoError(t, err)
@@ -69,7 +69,7 @@ func Test_OpenFileFails(t *testing.T) {
 func Test_RemoveSeparators(t *testing.T) {
 	first, err := NewLocalFileStore(baseDir)
 	require.NoError(t, err)
-	second, err := NewLocalFileStore(Path(fmt.Sprintf("%s%c%c", baseDir, os.PathSeparator, os.PathSeparator)))
+	second, err := NewLocalFileStore(OsPath(fmt.Sprintf("%s%c%c", baseDir, os.PathSeparator, os.PathSeparator)))
 	require.NoError(t, err)
 	f1, err := first.Open(existingFile)
 	require.NoError(t, err)
@@ -80,7 +80,7 @@ func Test_RemoveSeparators(t *testing.T) {
 
 func Test_BaseDirIsFileFails(t *testing.T) {
 	base := fmt.Sprintf("%s%c%s", baseDir, os.PathSeparator, existingFile)
-	_, err := NewLocalFileStore(Path(base))
+	_, err := NewLocalFileStore(OsPath(base))
 	require.Error(t, err)
 }
 
@@ -117,14 +117,12 @@ func Test_CreateFile(t *testing.T) {
 	store, err := NewLocalFileStore(baseDir)
 	require.NoError(t, err)
 	name := Path("newFile.txt")
-	path := fmt.Sprintf("%s%c%s", baseDir, os.PathSeparator, name)
 	f, err := store.Create(name)
 	require.NoError(t, err)
 	defer func() {
 		err := store.Delete(f.Path())
 		require.NoError(t, err)
 	}()
-	require.Equal(t, Path(path), f.Path())
 	bytesToWrite := 32
 	written, err := f.Write(randBytes(bytesToWrite))
 	require.NoError(t, err)

--- a/filestore/mocks/File.go
+++ b/filestore/mocks/File.go
@@ -38,6 +38,20 @@ func (_m *File) Path() filestore.Path {
 	return r0
 }
 
+// OsPath provides a mock function with given fields:
+func (_m *File) OsPath() filestore.OsPath {
+	ret := _m.Called()
+
+	var r0 filestore.OsPath
+	if rf, ok := ret.Get(0).(func() filestore.OsPath); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(filestore.OsPath)
+	}
+
+	return r0
+}
+
 // Read provides a mock function with given fields: p
 func (_m *File) Read(p []byte) (int, error) {
 	ret := _m.Called(p)

--- a/filestore/types.go
+++ b/filestore/types.go
@@ -5,9 +5,14 @@ import "io"
 // Path represents an abstract path to a file
 type Path string
 
+// OsPath represents a path that can be located on
+// the operating system with standard os.File operations
+type OsPath string
+
 // File is a wrapper around an os file
 type File interface {
 	Path() Path
+	OsPath() OsPath
 	Size() int64
 
 	io.Closer

--- a/pieceio/padreader/padreader.go
+++ b/pieceio/padreader/padreader.go
@@ -5,18 +5,10 @@ import (
 	"math/bits"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-fil-markets/pieceio"
 )
 
-type padReader struct {
-}
-
-func NewPadReader() pieceio.PadReader {
-	return &padReader{}
-}
-
 // Functions bellow copied from lotus/lib/padreader/padreader.go
-func (p padReader) PaddedSize(size uint64) uint64 {
+func PaddedSize(size uint64) uint64 {
 	logv := 64 - bits.LeadingZeros64(size)
 
 	sectSize := uint64(1 << logv)
@@ -38,7 +30,7 @@ func (nr nullReader) Read(b []byte) (int, error) {
 }
 
 func NewPaddedReader(r io.Reader, size uint64) (io.Reader, uint64) {
-	padSize := NewPadReader().PaddedSize(size)
+	padSize := PaddedSize(size)
 
 	return io.MultiReader(
 		io.LimitReader(r, int64(size)),

--- a/pieceio/pieceio.go
+++ b/pieceio/pieceio.go
@@ -2,7 +2,6 @@ package pieceio
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	"github.com/ipfs/go-cid"
@@ -10,13 +9,9 @@ import (
 	"github.com/ipld/go-ipld-prime"
 
 	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-sectorbuilder"
 )
-
-type PadReader interface {
-	// PaddedSize returns the expected size of a piece after it's been padded
-	PaddedSize(size uint64) uint64
-}
 
 type CarIO interface {
 	// WriteCar writes a given payload to a CAR file and into the passed IO stream
@@ -26,20 +21,19 @@ type CarIO interface {
 }
 
 type pieceIO struct {
-	padReader PadReader
-	carIO     CarIO
-	store     filestore.FileStore
-	bs        blockstore.Blockstore
+	carIO CarIO
+	store filestore.FileStore
+	bs    blockstore.Blockstore
 }
 
-func NewPieceIO(padReader PadReader, carIO CarIO, store filestore.FileStore, bs blockstore.Blockstore) PieceIO {
-	return &pieceIO{padReader, carIO, store, bs}
+func NewPieceIO(carIO CarIO, store filestore.FileStore, bs blockstore.Blockstore) PieceIO {
+	return &pieceIO{carIO, store, bs}
 }
 
-func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error) {
+func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, uint64, error) {
 	f, err := pio.store.CreateTemp()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	cleanup := func() {
 		f.Close()
@@ -48,33 +42,29 @@ func (pio *pieceIO) GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.No
 	err = pio.carIO.WriteCar(context.Background(), pio.bs, payloadCid, selector, f)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	size := f.Size()
-	pieceSize := uint64(size)
-	paddedSize := pio.padReader.PaddedSize(pieceSize)
-	remaining := paddedSize - pieceSize
-	padbuf := make([]byte, remaining)
-	padded, err := f.Write(padbuf)
-	if err != nil {
-		cleanup()
-		return nil, nil, err
-	}
-	if uint64(padded) != remaining {
-		cleanup()
-		return nil, nil, fmt.Errorf("wrote %d byte of padding while expecting %d to be written", padded, remaining)
-	}
+	pieceSize := uint64(f.Size())
 	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	commitment, err := sectorbuilder.GeneratePieceCommitment(f, paddedSize)
+	commitment, paddedSize, err := GeneratePieceCommitment(f, pieceSize)
 	if err != nil {
 		cleanup()
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	return commitment[:], f, nil
+	return commitment, f, paddedSize, nil
+}
+
+func GeneratePieceCommitment(rd io.Reader, pieceSize uint64) ([]byte, uint64, error) {
+	paddedReader, paddedSize := padreader.NewPaddedReader(rd, pieceSize)
+	commitment, err := sectorbuilder.GeneratePieceCommitment(paddedReader, paddedSize)
+	if err != nil {
+		return nil, 0, err
+	}
+	return commitment[:], paddedSize, nil
 }
 
 func (pio *pieceIO) ReadPiece(r io.Reader) (cid.Cid, error) {

--- a/pieceio/pieceio_test.go
+++ b/pieceio/pieceio_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Test_ThereAndBackAgain(t *testing.T) {
-	tempDir := filestore.Path("./tempDir")
+	tempDir := filestore.OsPath("./tempDir")
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -65,7 +65,9 @@ func Test_ThereAndBackAgain(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	bytes, tmpFile, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	bytes, tmpPath, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	require.NoError(t, err)
+	tmpFile, err := store.Open(tmpPath)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -113,7 +115,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 }
 
 func Test_StoreRestoreMemoryBuffer(t *testing.T) {
-	tempDir := filestore.Path("./tempDir")
+	tempDir := filestore.OsPath("./tempDir")
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -153,7 +155,9 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	commitment, tmpFile, paddedSize, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	commitment, tmpPath, paddedSize, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	require.NoError(t, err)
+	tmpFile, err := store.Open(tmpPath)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -161,6 +165,7 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 		deferErr = store.Delete(tmpFile.Path())
 		require.NoError(t, deferErr)
 	}()
+
 	_, err = tmpFile.Seek(0, io.SeekStart)
 	require.NoError(t, err)
 
@@ -217,7 +222,7 @@ func Test_Failures(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("write CAR fails", func(t *testing.T) {
-		tempDir := filestore.Path("./tempDir")
+		tempDir := filestore.OsPath("./tempDir")
 		store, err := filestore.NewLocalFileStore(tempDir)
 		require.NoError(t, err)
 

--- a/pieceio/pieceio_test.go
+++ b/pieceio/pieceio_test.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	fsmocks "github.com/filecoin-project/go-fil-markets/filestore/mocks"
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	pmocks "github.com/filecoin-project/go-fil-markets/pieceio/mocks"
-	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-sectorbuilder"
 	dag "github.com/ipfs/go-merkledag"
 	dstest "github.com/ipfs/go-merkledag/test"
@@ -24,7 +24,6 @@ import (
 
 func Test_ThereAndBackAgain(t *testing.T) {
 	tempDir := filestore.Path("./tempDir")
-	pr := padreader.NewPadReader()
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -33,7 +32,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 	sourceBserv := dstest.Bserv()
 	sourceBs := sourceBserv.Blockstore()
 
-	pio := pieceio.NewPieceIO(pr, cio, store, sourceBs)
+	pio := pieceio.NewPieceIO(cio, store, sourceBs)
 	require.NoError(t, err)
 
 	dserv := dag.NewDAGService(sourceBserv)
@@ -66,7 +65,7 @@ func Test_ThereAndBackAgain(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	bytes, tmpFile, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	bytes, tmpFile, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -115,7 +114,6 @@ func Test_ThereAndBackAgain(t *testing.T) {
 
 func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 	tempDir := filestore.Path("./tempDir")
-	pr := padreader.NewPadReader()
 	cio := cario.NewCarIO()
 
 	store, err := filestore.NewLocalFileStore(tempDir)
@@ -123,7 +121,7 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 
 	sourceBserv := dstest.Bserv()
 	sourceBs := sourceBserv.Blockstore()
-	pio := pieceio.NewPieceIO(pr, cio, store, sourceBs)
+	pio := pieceio.NewPieceIO(cio, store, sourceBs)
 
 	dserv := dag.NewDAGService(sourceBserv)
 	a := dag.NewRawNode([]byte("aaaa"))
@@ -155,7 +153,7 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 			ssb.ExploreIndex(1, ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge()))))
 	}).Node()
 
-	commitment, tmpFile, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+	commitment, tmpFile, paddedSize, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 	require.NoError(t, err)
 	defer func() {
 		deferErr := tmpFile.Close()
@@ -169,11 +167,11 @@ func Test_StoreRestoreMemoryBuffer(t *testing.T) {
 	for _, b := range commitment {
 		require.NotEqual(t, 0, b)
 	}
-	buf := make([]byte, tmpFile.Size())
+	buf := make([]byte, paddedSize)
 	_, err = tmpFile.Read(buf)
 	require.NoError(t, err)
 	buffer := bytes.NewBuffer(buf)
-	secondCommitment, err := sectorbuilder.GeneratePieceCommitment(buffer, uint64(tmpFile.Size()))
+	secondCommitment, err := sectorbuilder.GeneratePieceCommitment(buffer, paddedSize)
 	require.NoError(t, err)
 	require.Equal(t, commitment, secondCommitment[:])
 }
@@ -214,79 +212,23 @@ func Test_Failures(t *testing.T) {
 	t.Run("create temp file fails", func(t *testing.T) {
 		fsmock := fsmocks.FileStore{}
 		fsmock.On("CreateTemp").Return(nil, fmt.Errorf("Failed"))
-		pio := pieceio.NewPieceIO(nil, nil, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(nil, &fsmock, sourceBs)
+		_, _, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 	t.Run("write CAR fails", func(t *testing.T) {
 		tempDir := filestore.Path("./tempDir")
-		pr := padreader.NewPadReader()
 		store, err := filestore.NewLocalFileStore(tempDir)
 		require.NoError(t, err)
 
 		ciomock := pmocks.CarIO{}
 		any := mock.Anything
 		ciomock.On("WriteCar", any, any, any, any, any).Return(fmt.Errorf("failed to write car"))
-		pio := pieceio.NewPieceIO(pr, &ciomock, store, sourceBs)
-		_, _, err = pio.GeneratePieceCommitment(nd3.Cid(), node)
-		require.Error(t, err)
-	})
-	t.Run("padding fails", func(t *testing.T) {
-		pr := padreader.NewPadReader()
-		cio := cario.NewCarIO()
-
-		fsmock := fsmocks.FileStore{}
-		mockfile := fsmocks.File{}
-
-		fsmock.On("CreateTemp").Return(&mockfile, nil).Once()
-		fsmock.On("Delete", mock.Anything).Return(nil).Once()
-
-		counter := 0
-		size := 0
-		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
-			arg := args[0]
-			buf := arg.([]byte)
-			size := len(buf)
-			counter += size
-		}).Return(size, nil).Times(17)
-		mockfile.On("Size").Return(int64(484))
-		mockfile.On("Write", mock.Anything).Return(0, fmt.Errorf("write failed")).Once()
-		mockfile.On("Close").Return(nil).Once()
-		mockfile.On("Path").Return(filestore.Path("mock")).Once()
-
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
-		require.Error(t, err)
-	})
-	t.Run("incorrect padding", func(t *testing.T) {
-		pr := padreader.NewPadReader()
-		cio := cario.NewCarIO()
-
-		fsmock := fsmocks.FileStore{}
-		mockfile := fsmocks.File{}
-
-		fsmock.On("CreateTemp").Return(&mockfile, nil).Once()
-		fsmock.On("Delete", mock.Anything).Return(nil).Once()
-
-		counter := 0
-		size := 0
-		mockfile.On("Write", mock.Anything).Run(func(args mock.Arguments) {
-			arg := args[0]
-			buf := arg.([]byte)
-			size := len(buf)
-			counter += size
-		}).Return(size, nil).Times(17)
-		mockfile.On("Size").Return(int64(484))
-		mockfile.On("Write", mock.Anything).Return(16, nil).Once()
-		mockfile.On("Close").Return(nil).Once()
-		mockfile.On("Path").Return(filestore.Path("mock")).Once()
-
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(&ciomock, store, sourceBs)
+		_, _, _, err = pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 	t.Run("seek fails", func(t *testing.T) {
-		pr := padreader.NewPadReader()
 		cio := cario.NewCarIO()
 
 		fsmock := fsmocks.FileStore{}
@@ -309,8 +251,8 @@ func Test_Failures(t *testing.T) {
 		mockfile.On("Path").Return(filestore.Path("mock")).Once()
 		mockfile.On("Seek", mock.Anything, mock.Anything).Return(int64(0), fmt.Errorf("seek failed"))
 
-		pio := pieceio.NewPieceIO(pr, cio, &fsmock, sourceBs)
-		_, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
+		pio := pieceio.NewPieceIO(cio, &fsmock, sourceBs)
+		_, _, _, err := pio.GeneratePieceCommitment(nd3.Cid(), node)
 		require.Error(t, err)
 	})
 }

--- a/pieceio/types.go
+++ b/pieceio/types.go
@@ -19,6 +19,6 @@ type ReadStore interface {
 
 // PieceIO converts between payloads and pieces
 type PieceIO interface {
-	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, error)
+	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, uint64, error)
 	ReadPiece(r io.Reader) (cid.Cid, error)
 }

--- a/pieceio/types.go
+++ b/pieceio/types.go
@@ -19,6 +19,6 @@ type ReadStore interface {
 
 // PieceIO converts between payloads and pieces
 type PieceIO interface {
-	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.File, uint64, error)
+	GeneratePieceCommitment(payloadCid cid.Cid, selector ipld.Node) ([]byte, filestore.Path, uint64, error)
 	ReadPiece(r io.Reader) (cid.Cid, error)
 }

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -3,31 +3,26 @@ package storageimpl
 import (
 	"context"
 
-	"github.com/filecoin-project/go-data-transfer"
-	blockstore "github.com/ipfs/go-ipfs-blockstore"
-
-	"github.com/filecoin-project/go-fil-markets/filestore"
-	"github.com/filecoin-project/go-fil-markets/pieceio"
-	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
-	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
-
+	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/ipfs/go-cid"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/host"
 	inet "github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-cbor-util"
-
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/pieceio"
+	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/discovery"
-
-	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-statestore"
-
+	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	"github.com/filecoin-project/go-fil-markets/shared/types"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/go-statestore"
 )
 
 //go:generate cbor-gen-for ClientDeal ClientDealProposal
@@ -73,12 +68,8 @@ type clientDealUpdate struct {
 	mut      func(*ClientDeal)
 }
 
-func NewClient(h host.Host, bs blockstore.Blockstore, dataTransfer datatransfer.Manager, discovery *discovery.Local, deals *statestore.StateStore, scn storagemarket.StorageClientNode) (*Client, error) {
+func NewClient(h host.Host, bs blockstore.Blockstore, fs filestore.FileStore, dataTransfer datatransfer.Manager, discovery *discovery.Local, deals *statestore.StateStore, scn storagemarket.StorageClientNode) *Client {
 	carIO := cario.NewCarIO()
-	fs, err := filestore.NewLocalFileStore("")
-	if err != nil {
-		return nil, err
-	}
 	pio := pieceio.NewPieceIO(carIO, fs, bs)
 
 	c := &Client{
@@ -100,7 +91,7 @@ func NewClient(h host.Host, bs blockstore.Blockstore, dataTransfer datatransfer.
 		stopped: make(chan struct{}),
 	}
 
-	return c, nil
+	return c
 }
 
 func (c *Client) Run(ctx context.Context) {

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
-	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 
 	"github.com/ipfs/go-cid"
@@ -75,13 +74,12 @@ type clientDealUpdate struct {
 }
 
 func NewClient(h host.Host, bs blockstore.Blockstore, dataTransfer datatransfer.Manager, discovery *discovery.Local, deals *statestore.StateStore, scn storagemarket.StorageClientNode) (*Client, error) {
-	pr := padreader.NewPadReader()
 	carIO := cario.NewCarIO()
 	fs, err := filestore.NewLocalFileStore("")
 	if err != nil {
 		return nil, err
 	}
-	pio := pieceio.NewPieceIO(pr, carIO, fs, bs)
+	pio := pieceio.NewPieceIO(carIO, fs, bs)
 
 	c := &Client{
 		h:            h,

--- a/storagemarket/impl/client_utils.go
+++ b/storagemarket/impl/client_utils.go
@@ -41,11 +41,10 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, tmpFile, err := c.pio.GeneratePieceCommitment(root, allSelector)
+	commp, tmpFile, paddedSize, err := c.pio.GeneratePieceCommitment(root, allSelector)
 	if err != nil {
 		return nil, 0, xerrors.Errorf("generating CommP: %w", err)
 	}
-	size := tmpFile.Size()
 
 	err = tmpFile.Close()
 	if err != nil {
@@ -57,7 +56,7 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 		return nil, 0, xerrors.Errorf("error deleting temp file from filestore: %w", err)
 	}
 
-	return commp[:], uint64(size), nil
+	return commp[:], paddedSize, nil
 }
 
 func (c *Client) readStorageDealResp(deal ClientDeal) (*Response, error) {

--- a/storagemarket/impl/client_utils.go
+++ b/storagemarket/impl/client_utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-cbor-util"
+	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-statestore"
 )
@@ -41,17 +41,12 @@ func (c *Client) commP(ctx context.Context, root cid.Cid) ([]byte, uint64, error
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, tmpFile, paddedSize, err := c.pio.GeneratePieceCommitment(root, allSelector)
+	commp, tmpPath, paddedSize, err := c.pio.GeneratePieceCommitment(root, allSelector)
 	if err != nil {
 		return nil, 0, xerrors.Errorf("generating CommP: %w", err)
 	}
 
-	err = tmpFile.Close()
-	if err != nil {
-		return nil, 0, xerrors.Errorf("error closing temp file: %w", err)
-	}
-
-	err = c.fs.Delete(tmpFile.Path())
+	err = c.fs.Delete(tmpPath)
 	if err != nil {
 		return nil, 0, xerrors.Errorf("error deleting temp file from filestore: %w", err)
 	}

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -108,7 +108,7 @@ func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerD
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, file, _, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
+	commp, path, _, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerD
 	}
 
 	return func(deal *MinerDeal) {
-		deal.PiecePath = file.Path()
+		deal.PiecePath = path
 	}, nil
 }
 

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -107,7 +107,7 @@ func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerD
 	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 
-	commp, file, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
+	commp, file, _, err := p.pio.GeneratePieceCommitment(deal.Ref, allSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/xerrors"
 
+	"github.com/filecoin-project/go-fil-markets/pieceio/padreader"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 )
@@ -169,6 +170,11 @@ func (p *Provider) publishing(ctx context.Context, deal MinerDeal) (func(*MinerD
 
 // STAGED
 func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
+	file, err := p.fs.Open(deal.PiecePath)
+	if err != nil {
+		return nil, err
+	}
+	paddedReader, paddedSize := padreader.NewPaddedReader(file, uint64(file.Size()))
 	sectorID, err := p.spn.OnDealComplete(
 		ctx,
 		storagemarket.MinerDeal{
@@ -179,7 +185,8 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 			Ref:         deal.Ref,
 			DealID:      deal.DealID,
 		},
-		string(deal.PiecePath),
+		paddedSize,
+		paddedReader,
 	)
 
 	if err != nil {
@@ -195,12 +202,24 @@ func (p *Provider) staged(ctx context.Context, deal MinerDeal) (func(*MinerDeal)
 
 func (p *Provider) sealing(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	// TODO: consider waiting for seal to happen
+	cb := func(err error) {
+		select {
+		case p.updated <- minerDealUpdate{
+			newState: storagemarket.DealComplete,
+			id:       deal.ProposalCid,
+			err:      err,
+		}:
+		case <-p.stop:
+		}
+	}
 
-	return nil, nil
+	err := p.spn.OnDealSectorCommitted(ctx, deal.Proposal.Provider, deal.DealID, cb)
+
+	return nil, err
+
 }
 
 func (p *Provider) complete(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	// TODO: observe sector lifecycle, status, expiration..
-
-	return nil, nil
+	return nil, p.fs.Delete(deal.PiecePath)
 }

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -3,6 +3,7 @@ package storagemarket
 import (
 	"bytes"
 	"context"
+	"io"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/host"
@@ -218,13 +219,15 @@ type StorageProviderNode interface {
 
 	// Called when a deal is complete and on chain, and data has been transferred and is ready to be added to a sector
 	// returns sector id
-	OnDealComplete(ctx context.Context, deal MinerDeal, piecePath string) (uint64, error)
+	OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize uint64, pieceReader io.Reader) (uint64, error)
 
 	// returns the worker address associated with a miner
 	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)
 
 	// Signs bytes
 	SignBytes(ctx context.Context, signer address.Address, b []byte) (*types.Signature, error)
+
+	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID uint64, cb DealSectorCommittedCallback) error
 }
 
 type DealSectorCommittedCallback func(error)


### PR DESCRIPTION
# Goals

Many people have balked at the "Filestore" concept as a handoff between storage market and storage miner and requested we simply pass a direct io.reader from one to the other. This implements that change.

As I understand it, the filestore was originally introduced in specs on the theory that markets & miner might run on different machines, and that, rather than RPC over the whole piece, the filestore would act as a shared interface to a single storage staging area (a networked hard drive or perhaps other device). It seems to me while this concept might still have value, it's a concern best left to the code integrating storage market and storage miner, and the miner who wishes to customize that code.

# Implementation

While this PR does not delete the Filestore code, it moves all management of files internal to the module (also removing the requirement that the StorageMiner delete the files when it's done -- this is now managed internally as well).

I'm tagging @laser @acruikshank and @magik6k who will work with this in their own node implementations. Note @magik6k we are working on a replacement for sealed refs as well that works with CAR files that will be ready before we attempt to integrate this with Lotus.

The key line of concern to external stakeholders is this:

```diff
-	OnDealComplete(ctx context.Context, deal MinerDeal, piecePath string) (uint64, error)
+	OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize uint64, pieceReader io.Reader) (uint64, error)
```

There is some other code to also make PieceIO more modular submitted by @rvagg so that external uses of go-fil-markets can generate commP from a CAR file they made themselves (there will be reasons to do this soon)

# For Discussion

One potential future inefficiency, in a scenario where one does wish to customize the handoff between markets and miner, is that we still have to write the piece file to disk internally, and if you were to write it to disk outside this module, it would be an inefficiency.