### PR TITLE
Sync up DealState to match spec

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -62,7 +62,7 @@ type Client struct {
 }
 
 type clientDealUpdate struct {
-	newState storagemarket.DealState
+	newState storagemarket.StorageDealStatus
 	id       cid.Cid
 	err      error
 	mut      func(*ClientDeal)

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -129,7 +129,7 @@ func (c *Client) onIncoming(deal *ClientDeal) {
 
 	go func() {
 		c.updated <- clientDealUpdate{
-			newState: storagemarket.DealUnknown,
+			newState: storagemarket.StorageDealUnknown,
 			id:       deal.ProposalCid,
 			err:      nil,
 		}
@@ -158,15 +158,15 @@ func (c *Client) onUpdated(ctx context.Context, update clientDealUpdate) {
 	}
 
 	switch update.newState {
-	case storagemarket.DealUnknown: // new
-		c.handle(ctx, deal, c.new, storagemarket.DealAccepted)
-	case storagemarket.DealAccepted:
-		c.handle(ctx, deal, c.accepted, storagemarket.DealStaged)
-	case storagemarket.DealStaged:
-		c.handle(ctx, deal, c.staged, storagemarket.DealSealing)
-	case storagemarket.DealSealing:
-		c.handle(ctx, deal, c.sealing, storagemarket.DealNoUpdate)
-		// TODO: DealComplete -> watch for faults, expiration, etc.
+	case storagemarket.StorageDealUnknown: // new
+		c.handle(ctx, deal, c.new, storagemarket.StorageDealProposalAccepted)
+	case storagemarket.StorageDealProposalAccepted:
+		c.handle(ctx, deal, c.accepted, storagemarket.StorageDealStaged)
+	case storagemarket.StorageDealStaged:
+		c.handle(ctx, deal, c.staged, storagemarket.StorageDealSealing)
+	case storagemarket.StorageDealSealing:
+		c.handle(ctx, deal, c.sealing, storagemarket.StorageDealNoUpdate)
+		// TODO: StorageDealActive -> watch for faults, expiration, etc.
 	}
 }
 
@@ -233,7 +233,7 @@ func (c *Client) Start(ctx context.Context, p ClientDealProposal) (cid.Cid, erro
 		ClientDeal: storagemarket.ClientDeal{
 			ProposalCid: proposalNd.Cid(),
 			Proposal:    *dealProposal,
-			State:       storagemarket.DealUnknown,
+			State:       storagemarket.StorageDealUnknown,
 			Miner:       p.MinerID,
 			MinerWorker: p.MinerWorker,
 			PayloadCid:  p.Data,

--- a/storagemarket/impl/client_states.go
+++ b/storagemarket/impl/client_states.go
@@ -15,10 +15,10 @@ func (c *Client) handle(ctx context.Context, deal ClientDeal, cb clientHandlerFu
 	go func() {
 		mut, err := cb(ctx, deal)
 		if err != nil {
-			next = storagemarket.DealError
+			next = storagemarket.StorageDealError
 		}
 
-		if err == nil && next == storagemarket.DealNoUpdate {
+		if err == nil && next == storagemarket.StorageDealNoUpdate {
 			return
 		}
 
@@ -47,7 +47,7 @@ func (c *Client) new(ctx context.Context, deal ClientDeal) (func(*ClientDeal), e
 	}
 
 	/* data transfer happens */
-	if resp.State != storagemarket.DealAccepted {
+	if resp.State != storagemarket.StorageDealProposalAccepted {
 		return nil, xerrors.Errorf("deal wasn't accepted (State=%d)", resp.State)
 	}
 
@@ -79,7 +79,7 @@ func (c *Client) sealing(ctx context.Context, deal ClientDeal) (func(*ClientDeal
 	cb := func(err error) {
 		select {
 		case c.updated <- clientDealUpdate{
-			newState: storagemarket.DealComplete,
+			newState: storagemarket.StorageDealActive,
 			id:       deal.ProposalCid,
 			err:      err,
 		}:

--- a/storagemarket/impl/client_states.go
+++ b/storagemarket/impl/client_states.go
@@ -11,7 +11,7 @@ import (
 
 type clientHandlerFunc func(ctx context.Context, deal ClientDeal) (func(*ClientDeal), error)
 
-func (c *Client) handle(ctx context.Context, deal ClientDeal, cb clientHandlerFunc, next storagemarket.DealState) {
+func (c *Client) handle(ctx context.Context, deal ClientDeal, cb clientHandlerFunc, next storagemarket.StorageDealStatus) {
 	go func() {
 		mut, err := cb(ctx, deal)
 		if err != nil {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -63,7 +63,7 @@ type Provider struct {
 }
 
 type minerDealUpdate struct {
-	newState storagemarket.DealState
+	newState storagemarket.StorageDealStatus
 	id       cid.Cid
 	err      error
 	mut      func(*MinerDeal)
@@ -223,7 +223,7 @@ func (p *Provider) onDataTransferEvent(event datatransfer.Event, channelState da
 	}
 
 	// data transfer events for opening and progress do not affect deal state
-	var next storagemarket.DealState
+	var next storagemarket.StorageDealStatus
 	var err error
 	var mut func(*MinerDeal)
 	switch event.Code {

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -21,7 +21,7 @@ func (p *Provider) handle(ctx context.Context, deal MinerDeal, cb providerHandle
 	go func() {
 		mut, err := cb(ctx, deal)
 
-		if err == nil && next == storagemarket.DealNoUpdate {
+		if err == nil && next == storagemarket.StorageDealNoUpdate {
 			return
 		}
 
@@ -37,7 +37,7 @@ func (p *Provider) handle(ctx context.Context, deal MinerDeal, cb providerHandle
 	}()
 }
 
-// DealValidating
+// StorageDealValidating
 func (p *Provider) validating(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	head, err := p.spn.MostRecentStateId(ctx)
 	if err != nil {
@@ -74,7 +74,7 @@ func (p *Provider) validating(ctx context.Context, deal MinerDeal) (func(*MinerD
 	return nil, nil
 }
 
-// State: DealTransferring
+// State: StorageDealTransferring
 func (p *Provider) transferring(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
 
@@ -101,7 +101,7 @@ func (p *Provider) transferring(ctx context.Context, deal MinerDeal) (func(*Mine
 	return nil, nil
 }
 
-// State: DealVerifyData
+// State: StorageDealVerifyData
 func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	// entire DAG selector
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
@@ -123,7 +123,7 @@ func (p *Provider) verifydata(ctx context.Context, deal MinerDeal) (func(*MinerD
 	}, nil
 }
 
-// State: DealPublishing
+// State: StorageDealPublishing
 func (p *Provider) publishing(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error) {
 	waddr, err := p.spn.GetMinerWorker(ctx, deal.Proposal.Provider)
 	if err != nil {
@@ -150,7 +150,7 @@ func (p *Provider) publishing(ctx context.Context, deal MinerDeal) (func(*MinerD
 	}
 
 	err = p.sendSignedResponse(ctx, &Response{
-		State: storagemarket.DealAccepted,
+		State: storagemarket.StorageDealProposalAccepted,
 
 		Proposal:       deal.ProposalCid,
 		PublishMessage: &mcid,
@@ -205,7 +205,7 @@ func (p *Provider) sealing(ctx context.Context, deal MinerDeal) (func(*MinerDeal
 	cb := func(err error) {
 		select {
 		case p.updated <- minerDealUpdate{
-			newState: storagemarket.DealComplete,
+			newState: storagemarket.StorageDealActive,
 			id:       deal.ProposalCid,
 			err:      err,
 		}:

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -17,7 +17,7 @@ import (
 
 type providerHandlerFunc func(ctx context.Context, deal MinerDeal) (func(*MinerDeal), error)
 
-func (p *Provider) handle(ctx context.Context, deal MinerDeal, cb providerHandlerFunc, next storagemarket.DealState) {
+func (p *Provider) handle(ctx context.Context, deal MinerDeal, cb providerHandlerFunc, next storagemarket.StorageDealStatus) {
 	go func() {
 		mut, err := cb(ctx, deal)
 

--- a/storagemarket/impl/provider_utils.go
+++ b/storagemarket/impl/provider_utils.go
@@ -32,7 +32,7 @@ func (p *Provider) failDeal(ctx context.Context, id cid.Cid, cerr error) {
 	log.Warnf("deal %s failed: %s", id, cerr)
 
 	err := p.sendSignedResponse(ctx, &Response{
-		State:    storagemarket.DealFailed,
+		State:    storagemarket.StorageDealFailing,
 		Message:  cerr.Error(),
 		Proposal: id,
 	})

--- a/storagemarket/impl/request_validation_test.go
+++ b/storagemarket/impl/request_validation_test.go
@@ -58,7 +58,7 @@ func uniqueStorageDealProposal() (storagemarket.StorageDealProposal, error) {
 	}, nil
 }
 
-func newClientDeal(minerID peer.ID, state storagemarket.DealState) (deals.ClientDeal, error) {
+func newClientDeal(minerID peer.ID, state storagemarket.StorageDealStatus) (deals.ClientDeal, error) {
 	newProposal, err := uniqueStorageDealProposal()
 	if err != nil {
 		return deals.ClientDeal{}, err
@@ -84,7 +84,7 @@ func newClientDeal(minerID peer.ID, state storagemarket.DealState) (deals.Client
 	}, nil
 }
 
-func newMinerDeal(clientID peer.ID, state storagemarket.DealState) (deals.MinerDeal, error) {
+func newMinerDeal(clientID peer.ID, state storagemarket.StorageDealStatus) (deals.MinerDeal, error) {
 	newProposal, err := uniqueStorageDealProposal()
 	if err != nil {
 		return deals.MinerDeal{}, err

--- a/storagemarket/impl/request_validation_test.go
+++ b/storagemarket/impl/request_validation_test.go
@@ -137,7 +137,7 @@ func TestClientRequestValidation(t *testing.T) {
 	})
 	t.Run("ValidatePull fails wrong client", func(t *testing.T) {
 		otherMiner := peer.ID("otherminer")
-		clientDeal, err := newClientDeal(otherMiner, storagemarket.DealAccepted)
+		clientDeal, err := newClientDeal(otherMiner, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -150,7 +150,7 @@ func TestClientRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePull fails wrong piece ref", func(t *testing.T) {
-		clientDeal, err := newClientDeal(minerID, storagemarket.DealAccepted)
+		clientDeal, err := newClientDeal(minerID, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -162,7 +162,7 @@ func TestClientRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePull fails wrong deal state", func(t *testing.T) {
-		clientDeal, err := newClientDeal(minerID, storagemarket.DealComplete)
+		clientDeal, err := newClientDeal(minerID, storagemarket.StorageDealActive)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -175,7 +175,7 @@ func TestClientRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePull succeeds", func(t *testing.T) {
-		clientDeal, err := newClientDeal(minerID, storagemarket.DealAccepted)
+		clientDeal, err := newClientDeal(minerID, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -221,7 +221,7 @@ func TestProviderRequestValidation(t *testing.T) {
 	})
 	t.Run("ValidatePush fails wrong miner", func(t *testing.T) {
 		otherClient := peer.ID("otherclient")
-		minerDeal, err := newMinerDeal(otherClient, storagemarket.DealAccepted)
+		minerDeal, err := newMinerDeal(otherClient, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -234,7 +234,7 @@ func TestProviderRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePush fails wrong piece ref", func(t *testing.T) {
-		minerDeal, err := newMinerDeal(clientID, storagemarket.DealAccepted)
+		minerDeal, err := newMinerDeal(clientID, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -246,7 +246,7 @@ func TestProviderRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePush fails wrong deal state", func(t *testing.T) {
-		minerDeal, err := newMinerDeal(clientID, storagemarket.DealComplete)
+		minerDeal, err := newMinerDeal(clientID, storagemarket.StorageDealActive)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}
@@ -259,7 +259,7 @@ func TestProviderRequestValidation(t *testing.T) {
 		}
 	})
 	t.Run("ValidatePush succeeds", func(t *testing.T) {
-		minerDeal, err := newMinerDeal(clientID, storagemarket.DealAccepted)
+		minerDeal, err := newMinerDeal(clientID, storagemarket.StorageDealProposalAccepted)
 		if err != nil {
 			t.Fatal("error creating client deal")
 		}

--- a/storagemarket/impl/types.go
+++ b/storagemarket/impl/types.go
@@ -40,7 +40,7 @@ var (
 	ErrInacceptableDealState = errors.New("deal is not a in a state where deals are accepted.")
 
 	// DataTransferStates are the states in which it would make sense to actually start a data transfer
-	DataTransferStates = []storagemarket.StorageDealStatus{storagemarket.DealAccepted, storagemarket.DealUnknown}
+	DataTransferStates = []storagemarket.StorageDealStatus{storagemarket.StorageDealProposalAccepted, storagemarket.StorageDealUnknown}
 )
 
 type Proposal struct {
@@ -56,7 +56,7 @@ type Response struct {
 	Message  string
 	Proposal cid.Cid
 
-	// DealAccepted
+	// StorageDealProposalAccepted
 	PublishMessage *cid.Cid
 }
 

--- a/storagemarket/impl/types.go
+++ b/storagemarket/impl/types.go
@@ -40,7 +40,7 @@ var (
 	ErrInacceptableDealState = errors.New("deal is not a in a state where deals are accepted.")
 
 	// DataTransferStates are the states in which it would make sense to actually start a data transfer
-	DataTransferStates = []storagemarket.DealState{storagemarket.DealAccepted, storagemarket.DealUnknown}
+	DataTransferStates = []storagemarket.StorageDealStatus{storagemarket.DealAccepted, storagemarket.DealUnknown}
 )
 
 type Proposal struct {
@@ -50,7 +50,7 @@ type Proposal struct {
 }
 
 type Response struct {
-	State storagemarket.DealState
+	State storagemarket.StorageDealStatus
 
 	// DealProposalRejected
 	Message  string

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -27,10 +27,10 @@ type Balance struct {
 	Available tokenamount.TokenAmount
 }
 
-type DealState = uint64
+type StorageDealStatus = uint64
 
 const (
-	DealUnknown  = DealState(iota)
+	DealUnknown  = StorageDealStatus(iota)
 	DealRejected // Provider didn't like the proposal
 	DealAccepted // Proposal accepted
 	DealStaged   // Data put into the sector
@@ -153,7 +153,7 @@ type MinerDeal struct {
 	Proposal    StorageDealProposal
 	Miner       peer.ID
 	Client      peer.ID
-	State       DealState
+	State       StorageDealStatus
 	PiecePath   filestore.Path
 
 	Ref cid.Cid
@@ -165,7 +165,7 @@ type MinerDeal struct {
 type ClientDeal struct {
 	ProposalCid cid.Cid
 	Proposal    StorageDealProposal
-	State       DealState
+	State       StorageDealStatus
 	Miner       peer.ID
 	MinerWorker address.Address
 	DealID      uint64

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -30,40 +30,53 @@ type Balance struct {
 type StorageDealStatus = uint64
 
 const (
-	DealUnknown  = StorageDealStatus(iota)
-	DealRejected // Provider didn't like the proposal
-	DealAccepted // Proposal accepted
-	DealStaged   // Data put into the sector
-	DealSealing  // Data in process of being sealed
-
-	DealFailed
-	DealComplete
+	StorageDealUnknown = StorageDealStatus(iota)
+	StorageDealProposalNotFound
+	StorageDealProposalRejected
+	StorageDealProposalAccepted
+	StorageDealStaged
+	StorageDealSealing
+	StorageDealProposalSigned
+	StorageDealPublished
+	StorageDealCommitted
+	StorageDealActive
+	StorageDealFailing
+	StorageDealRecovering
+	StorageDealExpired
+	StorageDealNotFound
 
 	// Internal
 
-	DealValidating   // Verifying that deal parameters are good
-	DealTransferring // Moving data
-	DealVerifyData   // Verify transferred data - generate CAR / piece data
-	DealPublishing   // Publishing deal to chain
-	DealError        // deal failed with an unexpected error
+	StorageDealValidating   // Verifying that deal parameters are good
+	StorageDealTransferring // Moving data
+	StorageDealVerifyData   // Verify transferred data - generate CAR / piece data
+	StorageDealPublishing   // Publishing deal to chain
+	StorageDealError        // deal failed with an unexpected error
 
-	DealNoUpdate = DealUnknown
+	StorageDealNoUpdate = StorageDealUnknown
 )
 
 var DealStates = []string{
-	"DealUnknown",
-	"DealRejected",
-	"DealAccepted",
-	"DealStaged",
-	"DealSealing",
-	"DealFailed",
-	"DealComplete",
+	"StorageDealUnknown",
+	"StorageDealProposalNotFound",
+	"StorageDealProposalRejected",
+	"StorageDealProposalAccepted",
+	"StorageDealStaged",
+	"StorageDealSealing",
+	"StorageDealProposalSigned",
+	"StorageDealPublished",
+	"StorageDealCommitted",
+	"StorageDealActive",
+	"StorageDealFailing",
+	"StorageDealRecovering",
+	"StorageDealExpired",
+	"StorageDealNotFound",
 
-	"DealValidating",
-	"DealTransferring",
-	"DealVerifyData",
-	"DealPublishing",
-	"DealError",
+	"StorageDealValidating",
+	"StorageDealTransferring",
+	"StorageDealVerifyData",
+	"StorageDealPublishing",
+	"StorageDealError",
 }
 
 type DealID uint64
@@ -159,7 +172,7 @@ type MinerDeal struct {
 	Ref cid.Cid
 
 	DealID   uint64
-	SectorID uint64 // Set when sm >= DealStaged
+	SectorID uint64 // Set when sm >= StorageDealStaged
 }
 
 type ClientDeal struct {


### PR DESCRIPTION
## Summary
Rename `DealState` to `StorageDealStatus`, add the states from the spec, and map them as closely as possible to the old `DealState` enum.

### Notes
There are some unused states, and the provider and client states are not broken up according to the states in the spec (leaving some unused states).  This will be addressed when we figure out what is going on with the state machines for the client and provider deals.

Resolves https://github.com/filecoin-project/go-storage-market/issues/21