### PR TITLE
Properly Implement Retrieval Lookups Based on CIDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c
-	github.com/ipfs/go-car v0.0.3-0.20191203022317-23b0a85fd1b1
+	github.com/ipfs/go-car v0.0.3-0.20200124090545-1a340009d896
 	github.com/ipfs/go-cid v0.0.4
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-graphsync v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c h1:lN5IQA07
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c/go.mod h1:t+411r7psEUhLueM8C7aPA7cxCclv4O3VsUVxt9kz2I=
 github.com/ipfs/go-car v0.0.3-0.20191203022317-23b0a85fd1b1 h1:Nq8xEW+2KZq7IkRlkOh0rTEUI8FgunhMoLj5EMkJzbQ=
 github.com/ipfs/go-car v0.0.3-0.20191203022317-23b0a85fd1b1/go.mod h1:rmd887mJxQRDfndfDEY3Liyx8gQVyfFFRSHdsnDSAlk=
+github.com/ipfs/go-car v0.0.3-0.20200124090545-1a340009d896 h1:l8gnU1VBhftugMKzfh+n7nuDhOw3X1iqfrA33GVBMMY=
+github.com/ipfs/go-car v0.0.3-0.20200124090545-1a340009d896/go.mod h1:rmd887mJxQRDfndfDEY3Liyx8gQVyfFFRSHdsnDSAlk=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJ
 github.com/ipfs/go-blockservice v0.1.0/go.mod h1:hzmMScl1kXHg3M2BjTymbVPjv627N7sYcvYaKbop39M=
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c h1:lN5IQA07VtLiTLAp/Scezp1ljFhXErC6yq4O1cu+yJ0=
 github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c/go.mod h1:t+411r7psEUhLueM8C7aPA7cxCclv4O3VsUVxt9kz2I=
-github.com/ipfs/go-car v0.0.3-0.20191203022317-23b0a85fd1b1 h1:Nq8xEW+2KZq7IkRlkOh0rTEUI8FgunhMoLj5EMkJzbQ=
-github.com/ipfs/go-car v0.0.3-0.20191203022317-23b0a85fd1b1/go.mod h1:rmd887mJxQRDfndfDEY3Liyx8gQVyfFFRSHdsnDSAlk=
 github.com/ipfs/go-car v0.0.3-0.20200124090545-1a340009d896 h1:l8gnU1VBhftugMKzfh+n7nuDhOw3X1iqfrA33GVBMMY=
 github.com/ipfs/go-car v0.0.3-0.20200124090545-1a340009d896/go.mod h1:rmd887mJxQRDfndfDEY3Liyx8gQVyfFFRSHdsnDSAlk=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/piecestore/piecestore.go
