### PR TITLE
Fix/flaky tests

### DIFF
--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -130,17 +130,16 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 		voucherAmts []tokenamount.TokenAmount
 		unsealing   bool
 	}{
-		// skipping for now due to flakiness
-		// {name: "1 block file retrieval succeeds",
-		// 	filename:    "lorem_under_1_block.txt",
-		// 	filesize:    410,
-		// 	voucherAmts: []tokenamount.TokenAmount{tokenamount.FromInt(410000)},
-		// 	unsealing:   false},
-		// {name: "1 block file retrieval succeeds with unsealing",
-		// 	filename:    "lorem_under_1_block.txt",
-		// 	filesize:    410,
-		// 	voucherAmts: []tokenamount.TokenAmount{tokenamount.FromInt(410000)},
-		// 	unsealing:   true},
+		{name: "1 block file retrieval succeeds",
+			filename:    "lorem_under_1_block.txt",
+			filesize:    410,
+			voucherAmts: []tokenamount.TokenAmount{tokenamount.FromInt(410000)},
+			unsealing:   false},
+		{name: "1 block file retrieval succeeds with unsealing",
+			filename:    "lorem_under_1_block.txt",
+			filesize:    410,
+			voucherAmts: []tokenamount.TokenAmount{tokenamount.FromInt(410000)},
+			unsealing:   true},
 		{name: "multi-block file retrieval succeeds",
 			filename:    "lorem.txt",
 			filesize:    19000,

--- a/retrievalmarket/network/deal_stream.go
+++ b/retrievalmarket/network/deal_stream.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"bufio"
+
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -9,8 +11,9 @@ import (
 )
 
 type DealStream struct {
-	p  peer.ID
-	rw mux.MuxedStream
+	p        peer.ID
+	rw       mux.MuxedStream
+	buffered *bufio.Reader
 }
 
 var _ RetrievalDealStream = (*DealStream)(nil)
@@ -18,7 +21,7 @@ var _ RetrievalDealStream = (*DealStream)(nil)
 func (d *DealStream) ReadDealProposal() (retrievalmarket.DealProposal, error) {
 	var ds retrievalmarket.DealProposal
 
-	if err := ds.UnmarshalCBOR(d.rw); err != nil {
+	if err := ds.UnmarshalCBOR(d.buffered); err != nil {
 		log.Warn(err)
 		return retrievalmarket.DealProposalUndefined, err
 	}
@@ -32,7 +35,7 @@ func (d *DealStream) WriteDealProposal(dp retrievalmarket.DealProposal) error {
 func (d *DealStream) ReadDealResponse() (retrievalmarket.DealResponse, error) {
 	var dr retrievalmarket.DealResponse
 
-	if err := dr.UnmarshalCBOR(d.rw); err != nil {
+	if err := dr.UnmarshalCBOR(d.buffered); err != nil {
 		return retrievalmarket.DealResponseUndefined, err
 	}
 	return dr, nil

--- a/retrievalmarket/network/libp2p_impl.go
+++ b/retrievalmarket/network/libp2p_impl.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"bufio"
 	"context"
 
 	logging "github.com/ipfs/go-log/v2"
@@ -31,7 +32,8 @@ func (impl *libp2pRetrievalMarketNetwork) NewQueryStream(id peer.ID) (RetrievalQ
 		log.Warn(err)
 		return nil, err
 	}
-	return &QueryStream{p: id, rw: s}, nil
+	buffered := bufio.NewReaderSize(s, 16)
+	return &QueryStream{p: id, rw: s, buffered: buffered}, nil
 }
 
 func (impl *libp2pRetrievalMarketNetwork) NewDealStream(id peer.ID) (RetrievalDealStream, error) {
@@ -39,7 +41,8 @@ func (impl *libp2pRetrievalMarketNetwork) NewDealStream(id peer.ID) (RetrievalDe
 	if err != nil {
 		return nil, err
 	}
-	return &DealStream{p: id, rw: s}, nil
+	buffered := bufio.NewReaderSize(s, 16)
+	return &DealStream{p: id, rw: s, buffered: buffered}, nil
 }
 
 func (impl *libp2pRetrievalMarketNetwork) SetDelegate(r RetrievalReceiver) error {
@@ -63,7 +66,8 @@ func (impl *libp2pRetrievalMarketNetwork) handleNewQueryStream(s network.Stream)
 		return
 	}
 	remotePID := s.Conn().RemotePeer()
-	qs := &QueryStream{remotePID, s}
+	buffered := bufio.NewReaderSize(s, 16)
+	qs := &QueryStream{remotePID, s, buffered}
 	impl.receiver.HandleQueryStream(qs)
 }
 
@@ -74,6 +78,7 @@ func (impl *libp2pRetrievalMarketNetwork) handleNewDealStream(s network.Stream) 
 		return
 	}
 	remotePID := s.Conn().RemotePeer()
-	ds := &DealStream{remotePID, s}
+	buffered := bufio.NewReaderSize(s, 16)
+	ds := &DealStream{remotePID, s, buffered}
 	impl.receiver.HandleDealStream(ds)
 }

--- a/retrievalmarket/network/query_stream.go
+++ b/retrievalmarket/network/query_stream.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"bufio"
+
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 
@@ -9,8 +11,9 @@ import (
 )
 
 type QueryStream struct {
-	p  peer.ID
-	rw mux.MuxedStream
+	p        peer.ID
+	rw       mux.MuxedStream
+	buffered *bufio.Reader
 }
 
 var _ RetrievalQueryStream = (*QueryStream)(nil)
@@ -18,7 +21,7 @@ var _ RetrievalQueryStream = (*QueryStream)(nil)
 func (qs *QueryStream) ReadQuery() (retrievalmarket.Query, error) {
 	var q retrievalmarket.Query
 
-	if err := q.UnmarshalCBOR(qs.rw); err != nil {
+	if err := q.UnmarshalCBOR(qs.buffered); err != nil {
 		log.Warn(err)
 		return retrievalmarket.QueryUndefined, err
 
@@ -34,7 +37,7 @@ func (qs *QueryStream) WriteQuery(q retrievalmarket.Query) error {
 func (qs *QueryStream) ReadQueryResponse() (retrievalmarket.QueryResponse, error) {
 	var resp retrievalmarket.QueryResponse
 
-	if err := resp.UnmarshalCBOR(qs.rw); err != nil {
+	if err := resp.UnmarshalCBOR(qs.buffered); err != nil {
 		log.Warn(err)
 		return retrievalmarket.QueryResponseUndefined, err
 	}

--- a/storagemarket/network/ask_stream.go
+++ b/storagemarket/network/ask_stream.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"bufio"
+
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 
@@ -8,8 +10,9 @@ import (
 )
 
 type askStream struct {
-	p  peer.ID
-	rw mux.MuxedStream
+	p        peer.ID
+	rw       mux.MuxedStream
+	buffered *bufio.Reader
 }
 
 var _ StorageAskStream = (*askStream)(nil)
@@ -17,7 +20,7 @@ var _ StorageAskStream = (*askStream)(nil)
 func (as *askStream) ReadAskRequest() (AskRequest, error) {
 	var a AskRequest
 
-	if err := a.UnmarshalCBOR(as.rw); err != nil {
+	if err := a.UnmarshalCBOR(as.buffered); err != nil {
 		log.Warn(err)
 		return AskRequestUndefined, err
 
@@ -33,7 +36,7 @@ func (as *askStream) WriteAskRequest(q AskRequest) error {
 func (as *askStream) ReadAskResponse() (AskResponse, error) {
 	var resp AskResponse
 
-	if err := resp.UnmarshalCBOR(as.rw); err != nil {
+	if err := resp.UnmarshalCBOR(as.buffered); err != nil {
 		log.Warn(err)
 		return AskResponseUndefined, err
 	}

--- a/storagemarket/network/deal_stream.go
+++ b/storagemarket/network/deal_stream.go
@@ -1,14 +1,17 @@
 package network
 
 import (
+	"bufio"
+
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 type dealStream struct {
-	p  peer.ID
-	rw mux.MuxedStream
+	p        peer.ID
+	rw       mux.MuxedStream
+	buffered *bufio.Reader
 }
 
 var _ StorageDealStream = (*dealStream)(nil)
@@ -16,7 +19,7 @@ var _ StorageDealStream = (*dealStream)(nil)
 func (d *dealStream) ReadDealProposal() (Proposal, error) {
 	var ds Proposal
 
-	if err := ds.UnmarshalCBOR(d.rw); err != nil {
+	if err := ds.UnmarshalCBOR(d.buffered); err != nil {
 		log.Warn(err)
 		return ProposalUndefined, err
 	}
@@ -30,7 +33,7 @@ func (d *dealStream) WriteDealProposal(dp Proposal) error {
 func (d *dealStream) ReadDealResponse() (SignedResponse, error) {
 	var dr SignedResponse
 
-	if err := dr.UnmarshalCBOR(d.rw); err != nil {
+	if err := dr.UnmarshalCBOR(d.buffered); err != nil {
 		return SignedResponseUndefined, err
 	}
 	return dr, nil

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"bufio"
 	"context"
 
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -31,7 +32,8 @@ func (impl *libp2pStorageMarketNetwork) NewAskStream(id peer.ID) (StorageAskStre
 		log.Warn(err)
 		return nil, err
 	}
-	return &askStream{p: id, rw: s}, nil
+	buffered := bufio.NewReaderSize(s, 16)
+	return &askStream{p: id, rw: s, buffered: buffered}, nil
 }
 
 func (impl *libp2pStorageMarketNetwork) NewDealStream(id peer.ID) (StorageDealStream, error) {
@@ -39,7 +41,8 @@ func (impl *libp2pStorageMarketNetwork) NewDealStream(id peer.ID) (StorageDealSt
 	if err != nil {
 		return nil, err
 	}
-	return &dealStream{p: id, rw: s}, nil
+	buffered := bufio.NewReaderSize(s, 16)
+	return &dealStream{p: id, rw: s, buffered: buffered}, nil
 }
 
 func (impl *libp2pStorageMarketNetwork) SetDelegate(r StorageReceiver) error {
@@ -63,7 +66,8 @@ func (impl *libp2pStorageMarketNetwork) handleNewAskStream(s network.Stream) {
 		return
 	}
 	remotePID := s.Conn().RemotePeer()
-	as := &askStream{remotePID, s}
+	buffered := bufio.NewReaderSize(s, 16)
+	as := &askStream{remotePID, s, buffered}
 	impl.receiver.HandleAskStream(as)
 }
 
@@ -74,6 +78,7 @@ func (impl *libp2pStorageMarketNetwork) handleNewDealStream(s network.Stream) {
 		return
 	}
 	remotePID := s.Conn().RemotePeer()
-	ds := &dealStream{remotePID, s}
+	buffered := bufio.NewReaderSize(s, 16)
+	ds := &dealStream{remotePID, s, buffered}
 	impl.receiver.HandleDealStream(ds)
 }


### PR DESCRIPTION
# Goals

Fix our tests, discover underlying bugs

# Implementation

So I have discovered the source of at least one bug. When unmarshalling CBOR, the generated cbor-gen Unmarshallers call cbg.GetPeeker(r) which returns a new buffered reader, unless it is passed a reader that is already buffered. This buffered reader reads 16 bytes at a time from the network stream. So, if two responses end up in the stream ahead of each other, it will read extra bytes from the first. However, those bytes will be lost from the underlying reader when we come back to read the second response. The solution is to maintain a buffered reader at the stream level, so that buffered data is preserved between reads. I have verified this seems to resolve our integration test failures. It is an expected and conceivable behavior that the retrieval protocol could write two responses on the server before the client reads the first.