### PR TITLE
ci(config): use large resource_class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   golang:
     docker:
       - image: circleci/golang:1.13
-    resource_class: small
+    resource_class: large
 
 commands:
   install-deps:


### PR DESCRIPTION
We are getting OOM errors while linking on CI, so let's try switching to the large resource class for now