+++ b/piecestore/piecestore.go
@@ -30,7 +30,6 @@ type pieceStore struct {
 }
 
 func (ps *pieceStore) AddDealForPiece(pieceCID []byte, dealInfo DealInfo) error {
-	// Do we need to de-dupe or anything here?
 	return ps.mutatePieceInfo(pieceCID, func(pi *PieceInfo) error {
 		for _, di := range pi.Deals {
 			if di == dealInfo {

--- a/piecestore/piecestore.go
+++ b/piecestore/piecestore.go
@@ -10,9 +10,13 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 )
 
+// DSPiecePrefix is the name space for storing piece infos
 var DSPiecePrefix = "/storagemarket/pieces"
+
+// DSCIDPrefix is the name space for storing CID infos
 var DSCIDPrefix = "/storagemarket/cid-infos"
 
+// NewPieceStore returns a new piecestore based on the given datastore
 func NewPieceStore(ds datastore.Batching) PieceStore {
 	return &pieceStore{
 		pieces:   statestore.New(namespace.Wrap(ds, datastore.NewKey(DSPiecePrefix))),

--- a/piecestore/piecestore_test.go
+++ b/piecestore/piecestore_test.go
@@ -9,51 +9,164 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
 func TestStorePieceInfo(t *testing.T) {
-	ps := piecestore.NewPieceStore(datastore.NewMapDatastore())
+
 	pieceCid := []byte{1, 2, 3, 4}
-
-	_, err := ps.GetPieceInfo(pieceCid)
-	assert.Error(t, err)
-
-	// Add a PieceInfo and some state
-	testCid, err := cid.Decode("bafzbeigai3eoy2ccc7ybwjfz5r3rdxqrinwi4rwytly24tdbh6yk7zslrm")
-	assert.NoError(t, err)
-	blockInfos := []piecestore.BlockInfo{{testCid, 42, 43}}
-
-	err = ps.AddBlockInfosToPiece(pieceCid, blockInfos)
-	assert.NoError(t, err)
-	has, err := ps.HasBlockInfo(pieceCid)
-	assert.True(t, has)
-	assert.NoError(t, err)
-	has, err = ps.HasDealInfo(pieceCid)
-	assert.False(t, has)
-	assert.NoError(t, err)
-
-	pi, err := ps.GetPieceInfo(pieceCid)
-	assert.NoError(t, err)
-	assert.Len(t, pi.Blocks, 1)
-	assert.Equal(t, pi.Blocks[0], piecestore.BlockInfo{testCid, 42, 43})
-
-	dealInfo := piecestore.DealInfo{
-		DealID:   rand.Uint64(),
-		SectorID: rand.Uint64(),
-		Offset:   rand.Uint64(),
-		Length:   rand.Uint64(),
+	initializePieceStore := func(t *testing.T) piecestore.PieceStore {
+		ps := piecestore.NewPieceStore(datastore.NewMapDatastore())
+		_, err := ps.GetPieceInfo(pieceCid)
+		assert.Error(t, err)
+		return ps
 	}
-	err = ps.AddDealForPiece(pieceCid, dealInfo)
-	assert.NoError(t, err)
 
-	has, err = ps.HasBlockInfo(pieceCid)
-	assert.True(t, has)
-	assert.NoError(t, err)
-	has, err = ps.HasDealInfo(pieceCid)
-	assert.True(t, has)
-	assert.NoError(t, err)
-	pi, err = ps.GetPieceInfo(pieceCid)
-	assert.NoError(t, err)
-	assert.Len(t, pi.Deals, 1)
-	assert.Equal(t, pi.Deals[0], dealInfo)
+	// Add a deal info
+	t.Run("can add deals", func(t *testing.T) {
+		ps := initializePieceStore(t)
+		dealInfo := piecestore.DealInfo{
+			DealID:   rand.Uint64(),
+			SectorID: rand.Uint64(),
+			Offset:   rand.Uint64(),
+			Length:   rand.Uint64(),
+		}
+		err := ps.AddDealForPiece(pieceCid, dealInfo)
+		assert.NoError(t, err)
+
+		pi, err := ps.GetPieceInfo(pieceCid)
+		assert.NoError(t, err)
+		assert.Len(t, pi.Deals, 1)
+		assert.Equal(t, pi.Deals[0], dealInfo)
+	})
+
+	t.Run("adding same deal twice does not dup", func(t *testing.T) {
+		ps := initializePieceStore(t)
+		dealInfo := piecestore.DealInfo{
+			DealID:   rand.Uint64(),
+			SectorID: rand.Uint64(),
+			Offset:   rand.Uint64(),
+			Length:   rand.Uint64(),
+		}
+		err := ps.AddDealForPiece(pieceCid, dealInfo)
+		assert.NoError(t, err)
+
+		pi, err := ps.GetPieceInfo(pieceCid)
+		assert.NoError(t, err)
+		assert.Len(t, pi.Deals, 1)
+		assert.Equal(t, pi.Deals[0], dealInfo)
+
+		err = ps.AddDealForPiece(pieceCid, dealInfo)
+		assert.NoError(t, err)
+
+		pi, err = ps.GetPieceInfo(pieceCid)
+		assert.NoError(t, err)
+		assert.Len(t, pi.Deals, 1)
+		assert.Equal(t, pi.Deals[0], dealInfo)
+	})
+}
+
+func TestStoreCIDInfo(t *testing.T) {
+
+	pieceCid1 := []byte{1, 2, 3, 4}
+	pieceCid2 := []byte{5, 6, 7, 8}
+	testCIDs := shared_testutil.GenerateCids(3)
+	blockLocations := make([]piecestore.BlockLocation, 0, 3)
+	for i := 0; i < 3; i++ {
+		blockLocations = append(blockLocations, piecestore.BlockLocation{
+			RelOffset: rand.Uint64(),
+			BlockSize: rand.Uint64(),
+		})
+	}
+
+	initializePieceStore := func(t *testing.T) piecestore.PieceStore {
+		ps := piecestore.NewPieceStore(datastore.NewMapDatastore())
+		_, err := ps.GetCIDInfo(testCIDs[0])
+		assert.Error(t, err)
+		return ps
+	}
+
+	t.Run("can add piece block locations", func(t *testing.T) {
+		ps := initializePieceStore(t)
+		err := ps.AddPieceBlockLocations(pieceCid1, map[cid.Cid]piecestore.BlockLocation{
+			testCIDs[0]: blockLocations[0],
+			testCIDs[1]: blockLocations[1],
+			testCIDs[2]: blockLocations[2],
+		})
+		assert.NoError(t, err)
+
+		ci, err := ps.GetCIDInfo(testCIDs[0])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[0], pieceCid1})
+
+		ci, err = ps.GetCIDInfo(testCIDs[1])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[1], pieceCid1})
+
+		ci, err = ps.GetCIDInfo(testCIDs[2])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[2], pieceCid1})
+	})
+
+	t.Run("overlapping adds", func(t *testing.T) {
+		ps := initializePieceStore(t)
+		err := ps.AddPieceBlockLocations(pieceCid1, map[cid.Cid]piecestore.BlockLocation{
+			testCIDs[0]: blockLocations[0],
+			testCIDs[1]: blockLocations[2],
+		})
+		assert.NoError(t, err)
+		err = ps.AddPieceBlockLocations(pieceCid2, map[cid.Cid]piecestore.BlockLocation{
+			testCIDs[1]: blockLocations[1],
+			testCIDs[2]: blockLocations[2],
+		})
+		assert.NoError(t, err)
+
+		ci, err := ps.GetCIDInfo(testCIDs[0])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[0], pieceCid1})
+
+		ci, err = ps.GetCIDInfo(testCIDs[1])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 2)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[2], pieceCid1})
+		assert.Equal(t, ci.PieceBlockLocations[1], piecestore.PieceBlockLocation{blockLocations[1], pieceCid2})
+
+		ci, err = ps.GetCIDInfo(testCIDs[2])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[2], pieceCid2})
+	})
+
+	t.Run("duplicate adds", func(t *testing.T) {
+		ps := initializePieceStore(t)
+		err := ps.AddPieceBlockLocations(pieceCid1, map[cid.Cid]piecestore.BlockLocation{
+			testCIDs[0]: blockLocations[0],
+			testCIDs[1]: blockLocations[1],
+		})
+		assert.NoError(t, err)
+		err = ps.AddPieceBlockLocations(pieceCid1, map[cid.Cid]piecestore.BlockLocation{
+			testCIDs[1]: blockLocations[1],
+			testCIDs[2]: blockLocations[2],
+		})
+		assert.NoError(t, err)
+
+		ci, err := ps.GetCIDInfo(testCIDs[0])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[0], pieceCid1})
+
+		ci, err = ps.GetCIDInfo(testCIDs[1])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[1], pieceCid1})
+
+		ci, err = ps.GetCIDInfo(testCIDs[2])
+		assert.NoError(t, err)
+		assert.Len(t, ci.PieceBlockLocations, 1)
+		assert.Equal(t, ci.PieceBlockLocations[0], piecestore.PieceBlockLocation{blockLocations[2], pieceCid1})
+	})
 }

