### PR TITLE
Switch interfaces for retrieval to use Payload CIDs. NO IMPLEMENTATION

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/ipfs/go-unixfs v0.2.2-0.20190827150610-868af2e9e5cb
 	github.com/ipld/go-ipld-prime v0.0.2-0.20191108012745-28a82f04c785
 	github.com/ipld/go-ipld-prime-proto v0.0.0-20191113031812-e32bd156a1e5
+	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-libp2p v0.3.0
 	github.com/libp2p/go-libp2p-core v0.2.4
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1

--- a/retrievalmarket/discovery/local.go
+++ b/retrievalmarket/discovery/local.go
@@ -35,8 +35,8 @@ func (l *Local) AddPeer(cid cid.Cid, peer retrievalmarket.RetrievalPeer) error {
 	return l.ds.Put(dshelp.CidToDsKey(cid), entry)
 }
 
-func (l *Local) GetPeers(pieceCID []byte) ([]retrievalmarket.RetrievalPeer, error) {
-	key := string(pieceCID[:])
+func (l *Local) GetPeers(payloadCID cid.Cid) ([]retrievalmarket.RetrievalPeer, error) {
+	key := payloadCID.String()
 	entry, err := l.ds.Get(datastore.NewKey(key))
 	if err == datastore.ErrNotFound {
 		return []retrievalmarket.RetrievalPeer{}, nil

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -55,8 +55,8 @@ func NewClient(
 
 // V0
 
-func (c *client) FindProviders(pieceCID []byte) []retrievalmarket.RetrievalPeer {
-	peers, err := c.resolver.GetPeers(pieceCID)
+func (c *client) FindProviders(payloadCID cid.Cid) []retrievalmarket.RetrievalPeer {
+	peers, err := c.resolver.GetPeers(payloadCID)
 	if err != nil {
 		log.Error(err)
 		return []retrievalmarket.RetrievalPeer{}
@@ -64,7 +64,7 @@ func (c *client) FindProviders(pieceCID []byte) []retrievalmarket.RetrievalPeer 
 	return peers
 }
 
-func (c *client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, pieceCID []byte, params retrievalmarket.QueryParams) (retrievalmarket.QueryResponse, error) {
+func (c *client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, payloadCID cid.Cid, params retrievalmarket.QueryParams) (retrievalmarket.QueryResponse, error) {
 	s, err := c.network.NewQueryStream(p.ID)
 	if err != nil {
 		log.Warn(err)
@@ -73,7 +73,7 @@ func (c *client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, pie
 	defer s.Close()
 
 	err = s.WriteQuery(retrievalmarket.Query{
-		PieceCID: pieceCID,
+		PayloadCID: payloadCID,
 	})
 	if err != nil {
 		log.Warn(err)
@@ -83,7 +83,7 @@ func (c *client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, pie
 	return s.ReadQueryResponse()
 }
 
-func (c *client) Retrieve(ctx context.Context, pieceCID []byte, params retrievalmarket.Params, totalFunds tokenamount.TokenAmount, miner peer.ID, clientWallet address.Address, minerWallet address.Address) retrievalmarket.DealID {
+func (c *client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds tokenamount.TokenAmount, miner peer.ID, clientWallet address.Address, minerWallet address.Address) retrievalmarket.DealID {
 	/* The implementation of this function is just wrapper for the old code which retrieves UnixFS pieces
 	-- it will be replaced when we do the V0 implementation of the module */
 	c.nextDealLk.Lock()
@@ -93,9 +93,9 @@ func (c *client) Retrieve(ctx context.Context, pieceCID []byte, params retrieval
 
 	dealState := retrievalmarket.ClientDealState{
 		DealProposal: retrievalmarket.DealProposal{
-			PieceCID: pieceCID,
-			ID:       dealID,
-			Params:   params,
+			PayloadCID: payloadCID,
+			ID:         dealID,
+			Params:     params,
 		},
 		TotalFunds:       totalFunds,
 		ClientWallet:     clientWallet,

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -124,7 +124,7 @@ func (p *provider) HandleQueryStream(stream rmnet.RetrievalQueryStream) {
 		MaxPaymentIntervalIncrease: p.paymentIntervalIncrease,
 	}
 
-	pieceInfo, err := p.pieceStore.GetPieceInfo(query.PieceCID)
+	pieceInfo, err := p.pieceStore.GetPieceInfo(query.PayloadCID.Bytes())
 
 	if err == nil && len(pieceInfo.Deals) > 0 {
 		answer.Status = retrievalmarket.QueryResponseAvailable

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestHandleQueryStream(t *testing.T) {
 
-	pcid := []byte(string("applesauce"))
+	pcid := tut.GenerateCids(1)[0]
 	expectedPeer := peer.ID("somepeer")
 	expectedSize := uint64(1234)
 	expectedPiece := piecestore.PieceInfo{
@@ -63,12 +63,12 @@ func TestHandleQueryStream(t *testing.T) {
 	t.Run("it works", func(t *testing.T) {
 		qs := readWriteQueryStream()
 		err := qs.WriteQuery(retrievalmarket.Query{
-			PieceCID: pcid,
+			PayloadCID: pcid,
 		})
 		require.NoError(t, err)
 		pieceStore := tut.NewTestPieceStore()
 
-		pieceStore.ExpectPiece(pcid, expectedPiece)
+		pieceStore.ExpectPiece(pcid.Bytes(), expectedPiece)
 
 		receiveStreamOnProvider(qs, pieceStore)
 
@@ -86,11 +86,11 @@ func TestHandleQueryStream(t *testing.T) {
 	t.Run("piece not found", func(t *testing.T) {
 		qs := readWriteQueryStream()
 		err := qs.WriteQuery(retrievalmarket.Query{
-			PieceCID: pcid,
+			PayloadCID: pcid,
 		})
 		require.NoError(t, err)
 		pieceStore := tut.NewTestPieceStore()
-		pieceStore.ExpectMissingPiece(pcid)
+		pieceStore.ExpectMissingPiece(pcid.Bytes())
 
 		receiveStreamOnProvider(qs, pieceStore)
 
@@ -107,7 +107,7 @@ func TestHandleQueryStream(t *testing.T) {
 	t.Run("error reading piece", func(t *testing.T) {
 		qs := readWriteQueryStream()
 		err := qs.WriteQuery(retrievalmarket.Query{
-			PieceCID: pcid,
+			PayloadCID: pcid,
 		})
 		require.NoError(t, err)
 		pieceStore := tut.NewTestPieceStore()
@@ -142,11 +142,11 @@ func TestHandleQueryStream(t *testing.T) {
 			RespWriter: tut.FailResponseWriter,
 		})
 		err := qs.WriteQuery(retrievalmarket.Query{
-			PieceCID: pcid,
+			PayloadCID: pcid,
 		})
 		require.NoError(t, err)
 		pieceStore := tut.NewTestPieceStore()
-		pieceStore.ExpectPiece(pcid, expectedPiece)
+		pieceStore.ExpectPiece(pcid.Bytes(), expectedPiece)
 
 		receiveStreamOnProvider(qs, pieceStore)
 

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -54,7 +54,7 @@ func ReceiveDeal(ctx context.Context, environment ProviderDealEnvironment, deal 
 	}
 
 	// verify we have the piece
-	_, err = environment.GetPieceSize(dealProposal.PieceCID)
+	_, err = environment.GetPieceSize(dealProposal.PayloadCID.Bytes())
 	if err != nil {
 		if err == rm.ErrNotFound {
 			return responseFailure(environment.DealStream(), rm.DealStatusDealNotFound, rm.ErrNotFound.Error(), dealProposal.ID)

--- a/retrievalmarket/impl/providerstates/provider_states_test.go
+++ b/retrievalmarket/impl/providerstates/provider_states_test.go
@@ -36,10 +36,10 @@ func TestReceiveDeal(t *testing.T) {
 		}
 	}
 
-	expectedPiece := []byte(string("applesauce"))
+	expectedPiece := testnet.GenerateCids(1)[0]
 	proposal := retrievalmarket.DealProposal{
-		ID:       retrievalmarket.DealID(10),
-		PieceCID: expectedPiece,
+		ID:         retrievalmarket.DealID(10),
+		PayloadCID: expectedPiece,
 		Params: retrievalmarket.Params{
 			PricePerByte:            defaultPricePerByte,
 			PaymentInterval:         defaultCurrentInterval,
@@ -58,7 +58,7 @@ func TestReceiveDeal(t *testing.T) {
 			ProposalReader: testnet.StubbedDealProposalReader(proposal),
 			ResponseWriter: testnet.ExpectDealResponseWriter(t, expectedDealResponse),
 		})
-		fe.ExpectPiece(expectedPiece, 10000)
+		fe.ExpectPiece(expectedPiece.Bytes(), 10000)
 		fe.ExpectParams(defaultPricePerByte, defaultCurrentInterval, defaultIntervalIncrease, nil)
 		f := providerstates.ReceiveDeal(ctx, fe, *dealState)
 		fe.VerifyExpectations(t)
@@ -82,7 +82,7 @@ func TestReceiveDeal(t *testing.T) {
 			ProposalReader: testnet.StubbedDealProposalReader(proposal),
 			ResponseWriter: testnet.ExpectDealResponseWriter(t, expectedDealResponse),
 		})
-		fe.ExpectMissingPiece(expectedPiece)
+		fe.ExpectMissingPiece(expectedPiece.Bytes())
 		f := providerstates.ReceiveDeal(ctx, fe, *dealState)
 		node.VerifyExpectations(t)
 		fe.VerifyExpectations(t)
@@ -104,7 +104,7 @@ func TestReceiveDeal(t *testing.T) {
 			ProposalReader: testnet.StubbedDealProposalReader(proposal),
 			ResponseWriter: testnet.ExpectDealResponseWriter(t, expectedDealResponse),
 		})
-		fe.ExpectPiece(expectedPiece, 10000)
+		fe.ExpectPiece(expectedPiece.Bytes(), 10000)
 		fe.ExpectParams(defaultPricePerByte, defaultCurrentInterval, defaultIntervalIncrease, errors.New(message))
 		f := providerstates.ReceiveDeal(ctx, fe, *dealState)
 		fe.VerifyExpectations(t)
@@ -133,7 +133,7 @@ func TestReceiveDeal(t *testing.T) {
 			ProposalReader: testnet.StubbedDealProposalReader(proposal),
 			ResponseWriter: testnet.FailDealResponseWriter,
 		})
-		fe.ExpectPiece(expectedPiece, 10000)
+		fe.ExpectPiece(expectedPiece.Bytes(), 10000)
 		fe.ExpectParams(defaultPricePerByte, defaultCurrentInterval, defaultIntervalIncrease, nil)
 		f := providerstates.ReceiveDeal(ctx, fe, *dealState)
 		fe.VerifyExpectations(t)

--- a/retrievalmarket/network/libp2p_impl_test.go
+++ b/retrievalmarket/network/libp2p_impl_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-data-transfer/testutil"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
@@ -113,10 +112,10 @@ func TestQueryStreamSendReceiveMultipleSuccessful(t *testing.T) {
 	qs, err := nw1.NewQueryStream(td.Host2.ID())
 	require.NoError(t, err)
 
-	testCid := testutil.GenerateCids(1)[0]
+	testCid := shared_testutil.GenerateCids(1)[0]
 
 	var resp retrievalmarket.QueryResponse
-	go require.NoError(t, qs.WriteQuery(retrievalmarket.Query{PieceCID: testCid.Bytes()}))
+	go require.NoError(t, qs.WriteQuery(retrievalmarket.Query{PayloadCID: testCid}))
 	resp, err = qs.ReadQueryResponse()
 	require.NoError(t, err)
 
@@ -355,8 +354,8 @@ func assertQueryReceived(inCtx context.Context, t *testing.T, fromNetwork networ
 	require.NoError(t, err)
 
 	// send query to host2
-	cid := testutil.GenerateCids(1)[0]
-	q := retrievalmarket.NewQueryV0(cid.Bytes())
+	cid := shared_testutil.GenerateCids(1)[0]
+	q := retrievalmarket.NewQueryV0(cid)
 	require.NoError(t, qs1.WriteQuery(q))
 
 	var inq retrievalmarket.Query
@@ -366,7 +365,7 @@ func assertQueryReceived(inCtx context.Context, t *testing.T, fromNetwork networ
 	case inq = <-qchan:
 	}
 	require.NotNil(t, inq)
-	assert.Equal(t, q.PieceCID, inq.PieceCID)
+	assert.Equal(t, q.PayloadCID, inq.PayloadCID)
 }
 
 // assertQueryResponseReceived performs the verification that a QueryResponse is received

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -76,20 +76,20 @@ type RetrievalClient interface {
 	// V0
 
 	// Find Providers finds retrieval providers who may be storing a given piece
-	FindProviders(pieceCID []byte) []RetrievalPeer
+	FindProviders(payloadCID cid.Cid) []RetrievalPeer
 
 	// Query asks a provider for information about a piece it is storing
 	Query(
 		ctx context.Context,
 		p RetrievalPeer,
-		pieceCID []byte,
+		payloadCID cid.Cid,
 		params QueryParams,
 	) (QueryResponse, error)
 
 	// Retrieve retrieves all or part of a piece with the given retrieval parameters
 	Retrieve(
 		ctx context.Context,
-		pieceCID []byte,
+		payloadCID cid.Cid,
 		params Params,
 		totalFunds tokenamount.TokenAmount,
 		miner peer.ID,
@@ -196,7 +196,7 @@ type RetrievalProviderNode interface {
 
 // PeerResolver is an interface for looking up providers that may have a piece
 type PeerResolver interface {
-	GetPeers(pieceCID []byte) ([]RetrievalPeer, error) // TODO: channel
+	GetPeers(payloadCID cid.Cid) ([]RetrievalPeer, error) // TODO: channel
 }
 
 // RetrievalPeer is a provider address/peer.ID pair (everything needed to make
@@ -255,7 +255,7 @@ type QueryParams struct {
 // Query is a query to a given provider to determine information about a piece
 // they may have available for retrieval
 type Query struct {
-	PieceCID []byte // V0
+	PayloadCID cid.Cid // V0
 	// QueryParams        // V1
 }
 
@@ -263,8 +263,8 @@ type Query struct {
 var QueryUndefined = Query{}
 
 // NewQueryV0 creates a V0 query (which only specifies a piece)
-func NewQueryV0(pieceCID []byte) Query {
-	return Query{PieceCID: pieceCID}
+func NewQueryV0(payloadCID cid.Cid) Query {
+	return Query{PayloadCID: payloadCID}
 }
 
 // QueryResponse is a miners response to a given retrieval query
@@ -365,7 +365,6 @@ func IsTerminalStatus(status DealStatus) bool {
 
 // Params are the parameters requested for a retrieval deal proposal
 type Params struct {
-	PayloadCID cid.Cid
 	//Selector                ipld.Node // V1
 	PricePerByte            tokenamount.TokenAmount
 	PaymentInterval         uint64 // when to request payment
@@ -386,8 +385,8 @@ type DealID uint64
 
 // DealProposal is a proposal for a new retrieval deal
 type DealProposal struct {
-	PieceCID []byte
-	ID       DealID
+	PayloadCID cid.Cid
+	ID         DealID
 	Params
 }
 

--- a/retrievalmarket/types_cbor_gen.go
+++ b/retrievalmarket/types_cbor_gen.go
@@ -23,17 +23,12 @@ func (t *Query) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PieceCID ([]uint8) (slice)
-	if len(t.PieceCID) > cbg.ByteArrayMaxLen {
-		return xerrors.Errorf("Byte array in field t.PieceCID was too long")
+	// t.PayloadCID (cid.Cid) (struct)
+
+	if err := cbg.WriteCid(w, t.PayloadCID); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
 	}
 
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajByteString, uint64(len(t.PieceCID)))); err != nil {
-		return err
-	}
-	if _, err := w.Write(t.PieceCID); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -52,22 +47,17 @@ func (t *Query) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.PieceCID ([]uint8) (slice)
+	// t.PayloadCID (cid.Cid) (struct)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > cbg.ByteArrayMaxLen {
-		return fmt.Errorf("t.PieceCID: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
-	t.PieceCID = make([]byte, extra)
-	if _, err := io.ReadFull(br, t.PieceCID); err != nil {
-		return err
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+		}
+
+		t.PayloadCID = c
+
 	}
 	return nil
 }
@@ -220,16 +210,10 @@ func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.PieceCID ([]uint8) (slice)
-	if len(t.PieceCID) > cbg.ByteArrayMaxLen {
-		return xerrors.Errorf("Byte array in field t.PieceCID was too long")
-	}
+	// t.PayloadCID (cid.Cid) (struct)
 
-	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajByteString, uint64(len(t.PieceCID)))); err != nil {
-		return err
-	}
-	if _, err := w.Write(t.PieceCID); err != nil {
-		return err
+	if err := cbg.WriteCid(w, t.PayloadCID); err != nil {
+		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
@@ -259,22 +243,17 @@ func (t *DealProposal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.PieceCID ([]uint8) (slice)
+	// t.PayloadCID (cid.Cid) (struct)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
-	}
+	{
 
-	if extra > cbg.ByteArrayMaxLen {
-		return fmt.Errorf("t.PieceCID: byte array too large (%d)", extra)
-	}
-	if maj != cbg.MajByteString {
-		return fmt.Errorf("expected byte array")
-	}
-	t.PieceCID = make([]byte, extra)
-	if _, err := io.ReadFull(br, t.PieceCID); err != nil {
-		return err
+		c, err := cbg.ReadCid(br)
+		if err != nil {
+			return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+		}
+
+		t.PayloadCID = c
+
 	}
 	// t.ID (retrievalmarket.DealID) (uint64)
 
@@ -439,14 +418,8 @@ func (t *Params) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{132}); err != nil {
+	if _, err := w.Write([]byte{131}); err != nil {
 		return err
-	}
-
-	// t.PayloadCID (cid.Cid) (struct)
-
-	if err := cbg.WriteCid(w, t.PayloadCID); err != nil {
-		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
 	}
 
 	// t.PricePerByte (tokenamount.TokenAmount) (struct)
@@ -477,22 +450,10 @@ func (t *Params) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
-	// t.PayloadCID (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
-		}
-
-		t.PayloadCID = c
-
-	}
 	// t.PricePerByte (tokenamount.TokenAmount) (struct)
 
 	{

--- a/shared_testutil/test_types.go
+++ b/shared_testutil/test_types.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/filecoin-project/go-data-transfer/testutil"
 	"github.com/libp2p/go-libp2p-core/test"
 	"github.com/stretchr/testify/require"
 
@@ -74,15 +73,14 @@ func MakeTestQueryResponse() retrievalmarket.QueryResponse {
 
 // MakeTestDealProposal generates a valid, random DealProposal
 func MakeTestDealProposal() retrievalmarket.DealProposal {
-	cid := testutil.GenerateCids(1)[0]
+	cid := GenerateCids(1)[0]
 	return retrievalmarket.DealProposal{
-		PieceCID: []byte("applesauce"),
-		ID:       retrievalmarket.DealID(rand.Uint64()),
+		PayloadCID: cid,
+		ID:         retrievalmarket.DealID(rand.Uint64()),
 		Params: retrievalmarket.Params{
 			PricePerByte:            MakeTestTokenAmount(),
 			PaymentInterval:         rand.Uint64(),
 			PaymentIntervalIncrease: rand.Uint64(),
-			PayloadCID:              cid,
 		},
 	}
 }

--- a/shared_testutil/testutil.go
+++ b/shared_testutil/testutil.go
@@ -1,0 +1,83 @@
+package shared_testutil
+
+import (
+	"bytes"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-cid"
+	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
+	"github.com/jbenet/go-random"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var blockGenerator = blocksutil.NewBlockGenerator()
+
+//var prioritySeq int
+var seedSeq int64
+
+// RandomBytes returns a byte array of the given size with random values.
+func RandomBytes(n int64) []byte {
+	data := new(bytes.Buffer)
+	random.WritePseudoRandomBytes(n, data, seedSeq) // nolint: gosec,errcheck
+	seedSeq++
+	return data.Bytes()
+}
+
+// GenerateBlocksOfSize generates a series of blocks of the given byte size
+func GenerateBlocksOfSize(n int, size int64) []blocks.Block {
+	generatedBlocks := make([]blocks.Block, 0, n)
+	for i := 0; i < n; i++ {
+		b := blocks.NewBlock(RandomBytes(size))
+		generatedBlocks = append(generatedBlocks, b)
+
+	}
+	return generatedBlocks
+}
+
+// GenerateCids produces n content identifiers.
+func GenerateCids(n int) []cid.Cid {
+	cids := make([]cid.Cid, 0, n)
+	for i := 0; i < n; i++ {
+		c := blockGenerator.Next().Cid()
+		cids = append(cids, c)
+	}
+	return cids
+}
+
+var peerSeq int
+
+// GeneratePeers creates n peer ids.
+func GeneratePeers(n int) []peer.ID {
+	peerIds := make([]peer.ID, 0, n)
+	for i := 0; i < n; i++ {
+		peerSeq++
+		p := peer.ID(peerSeq)
+		peerIds = append(peerIds, p)
+	}
+	return peerIds
+}
+
+// ContainsPeer returns true if a peer is found n a list of peers.
+func ContainsPeer(peers []peer.ID, p peer.ID) bool {
+	for _, n := range peers {
+		if p == n {
+			return true
+		}
+	}
+	return false
+}
+
+// IndexOf returns the index of a given cid in an array of blocks
+func IndexOf(blks []blocks.Block, c cid.Cid) int {
+	for i, n := range blks {
+		if n.Cid() == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// ContainsBlock returns true if a block is found n a list of blocks
+func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
+	return IndexOf(blks, block.Cid()) != -1
+}


### PR DESCRIPTION
# Goals

To support both Lotus and GFC integration, we are switching away from using pieceCIDs for retrieval.
This PR changes the names and types on the expected interfaces, thought importantly, it leaves the implementation the same under the hood (treating payloadCIDs as if they were pieceCIDs). The fix to actually implement PayloadCID based retrieval will come in the next PR.