### PR TITLE
Use latest specs-actors with uint64 lane and nonce from paych.Actor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b
 	github.com/filecoin-project/go-statestore v0.1.0
-	github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf
+	github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3-0.20190908200855-f22eea50656c

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIi
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf h1:fbxBG12yrxilPFV1EG2lYqpUyAlRZWkvtqjk2svSeXY=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
+github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362 h1:6FKMQbj6UIsg7t2qm1YlSbHjh/ehnCjaiOWzFwJefO0=
+github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=

--- a/retrievalmarket/impl/clientstates/client_states_test.go
+++ b/retrievalmarket/impl/clientstates/client_states_test.go
@@ -55,7 +55,7 @@ func TestSetupPaymentChannel(t *testing.T) {
 	ctx := context.Background()
 	ds := testnet.NewTestRetrievalDealStream(testnet.TestDealStreamParams{})
 	expectedPayCh := address.TestAddress2
-	expectedLane := int64(10)
+	expectedLane := uint64(10)
 
 	environment := func(params testnodes.TestRetrievalClientNodeParams) clientstates.ClientDealEnvironment {
 		node := testnodes.NewTestRetrievalClientNode(params)
@@ -490,7 +490,7 @@ func makeDealState(status retrievalmarket.DealStatus) *retrievalmarket.ClientDea
 		MinerWallet:      address.TestAddress,
 		ClientWallet:     address.TestAddress2,
 		PayCh:            address.TestAddress2,
-		Lane:             int64(10),
+		Lane:             uint64(10),
 		Status:           status,
 		BytesPaidFor:     defaultBytesPaidFor,
 		TotalReceived:    defaultTotalReceived,

--- a/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
@@ -14,7 +14,7 @@ import (
 type TestRetrievalClientNode struct {
 	payCh        address.Address
 	payChErr     error
-	lane         int64
+	lane         uint64
 	laneError    error
 	voucher      *paych.SignedVoucher
 	voucherError error
@@ -28,7 +28,7 @@ type TestRetrievalClientNode struct {
 type TestRetrievalClientNodeParams struct {
 	PayCh                  address.Address
 	PayChErr               error
-	Lane                   int64
+	Lane                   uint64
 	LaneError              error
 	Voucher                *paych.SignedVoucher
 	VoucherError           error
@@ -63,7 +63,7 @@ func (trcn *TestRetrievalClientNode) GetOrCreatePaymentChannel(ctx context.Conte
 }
 
 // AllocateLane creates a mock lane on a payment channel
-func (trcn *TestRetrievalClientNode) AllocateLane(paymentChannel address.Address) (int64, error) {
+func (trcn *TestRetrievalClientNode) AllocateLane(paymentChannel address.Address) (uint64, error) {
 	if trcn.allocateLaneRecorder != nil {
 		trcn.allocateLaneRecorder(paymentChannel)
 	}
@@ -71,7 +71,7 @@ func (trcn *TestRetrievalClientNode) AllocateLane(paymentChannel address.Address
 }
 
 // CreatePaymentVoucher creates a mock payment voucher based on a channel and lane
-func (trcn *TestRetrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane int64) (*paych.SignedVoucher, error) {
+func (trcn *TestRetrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64) (*paych.SignedVoucher, error) {
 	if trcn.createPaymentVoucherRecorder != nil {
 		trcn.createPaymentVoucherRecorder(trcn.voucher)
 	}

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -36,7 +36,7 @@ type ClientDealState struct {
 	ClientWallet     address.Address
 	MinerWallet      address.Address
 	PayCh            address.Address
-	Lane             int64
+	Lane             uint64
 	Status           DealStatus
 	Sender           peer.ID
 	TotalReceived    uint64
@@ -117,12 +117,12 @@ type RetrievalClientNode interface {
 	// Allocate late creates a lane within a payment channel so that calls to
 	// CreatePaymentVoucher will automatically make vouchers only for the difference
 	// in total
-	AllocateLane(paymentChannel address.Address) (int64, error)
+	AllocateLane(paymentChannel address.Address) (uint64, error)
 
 	// CreatePaymentVoucher creates a new payment voucher in the given lane for a
 	// given payment channel so that all the payment vouchers in the lane add up
 	// to the given amount (so the payment voucher will be for the difference)
-	CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane int64) (*paych.SignedVoucher, error)
+	CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64) (*paych.SignedVoucher, error)
 }
 
 // ProviderDealState is the current state of a deal from the point of view

--- a/retrievalmarket/types_cbor_gen.go
+++ b/retrievalmarket/types_cbor_gen.go
@@ -726,15 +726,9 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.Lane (int64) (int64)
-	if t.Lane >= 0 {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
-			return err
-		}
-	} else {
-		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.Lane)-1)); err != nil {
-			return err
-		}
+	// t.Lane (uint64) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
+		return err
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
@@ -865,31 +859,16 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.Lane (int64) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeader(br)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+	// t.Lane (uint64) (uint64)
 
-		t.Lane = int64(extraI)
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
 	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.Lane = uint64(extra)
 	// t.Status (retrievalmarket.DealStatus) (uint64)
 
 	maj, extra, err = cbg.CborReadHeader(br)

--- a/shared_testutil/test_types.go
+++ b/shared_testutil/test_types.go
@@ -25,8 +25,8 @@ func MakeTestSignedVoucher() *paych.SignedVoucher {
 		TimeLock:       abi.ChainEpoch(rand.Int63()),
 		SecretPreimage: []byte("secret-preimage"),
 		Extra:          MakeTestModVerifyParams(),
-		Lane:           rand.Int63(),
-		Nonce:          rand.Int63(),
+		Lane:           rand.Uint64(),
+		Nonce:          rand.Uint64(),
 		Amount:         MakeTestTokenAmount(),
 		Merges:         []paych.Merge{MakeTestMerge()},
 		Signature:      MakeTestSignature(),
@@ -45,8 +45,8 @@ func MakeTestModVerifyParams() *paych.ModVerifyParams {
 // MakeTestMerge generates a random Merge that has all non-zero fields
 func MakeTestMerge() paych.Merge {
 	return paych.Merge{
-		Lane:  rand.Int63(),
-		Nonce: rand.Int63(),
+		Lane:  rand.Uint64(),
+		Nonce: rand.Uint64(),
 	}
 }
 


### PR DESCRIPTION
## Problem

The latest specs-actors has the changes to paych.Actor that I introduced in [specs-actors PR #157](https://github.com/filecoin-project/specs-actors/pull/157), which makes Lane and Nonce `Uint64s`. In going back to retrieval market implementation I saw that go-fil-markets hasn't yet updated to the latest specs-actors.  This is blocking me, since my branch is up-to-date with go-filecoin master, which itself uses the latest specs-actors, and now I am seeing test failures which can't be resolved without this update.

## Solution
Update to latest specs-actors and fix the problems that arise:  int64 --> uint64 and rerun cbor-gen.