--- a/piecestore/types.go
+++ b/piecestore/types.go
@@ -1,8 +1,10 @@
 package piecestore
 
-import "github.com/ipfs/go-cid"
+import (
+	"github.com/ipfs/go-cid"
+)
 
-//go:generate cbor-gen-for PieceInfo DealInfo BlockInfo
+//go:generate cbor-gen-for PieceInfo DealInfo BlockLocation PieceBlockLocation CIDInfo
 
 // DealInfo is information about a single deal for a give piece
 type DealInfo struct {
@@ -12,11 +14,20 @@ type DealInfo struct {
 	Length   uint64
 }
 
-// BlockInfo is information about where a given block is within a piece
-type BlockInfo struct {
-	CID       cid.Cid
+// BlockLocation is information about where a given block is within a piece
+type BlockLocation struct {
 	RelOffset uint64
 	BlockSize uint64
+}
+
+type PieceBlockLocation struct {
+	BlockLocation
+	PieceCID []byte
+}
+
+type CIDInfo struct {
+	CID                 cid.Cid
+	PieceBlockLocations []PieceBlockLocation
 }
 
 // PieceInfo is metadata about a piece a provider may be storing based
@@ -25,7 +36,6 @@ type BlockInfo struct {
 type PieceInfo struct {
 	PieceCID []byte
 	Deals    []DealInfo
-	Blocks   []BlockInfo
 }
 
 // PieceInfoUndefined is piece info with no information
@@ -34,8 +44,7 @@ var PieceInfoUndefined = PieceInfo{}
 // PieceStore is a saved database of piece info that can be modified and queried
 type PieceStore interface {
 	AddDealForPiece(pieceCID []byte, dealInfo DealInfo) error
-	AddBlockInfosToPiece(pieceCID []byte, blockInfos []BlockInfo) error
-	HasBlockInfo(pieceCID []byte) (bool, error)
-	HasDealInfo(pieceCID []byte) (bool, error)
+	AddPieceBlockLocations(pieceCID []byte, blockLocations map[cid.Cid]BlockLocation) error
 	GetPieceInfo(pieceCID []byte) (PieceInfo, error)
+	GetCIDInfo(payloadCID cid.Cid) (CIDInfo, error)
 }

--- a/piecestore/types.go
+++ b/piecestore/types.go
@@ -14,21 +14,27 @@ type DealInfo struct {
 	Length   uint64
 }
 
-// BlockLocation is information about where a given block is within a piece
+// BlockLocation is information about where a given block is relative to the overall piece
 type BlockLocation struct {
 	RelOffset uint64
 	BlockSize uint64
 }
 
+// PieceBlockLocation is block information along with the pieceCID of the piece the block
+// is inside of
 type PieceBlockLocation struct {
 	BlockLocation
 	PieceCID []byte
 }
 
+// CIDInfo is information about where a given CID will live inside a piece
 type CIDInfo struct {
 	CID                 cid.Cid
 	PieceBlockLocations []PieceBlockLocation
 }
+
+// CIDInfoUndefined is cid info with no information
+var CIDInfoUndefined = CIDInfo{}
 
 // PieceInfo is metadata about a piece a provider may be storing based
 // on its PieceCID -- so that, given a pieceCID during retrieval, the miner

--- a/retrievalmarket/discovery/local.go
+++ b/retrievalmarket/discovery/local.go
@@ -36,8 +36,7 @@ func (l *Local) AddPeer(cid cid.Cid, peer retrievalmarket.RetrievalPeer) error {
 }
 
 func (l *Local) GetPeers(payloadCID cid.Cid) ([]retrievalmarket.RetrievalPeer, error) {
-	key := payloadCID.String()
-	entry, err := l.ds.Get(datastore.NewKey(key))
+	entry, err := l.ds.Get(dshelp.CidToDsKey(payloadCID))
 	if err == datastore.ErrNotFound {
 		return []retrievalmarket.RetrievalPeer{}, nil
 	}

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockunsealing"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/providerstates"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared/params"
 	"github.com/filecoin-project/go-fil-markets/shared/tokenamount"
 )
 
@@ -36,15 +37,29 @@ type provider struct {
 
 var _ retrievalmarket.RetrievalProvider = &provider{}
 
+// DefaultPricePerByte is the charge per byte retrieved if the miner does
+// not specifically set it
+var DefaultPricePerByte = tokenamount.FromInt(2)
+
+// DefaultPaymentInterval is the baseline interval, set to the unixfs chunk size
+// if the miner does not explicitly set it otherwise
+var DefaultPaymentInterval = uint64(params.UnixfsChunkSize)
+
+// DefaultPaymentIntervalIncrease is the amount interval increases on each payment, set to the unixfs chunk size
+// if the miner does not explicitly set it otherwise
+var DefaultPaymentIntervalIncrease = uint64(params.UnixfsChunkSize)
+
 // NewProvider returns a new retrieval provider
 func NewProvider(paymentAddress address.Address, node retrievalmarket.RetrievalProviderNode, network rmnet.RetrievalMarketNetwork, pieceStore piecestore.PieceStore, bs blockstore.Blockstore) retrievalmarket.RetrievalProvider {
 	return &provider{
-		bs:             bs,
-		node:           node,
-		network:        network,
-		paymentAddress: paymentAddress,
-		pieceStore:     pieceStore,
-		pricePerByte:   tokenamount.FromInt(2), // TODO: allow setting
+		bs:                      bs,
+		node:                    node,
+		network:                 network,
+		paymentAddress:          paymentAddress,
+		pieceStore:              pieceStore,
+		pricePerByte:            DefaultPricePerByte, // TODO: allow setting
+		paymentInterval:         DefaultPaymentInterval,
+		paymentIntervalIncrease: DefaultPaymentIntervalIncrease,
 	}
 }
 

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -3,6 +3,7 @@ package providerstates
 import (
 	"context"
 
+	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
@@ -13,7 +14,7 @@ import (
 // ProviderDealEnvironment is a bridge to the environment a provider deal is executing in
 type ProviderDealEnvironment interface {
 	Node() rm.RetrievalProviderNode
-	GetPieceSize(pieceCID []byte) (uint64, error)
+	GetPieceSize(c cid.Cid) (uint64, error)
 	DealStream() rmnet.RetrievalDealStream
 	NextBlock(context.Context) (rm.Block, bool, error)
 	CheckDealParams(pricePerByte tokenamount.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64) error
@@ -54,7 +55,7 @@ func ReceiveDeal(ctx context.Context, environment ProviderDealEnvironment, deal 
 	}
 
 	// verify we have the piece
-	_, err = environment.GetPieceSize(dealProposal.PayloadCID.Bytes())
+	_, err = environment.GetPieceSize(dealProposal.PayloadCID)
 	if err != nil {
 		if err == rm.ErrNotFound {
 			return responseFailure(environment.DealStream(), rm.DealStatusDealNotFound, rm.ErrNotFound.Error(), dealProposal.ID)

--- a/shared_testutil/test_piecestore.go
+++ b/shared_testutil/test_piecestore.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,15 +50,7 @@ func (tps *TestPieceStore) AddDealForPiece(pieceCID []byte, dealInfo piecestore.
 	panic("not implemented")
 }
 
-func (tps *TestPieceStore) AddBlockInfosToPiece(pieceCID []byte, blockInfos []piecestore.BlockInfo) error {
-	panic("not implemented")
-}
-
-func (tps *TestPieceStore) HasBlockInfo(pieceCID []byte) (bool, error) {
-	panic("not implemented")
-}
-
-func (tps *TestPieceStore) HasDealInfo(pieceCID []byte) (bool, error) {
+func (tps *TestPieceStore) AddPieceBlockLocations(pieceCID []byte, blockLocations map[cid.Cid]piecestore.BlockLocation) error {
 	panic("not implemented")
 }
 
@@ -73,4 +66,8 @@ func (tps *TestPieceStore) GetPieceInfo(pieceCID []byte) (piecestore.PieceInfo, 
 		return piecestore.PieceInfoUndefined, retrievalmarket.ErrNotFound
 	}
 	return piecestore.PieceInfoUndefined, errors.New("GetPieceSize failed")
+}
+
+func (tps *TestPieceStore) GetCIDInfo(c cid.Cid) (piecestore.CIDInfo, error) {
+	panic("not implemented")
 }

--- a/shared_testutil/test_piecestore.go
+++ b/shared_testutil/test_piecestore.go
@@ -12,10 +12,12 @@ import (
 
 // TestPieceStore is piecestore who's query results are mocked
 type TestPieceStore struct {
-	expectedPieces        map[string]piecestore.PieceInfo
-	expectedMissingPieces map[string]struct{}
-	receivedPieces        map[string]struct{}
-	receivedMissingPieces map[string]struct{}
+	piecesStubbed    map[string]piecestore.PieceInfo
+	piecesExpected   map[string]struct{}
+	piecesReceived   map[string]struct{}
+	cidInfosStubbed  map[cid.Cid]piecestore.CIDInfo
+	cidInfosExpected map[cid.Cid]struct{}
+	cidInfosReceived map[cid.Cid]struct{}
 }
 
 var _ piecestore.PieceStore = &TestPieceStore{}
@@ -23,27 +25,53 @@ var _ piecestore.PieceStore = &TestPieceStore{}
 // NewTestPieceStore creates a TestPieceStore
 func NewTestPieceStore() *TestPieceStore {
 	return &TestPieceStore{
-		expectedPieces:        make(map[string]piecestore.PieceInfo),
-		expectedMissingPieces: make(map[string]struct{}),
-		receivedPieces:        make(map[string]struct{}),
-		receivedMissingPieces: make(map[string]struct{}),
+		piecesStubbed:    make(map[string]piecestore.PieceInfo),
+		piecesExpected:   make(map[string]struct{}),
+		piecesReceived:   make(map[string]struct{}),
+		cidInfosStubbed:  make(map[cid.Cid]piecestore.CIDInfo),
+		cidInfosExpected: make(map[cid.Cid]struct{}),
+		cidInfosReceived: make(map[cid.Cid]struct{}),
 	}
+}
+
+// StubPiece creates a return value for the given piece cid without expecting it
+// to be called
+func (tps *TestPieceStore) StubPiece(pieceCid []byte, pieceInfo piecestore.PieceInfo) {
+	tps.piecesStubbed[string(pieceCid)] = pieceInfo
 }
 
 // ExpectPiece records a piece being expected to be queried and return the given piece info
 func (tps *TestPieceStore) ExpectPiece(pieceCid []byte, pieceInfo piecestore.PieceInfo) {
-	tps.expectedPieces[string(pieceCid)] = pieceInfo
+	tps.piecesExpected[string(pieceCid)] = struct{}{}
+	tps.StubPiece(pieceCid, pieceInfo)
 }
 
 // ExpectMissingPiece records a piece being expected to be queried and should fail
 func (tps *TestPieceStore) ExpectMissingPiece(pieceCid []byte) {
-	tps.expectedMissingPieces[string(pieceCid)] = struct{}{}
+	tps.piecesExpected[string(pieceCid)] = struct{}{}
+}
+
+// StubCID creates a return value for the given CID without expecting it
+// to be called
+func (tps *TestPieceStore) StubCID(c cid.Cid, cidInfo piecestore.CIDInfo) {
+	tps.cidInfosStubbed[c] = cidInfo
+}
+
+// ExpectCID records a CID being expected to be queried and return the given CID info
+func (tps *TestPieceStore) ExpectCID(c cid.Cid, cidInfo piecestore.CIDInfo) {
+	tps.cidInfosExpected[c] = struct{}{}
+	tps.StubCID(c, cidInfo)
+}
+
+// ExpectMissingCID records a CID being expected to be queried and should fail
+func (tps *TestPieceStore) ExpectMissingCID(c cid.Cid) {
+	tps.cidInfosExpected[c] = struct{}{}
 }
 
 // VerifyExpectations verifies that the piecestore was queried in the expected ways
 func (tps *TestPieceStore) VerifyExpectations(t *testing.T) {
-	require.Equal(t, len(tps.expectedPieces), len(tps.receivedPieces))
-	require.Equal(t, len(tps.expectedMissingPieces), len(tps.receivedMissingPieces))
+	require.Equal(t, tps.piecesExpected, tps.piecesReceived)
+	require.Equal(t, tps.cidInfosExpected, tps.cidInfosReceived)
 }
 
 func (tps *TestPieceStore) AddDealForPiece(pieceCID []byte, dealInfo piecestore.DealInfo) error {
@@ -55,19 +83,29 @@ func (tps *TestPieceStore) AddPieceBlockLocations(pieceCID []byte, blockLocation
 }
 
 func (tps *TestPieceStore) GetPieceInfo(pieceCID []byte) (piecestore.PieceInfo, error) {
-	pio, ok := tps.expectedPieces[string(pieceCID)]
+	tps.piecesReceived[string(pieceCID)] = struct{}{}
+
+	pio, ok := tps.piecesStubbed[string(pieceCID)]
 	if ok {
-		tps.receivedPieces[string(pieceCID)] = struct{}{}
 		return pio, nil
 	}
-	_, ok = tps.expectedMissingPieces[string(pieceCID)]
+	_, ok = tps.piecesExpected[string(pieceCID)]
 	if ok {
-		tps.receivedMissingPieces[string(pieceCID)] = struct{}{}
 		return piecestore.PieceInfoUndefined, retrievalmarket.ErrNotFound
 	}
-	return piecestore.PieceInfoUndefined, errors.New("GetPieceSize failed")
+	return piecestore.PieceInfoUndefined, errors.New("GetPieceInfo failed")
 }
 
 func (tps *TestPieceStore) GetCIDInfo(c cid.Cid) (piecestore.CIDInfo, error) {
-	panic("not implemented")
+	tps.cidInfosReceived[c] = struct{}{}
+
+	cio, ok := tps.cidInfosStubbed[c]
+	if ok {
+		return cio, nil
+	}
+	_, ok = tps.cidInfosExpected[c]
+	if ok {
+		return piecestore.CIDInfoUndefined, retrievalmarket.ErrNotFound
+	}
+	return piecestore.CIDInfoUndefined, errors.New("GetCIDInfo failed")
 }


### PR DESCRIPTION
# Goals

Allow Retrieval deals to work with actual Payload CIDs

# Implementation

-- add a second mapping to the PieceStore that translates from a CID to pieces its a part of
-- support unsealling pieces from CIDs as needed (theoretically a dag could span multiple pieces in the future where pieces are not whole dags -- not super important though)
-- add very preliminary writes of CID -> Piece mapping on storage provider side
    --- IMPORTANT: Not included is mapping any CIDs in the IPLD graph other than the root to Piece, or recording where in the piece blocks actually live. This can definitely be done by recording this information as we write the CAR file. This is definitely temporary implementation meant to get us to working retrieval by payload CID fast, with allowing retrievals based off of CIDs deeper in the dag later.