### PR TITLE
Use go-statemachine + FSMs in retrieval market

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b
-	github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15
+	github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b
-	github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7
+	github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
 	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b
+	github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/specs-actors v0.0.0-20200220011005-b2a2fbf40362
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b h1:ds4TQay8wuV+2ucC6ENAeSYQDdl9CWYXnX0gvxzGKHg=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b/go.mod h1:qsuPYsbKTHH2phNk81aUF9VJIilUxFrnxxnryJh4FOM=
+github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15 h1:EdUeo+IyT1Yaq0vW0uTZyrDM7bQCIdleQhPaJXmUmMg=
+github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf h1:fbxBG12yrxilPFV1EG2lYqpUyAlRZWkvtqjk2svSeXY=
@@ -220,6 +222,9 @@ github.com/ipfs/go-ipld-format v0.0.2/go.mod h1:4B6+FM2u9OJ9zCV+kSbgFAZlOrv1Hqbf
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log v1.0.0 h1:BW3LQIiZzpNyolt84yvKNCd3FU+AK4VDw1hnHR+1aiI=
 github.com/ipfs/go-log v1.0.0/go.mod h1:JO7RzlMK6rA+CIxFMLOuB6Wf5b81GDiKElL7UPSIKjA=
+github.com/ipfs/go-log v1.0.1 h1:5lIEEOQTk/vd1WuPFBRqz2mcp+5G1fMVcW+Ib/H5Hfo=
+github.com/ipfs/go-log v1.0.1/go.mod h1:HuWlQttfN6FWNHRhlY5yMk/lW7evQC0HHGOxEwMRR8I=
+github.com/ipfs/go-log/v2 v2.0.1/go.mod h1:O7P1lJt27vWHhOwQmcFEvlmo49ry2VY2+JfBWFaa9+0=
 github.com/ipfs/go-log/v2 v2.0.2 h1:xguurydRdfKMJjKyxNXNU8lYP0VZH1NUwJRwUorjuEw=
 github.com/ipfs/go-log/v2 v2.0.2/go.mod h1:O7P1lJt27vWHhOwQmcFEvlmo49ry2VY2+JfBWFaa9+0=
 github.com/ipfs/go-merkledag v0.2.3/go.mod h1:SQiXrtSts3KGNmgOzMICy5c0POOpUNQLvB3ClKnBAlk=
@@ -719,6 +724,8 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
+gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6 h
 github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7 h1:3dWTPc5WYTQeYJJ9/2xYWkUfqkTMWCnfZHcrDO6YWyo=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf h1:fbxBG12yrxilPFV1EG2lYqpUyAlRZWkvtqjk2svSeXY=

--- a/go.sum
+++ b/go.sum
@@ -78,14 +78,6 @@ github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b h1:ds4TQay8wuV+2ucC6ENAeSYQDdl9CWYXnX0gvxzGKHg=
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b/go.mod h1:qsuPYsbKTHH2phNk81aUF9VJIilUxFrnxxnryJh4FOM=
-github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15 h1:EdUeo+IyT1Yaq0vW0uTZyrDM7bQCIdleQhPaJXmUmMg=
-github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226011440-e5b11dff0e53 h1:kcARB+32nRhVun127ZG+0kA1dt6Cs81RzcYMOfkpNjE=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226011440-e5b11dff0e53/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6 h1:d4e+uFvw4Y48vM8wO9rTati88lLRYgEF5wZ0reyEtZw=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7 h1:3dWTPc5WYTQeYJJ9/2xYWkUfqkTMWCnfZHcrDO6YWyo=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,12 @@ github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6
 github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200210220012-eb75ec747d6b/go.mod h1:qsuPYsbKTHH2phNk81aUF9VJIilUxFrnxxnryJh4FOM=
 github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15 h1:EdUeo+IyT1Yaq0vW0uTZyrDM7bQCIdleQhPaJXmUmMg=
 github.com/filecoin-project/go-statemachine v0.0.0-20200224175926-054b5d105a15/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226011440-e5b11dff0e53 h1:kcARB+32nRhVun127ZG+0kA1dt6Cs81RzcYMOfkpNjE=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226011440-e5b11dff0e53/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6 h1:d4e+uFvw4Y48vM8wO9rTati88lLRYgEF5wZ0reyEtZw=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226012634-fce16a942bf6/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7 h1:3dWTPc5WYTQeYJJ9/2xYWkUfqkTMWCnfZHcrDO6YWyo=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226025251-5410df5fb7f7/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf h1:fbxBG12yrxilPFV1EG2lYqpUyAlRZWkvtqjk2svSeXY=

--- a/retrievalmarket/impl/blockunsealing/blockunsealing.go
+++ b/retrievalmarket/impl/blockunsealing/blockunsealing.go
@@ -21,12 +21,11 @@ type LoaderWithUnsealing interface {
 }
 
 type loaderWithUnsealing struct {
-	ctx             context.Context
-	bs              blockstore.Blockstore
-	pieceStore      piecestore.PieceStore
-	carIO           pieceio.CarIO
-	unsealer        UnsealingFunc
-	alreadyUnsealed bool
+	ctx        context.Context
+	bs         blockstore.Blockstore
+	pieceStore piecestore.PieceStore
+	carIO      pieceio.CarIO
+	unsealer   UnsealingFunc
 }
 
 // UnsealingFunc is a function that unseals sectors at a given offset and length
@@ -35,7 +34,7 @@ type UnsealingFunc func(ctx context.Context, sectorId uint64, offset uint64, len
 // NewLoaderWithUnsealing creates a loader that will attempt to read blocks from the blockstore but unseal the piece
 // as needed using the passed unsealing function
 func NewLoaderWithUnsealing(ctx context.Context, bs blockstore.Blockstore, pieceStore piecestore.PieceStore, carIO pieceio.CarIO, unsealer UnsealingFunc) LoaderWithUnsealing {
-	return &loaderWithUnsealing{ctx, bs, pieceStore, carIO, unsealer, false}
+	return &loaderWithUnsealing{ctx, bs, pieceStore, carIO, unsealer}
 }
 
 func (lu *loaderWithUnsealing) Load(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -65,12 +65,12 @@ func NewClient(
 		blockVerifiers: make(map[retrievalmarket.DealID]blockio.BlockVerifier),
 	}
 	stateMachines, err := fsm.New(namespace.Wrap(ds, datastore.NewKey(ClientDsPrefix)), fsm.Parameters{
-		Environment:   c,
-		StateType:     retrievalmarket.ClientDealState{},
-		StateKeyField: "Status",
-		Events:        clientstates.ClientEvents,
-		StateHandlers: clientstates.ClientHandlers,
-		Notifier:      c.notifySubscribers,
+		Environment:     c,
+		StateType:       retrievalmarket.ClientDealState{},
+		StateKeyField:   "Status",
+		Events:          clientstates.ClientEvents,
+		StateEntryFuncs: clientstates.ClientStateEntryFuncs,
+		Notifier:        c.notifySubscribers,
 	})
 	if err != nil {
 		return nil, err

--- a/retrievalmarket/impl/clientstates/client_fsm.go
+++ b/retrievalmarket/impl/clientstates/client_fsm.go
@@ -1,0 +1,171 @@
+package clientstates
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/go-address"
+	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-statemachine/fsm"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"golang.org/x/xerrors"
+)
+
+func recordPaymentOwed(deal *rm.ClientDealState, totalProcessed uint64, paymentOwed abi.TokenAmount) error {
+	deal.TotalReceived += totalProcessed
+	deal.PaymentRequested = paymentOwed
+	return nil
+}
+
+func recordProcessed(deal *rm.ClientDealState, totalProcessed uint64) error {
+	deal.TotalReceived += totalProcessed
+	return nil
+}
+
+// ClientEvents are the events that can happen in a retrieval client
+var ClientEvents = fsm.Events{
+	fsm.Event(rm.ClientEventOpen).
+		From(rm.DealStatusNew).ToNoChange(),
+	fsm.Event(rm.ClientEventPaymentChannelErrored).
+		From(rm.DealStatusAccepted).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("getting payment channel: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventAllocateLaneErrored).
+		From(rm.DealStatusAccepted).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("allocating payment lane: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventPaymentChannelCreated).
+		From(rm.DealStatusAccepted).To(rm.DealStatusPaymentChannelCreated).
+		WithCallback(func(deal *rm.ClientDealState, payCh address.Address, lane uint64) error {
+			deal.PaymentInfo = &rm.PaymentInfo{
+				PayCh: payCh,
+				Lane:  lane,
+			}
+			return nil
+		}),
+	fsm.Event(rm.ClientEventWriteDealProposalErrored).
+		FromAny().To(rm.DealStatusErrored).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("proposing deal: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventReadDealResponseErrored).
+		FromAny().To(rm.DealStatusErrored).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("reading deal response: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventDealRejected).
+		From(rm.DealStatusNew).To(rm.DealStatusRejected).
+		WithCallback(func(deal *rm.ClientDealState, message string) error {
+			deal.Message = fmt.Sprintf("deal rejected: %s", message)
+			return nil
+		}),
+	fsm.Event(rm.ClientEventDealNotFound).
+		From(rm.DealStatusNew).To(rm.DealStatusDealNotFound).
+		WithCallback(func(deal *rm.ClientDealState, message string) error {
+			deal.Message = fmt.Sprintf("deal not found: %s", message)
+			return nil
+		}),
+	fsm.Event(rm.ClientEventDealAccepted).
+		From(rm.DealStatusNew).To(rm.DealStatusAccepted),
+	fsm.Event(rm.ClientEventUnknownResponseReceived).
+		FromAny().To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState) error {
+			deal.Message = "Unexpected deal response status"
+			return nil
+		}),
+	fsm.Event(rm.ClientEventFundsExpended).
+		FromMany(rm.DealStatusFundsNeeded, rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, expectedTotal string, actualTotal string) error {
+			deal.Message = fmt.Sprintf("not enough funds left: expected amt = %s, actual amt = %s", expectedTotal, actualTotal)
+			return nil
+		}),
+	fsm.Event(rm.ClientEventBadPaymentRequested).
+		FromMany(rm.DealStatusFundsNeeded, rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, message string) error {
+			deal.Message = message
+			return nil
+		}),
+	fsm.Event(rm.ClientEventCreateVoucherFailed).
+		FromMany(rm.DealStatusFundsNeeded, rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("creating payment voucher: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventWriteDealPaymentErrored).
+		FromAny().To(rm.DealStatusErrored).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("writing deal payment: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventPaymentSent).
+		From(rm.DealStatusFundsNeeded).To(rm.DealStatusOngoing).
+		From(rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFinalizing).
+		WithCallback(func(deal *rm.ClientDealState) error {
+			// paymentRequested = 0
+			// fundsSpent = fundsSpent + paymentRequested
+			// if paymentRequested / pricePerByte >= currentInterval
+			// currentInterval = currentInterval + proposal.intervalIncrease
+			// bytesPaidFor = bytesPaidFor + (paymentRequested / pricePerByte)
+			deal.FundsSpent = big.Add(deal.FundsSpent, deal.PaymentRequested)
+			bytesPaidFor := big.Div(deal.PaymentRequested, deal.PricePerByte).Uint64()
+			if bytesPaidFor >= deal.CurrentInterval {
+				deal.CurrentInterval += deal.DealProposal.PaymentIntervalIncrease
+			}
+			deal.BytesPaidFor += bytesPaidFor
+			deal.PaymentRequested = abi.NewTokenAmount(0)
+			return nil
+		}),
+	fsm.Event(rm.ClientEventConsumeBlockFailed).
+		FromMany(rm.DealStatusPaymentChannelCreated, rm.DealStatusOngoing).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState, err error) error {
+			deal.Message = xerrors.Errorf("consuming block: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ClientEventLastPaymentRequested).
+		FromMany(rm.DealStatusPaymentChannelCreated,
+			rm.DealStatusOngoing,
+			rm.DealStatusBlocksComplete).To(rm.DealStatusFundsNeededLastPayment).
+		WithCallback(recordPaymentOwed),
+	fsm.Event(rm.ClientEventAllBlocksReceived).
+		FromMany(rm.DealStatusPaymentChannelCreated,
+			rm.DealStatusOngoing,
+			rm.DealStatusBlocksComplete).To(rm.DealStatusBlocksComplete).
+		WithCallback(recordProcessed),
+	fsm.Event(rm.ClientEventComplete).
+		FromMany(rm.DealStatusPaymentChannelCreated,
+			rm.DealStatusOngoing,
+			rm.DealStatusBlocksComplete,
+			rm.DealStatusFinalizing).To(rm.DealStatusCompleted).
+		WithCallback(recordProcessed),
+	fsm.Event(rm.ClientEventEarlyTermination).
+		FromMany(rm.DealStatusPaymentChannelCreated, rm.DealStatusOngoing).To(rm.DealStatusFailed).
+		WithCallback(func(deal *rm.ClientDealState) error {
+			deal.Message = "received complete status before all blocks received"
+			return nil
+		}),
+	fsm.Event(rm.ClientEventPaymentRequested).
+		FromMany(rm.DealStatusPaymentChannelCreated, rm.DealStatusOngoing).To(rm.DealStatusFundsNeeded).
+		WithCallback(recordPaymentOwed),
+	fsm.Event(rm.ClientEventBlocksReceived).
+		From(rm.DealStatusPaymentChannelCreated).To(rm.DealStatusOngoing).
+		From(rm.DealStatusOngoing).ToNoChange().
+		WithCallback(recordProcessed),
+}
+
+// ClientHandlers are the handlers for different states in a retrieval client
+var ClientHandlers = fsm.StateHandlers{
+	rm.DealStatusNew:                    ProposeDeal,
+	rm.DealStatusAccepted:               SetupPaymentChannel,
+	rm.DealStatusPaymentChannelCreated:  ProcessNextResponse,
+	rm.DealStatusOngoing:                ProcessNextResponse,
+	rm.DealStatusBlocksComplete:         ProcessNextResponse,
+	rm.DealStatusFundsNeeded:            ProcessPaymentRequested,
+	rm.DealStatusFundsNeededLastPayment: ProcessPaymentRequested,
+	rm.DealStatusFinalizing:             Finalize,
+}

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -2,12 +2,10 @@ package clientstates
 
 import (
 	"context"
-	"fmt"
-
-	"golang.org/x/xerrors"
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 )
@@ -15,8 +13,8 @@ import (
 // ClientDealEnvironment is a bridge to the environment a client deal is executing in
 type ClientDealEnvironment interface {
 	Node() rm.RetrievalClientNode
-	DealStream() rmnet.RetrievalDealStream
-	ConsumeBlock(context.Context, rm.Block) (uint64, bool, error)
+	DealStream(id rm.DealID) rmnet.RetrievalDealStream
+	ConsumeBlock(context.Context, rm.DealID, rm.Block) (uint64, bool, error)
 }
 
 func errorFunc(err error) func(*rm.ClientDealState) {
@@ -28,133 +26,100 @@ func errorFunc(err error) func(*rm.ClientDealState) {
 
 // ClientHandlerFunc is a function that handles a client deal being in a specific state
 // It processes the state and returns a modification function for a deal
-type ClientHandlerFunc func(ctx context.Context, environment ClientDealEnvironment, deal rm.ClientDealState) func(*rm.ClientDealState)
+type ClientHandlerFunc func(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error
 
 // SetupPaymentChannel sets up a payment channel for a deal
-func SetupPaymentChannel(ctx context.Context, environment ClientDealEnvironment, deal rm.ClientDealState) func(*rm.ClientDealState) {
-	paych, err := environment.Node().GetOrCreatePaymentChannel(ctx, deal.ClientWallet, deal.MinerWallet, deal.TotalFunds)
+func SetupPaymentChannel(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
+	paych, err := environment.Node().GetOrCreatePaymentChannel(ctx.Context(), deal.ClientWallet, deal.MinerWallet, deal.TotalFunds)
 	if err != nil {
-		return errorFunc(xerrors.Errorf("getting payment channel: %w", err))
+		return ctx.Event(rm.ClientEventPaymentChannelErrored, err)
 	}
 	lane, err := environment.Node().AllocateLane(paych)
 	if err != nil {
-		return errorFunc(xerrors.Errorf("allocating payment lane: %w", err))
+		return ctx.Event(rm.ClientEventAllocateLaneErrored, err)
 	}
-	return func(deal *rm.ClientDealState) {
-		deal.Status = rm.DealStatusPaymentChannelCreated
-		deal.PayCh = paych
-		deal.Lane = lane
-	}
+	return ctx.Event(rm.ClientEventPaymentChannelCreated, paych, lane)
 }
 
 // ProposeDeal sends the proposal to the other party
-func ProposeDeal(ctx context.Context, environment ClientDealEnvironment, deal rm.ClientDealState) func(*rm.ClientDealState) {
-	stream := environment.DealStream()
+func ProposeDeal(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
+	stream := environment.DealStream(deal.ID)
 	err := stream.WriteDealProposal(deal.DealProposal)
 	if err != nil {
-		return errorFunc(xerrors.Errorf("proposing deal: %w", err))
+		return ctx.Event(rm.ClientEventWriteDealProposalErrored, err)
 	}
 	response, err := stream.ReadDealResponse()
 	if err != nil {
-		return errorFunc(xerrors.Errorf("reading deal response: %w", err))
+		return ctx.Event(rm.ClientEventReadDealResponseErrored, err)
 	}
-	if response.Status == rm.DealStatusRejected {
-		return func(deal *rm.ClientDealState) {
-			deal.Status = rm.DealStatusRejected
-			deal.Message = fmt.Sprintf("deal rejected: %s", response.Message)
-		}
+	switch response.Status {
+	case rm.DealStatusRejected:
+		return ctx.Event(rm.ClientEventDealRejected, response.Message)
+	case rm.DealStatusDealNotFound:
+		return ctx.Event(rm.ClientEventDealNotFound, response.Message)
+	case rm.DealStatusAccepted:
+		return ctx.Event(rm.ClientEventDealAccepted)
+	default:
+		return ctx.Event(rm.ClientEventUnknownResponseReceived)
 	}
-	if response.Status == rm.DealStatusDealNotFound {
-		return func(deal *rm.ClientDealState) {
-			deal.Status = rm.DealStatusDealNotFound
-			deal.Message = fmt.Sprintf("deal not found: %s", response.Message)
-		}
-	}
-	if response.Status == rm.DealStatusAccepted {
-		return func(deal *rm.ClientDealState) {
-			deal.Status = rm.DealStatusAccepted
-		}
-	}
-	return errorFunc(xerrors.New("Unexpected deal response status"))
 }
 
 // ProcessPaymentRequested processes a request for payment from the provider
-func ProcessPaymentRequested(ctx context.Context, environment ClientDealEnvironment, deal rm.ClientDealState) func(*rm.ClientDealState) {
+func ProcessPaymentRequested(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
 
 	// check that fundsSpent + paymentRequested <= totalFunds, or fail
 	if big.Add(deal.FundsSpent, deal.PaymentRequested).GreaterThan(deal.TotalFunds) {
 		expectedTotal := deal.TotalFunds.String()
 		actualTotal := big.Add(deal.FundsSpent, deal.PaymentRequested).String()
-		errMsg := fmt.Sprintf("not enough funds left: expected amt = %s, actual amt = %s", expectedTotal, actualTotal)
-		return errorFunc(xerrors.New(errMsg))
+		return ctx.Event(rm.ClientEventFundsExpended, expectedTotal, actualTotal)
 	}
 
 	// check that totalReceived - bytesPaidFor >= currentInterval, or fail
 	if (deal.TotalReceived-deal.BytesPaidFor < deal.CurrentInterval) && deal.Status != rm.DealStatusFundsNeededLastPayment {
-		return errorFunc(xerrors.New("not enough bytes received between payment request"))
+		return ctx.Event(rm.ClientEventBadPaymentRequested, "not enough bytes received between payment request")
 	}
 
 	// check that paymentRequest <= (totalReceived - bytesPaidFor) * pricePerByte, or fail
 	if deal.PaymentRequested.GreaterThan(big.Mul(abi.NewTokenAmount(int64(deal.TotalReceived-deal.BytesPaidFor)), deal.PricePerByte)) {
-		return errorFunc(xerrors.New("too much money requested for bytes sent"))
+		return ctx.Event(rm.ClientEventBadPaymentRequested, "too much money requested for bytes sent")
 	}
+
 	// create payment voucher with node (or fail) for (fundsSpent + paymentRequested)
 	// use correct payCh + lane
 	// (node will do subtraction back to paymentRequested... slightly odd behavior but... well anyway)
-	voucher, err := environment.Node().CreatePaymentVoucher(ctx, deal.PayCh, big.Add(deal.FundsSpent, deal.PaymentRequested), deal.Lane)
+	voucher, err := environment.Node().CreatePaymentVoucher(ctx.Context(), deal.PaymentInfo.PayCh, big.Add(deal.FundsSpent, deal.PaymentRequested), deal.PaymentInfo.Lane)
 	if err != nil {
-		return errorFunc(xerrors.Errorf("creating payment voucher: %w", err))
+		return ctx.Event(rm.ClientEventCreateVoucherFailed, err)
 	}
 
 	// send payment voucher (or fail)
-	err = environment.DealStream().WriteDealPayment(rm.DealPayment{
+	err = environment.DealStream(deal.ID).WriteDealPayment(rm.DealPayment{
 		ID:             deal.DealProposal.ID,
-		PaymentChannel: deal.PayCh,
+		PaymentChannel: deal.PaymentInfo.PayCh,
 		PaymentVoucher: voucher,
 	})
 	if err != nil {
-		return errorFunc(xerrors.Errorf("writing deal payment: %w", err))
+		return ctx.Event(rm.ClientEventWriteDealPaymentErrored, err)
 	}
 
-	// return modify deal function --
-	// status = DealStatusOngoing
-	// paymentRequested = 0
-	// fundsSpent = fundsSpent + paymentRequested
-	// if paymentRequested / pricePerByte >= currentInterval
-	// currentInterval = currentInterval + proposal.intervalIncrease
-	// bytesPaidFor = bytesPaidFor + (paymentRequested / pricePerByte)
-
-	return func(deal *rm.ClientDealState) {
-		if deal.Status == rm.DealStatusFundsNeededLastPayment {
-			deal.Status = rm.DealStatusCompleted
-		} else {
-			deal.Status = rm.DealStatusOngoing
-		}
-		deal.FundsSpent = big.Add(deal.FundsSpent, deal.PaymentRequested)
-		bytesPaidFor := big.Div(deal.PaymentRequested, deal.PricePerByte).Uint64()
-		if bytesPaidFor >= deal.CurrentInterval {
-			deal.CurrentInterval += deal.DealProposal.PaymentIntervalIncrease
-		}
-		deal.BytesPaidFor += bytesPaidFor
-		deal.PaymentRequested = abi.NewTokenAmount(0)
-	}
+	return ctx.Event(rm.ClientEventPaymentSent)
 }
 
 // ProcessNextResponse reads and processes the next response from the provider
-func ProcessNextResponse(ctx context.Context, environment ClientDealEnvironment, deal rm.ClientDealState) func(*rm.ClientDealState) {
+func ProcessNextResponse(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
 	// Read next response (or fail)
-	response, err := environment.DealStream().ReadDealResponse()
+	response, err := environment.DealStream(deal.ID).ReadDealResponse()
 	if err != nil {
-		return errorFunc(xerrors.Errorf("reading deal response: %w", err))
+		return ctx.Event(rm.ClientEventReadDealResponseErrored, err)
 	}
 
 	// Process Blocks
 	totalProcessed := uint64(0)
-	completed := false
+	completed := deal.Status == rm.DealStatusBlocksComplete
 	for _, block := range response.Blocks {
-		processed, done, err := environment.ConsumeBlock(ctx, block)
+		processed, done, err := environment.ConsumeBlock(ctx.Context(), deal.ID, block)
 		if err != nil {
-			return errorFunc(xerrors.Errorf("consuming block: %w", err))
+			return ctx.Event(rm.ClientEventConsumeBlockFailed, err)
 		}
 		totalProcessed += processed
 		if done {
@@ -163,43 +128,42 @@ func ProcessNextResponse(ctx context.Context, environment ClientDealEnvironment,
 		}
 	}
 
-	// Check For Complete, set completeness
 	if completed {
-		if response.Status == rm.DealStatusFundsNeededLastPayment {
-			return func(deal *rm.ClientDealState) {
-				deal.TotalReceived += totalProcessed
-				deal.PaymentRequested = response.PaymentOwed
-				deal.Status = rm.DealStatusFundsNeededLastPayment
-			}
-		}
-		return func(deal *rm.ClientDealState) {
-			deal.TotalReceived += totalProcessed
-			deal.Status = rm.DealStatusCompleted
+		switch response.Status {
+		case rm.DealStatusFundsNeededLastPayment:
+			return ctx.Event(rm.ClientEventLastPaymentRequested, totalProcessed, response.PaymentOwed)
+		case rm.DealStatusBlocksComplete:
+			return ctx.Event(rm.ClientEventAllBlocksReceived, totalProcessed)
+		case rm.DealStatusCompleted:
+			return ctx.Event(rm.ClientEventComplete, totalProcessed)
+		default:
+			return ctx.Event(rm.ClientEventUnknownResponseReceived)
 		}
 	}
-
+	switch response.Status {
 	// Error on complete status, but not all blocks received
-	if response.Status == rm.DealStatusFundsNeededLastPayment ||
-		response.Status == rm.DealStatusCompleted {
-		return errorFunc(xerrors.New("received complete status before all blocks received"))
+	case rm.DealStatusFundsNeededLastPayment, rm.DealStatusCompleted:
+		return ctx.Event(rm.ClientEventEarlyTermination)
+	case rm.DealStatusFundsNeeded:
+		return ctx.Event(rm.ClientEventPaymentRequested, totalProcessed, response.PaymentOwed)
+	case rm.DealStatusOngoing:
+		return ctx.Event(rm.ClientEventBlocksReceived, totalProcessed)
+	default:
+		return ctx.Event(rm.ClientEventUnknownResponseReceived)
 	}
-	// Set PaymentRequested for funds needed statuses
-	if response.Status == rm.DealStatusFundsNeeded {
-		return func(deal *rm.ClientDealState) {
-			deal.TotalReceived += totalProcessed
-			deal.PaymentRequested = response.PaymentOwed
-			deal.Status = rm.DealStatusFundsNeeded
-		}
+}
+
+// Finalize completes a deal
+func Finalize(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
+	// Read next response (or fail)
+	response, err := environment.DealStream(deal.ID).ReadDealResponse()
+	if err != nil {
+		return ctx.Event(rm.ClientEventReadDealResponseErrored, err)
 	}
 
-	// Pass Through Statuses -- retrievalmarket.DealStatusOngoing, retrievalmarket.DealStatusUnsealing
-	if response.Status == rm.DealStatusOngoing || response.Status == rm.DealStatusUnsealing {
-		return func(deal *rm.ClientDealState) {
-			deal.TotalReceived += totalProcessed
-			deal.Status = response.Status
-		}
+	if response.Status != rm.DealStatusCompleted {
+		return ctx.Event(rm.ClientEventUnknownResponseReceived)
 	}
 
-	// Error On All Other Statuses
-	return errorFunc(xerrors.New("Unexpected deal response status"))
+	return ctx.Event(rm.ClientEventComplete, uint64(0))
 }

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -105,15 +105,17 @@ func ProcessNextResponse(ctx fsm.Context, environment ClientDealEnvironment, dea
 	// Process Blocks
 	totalProcessed := uint64(0)
 	completed := deal.Status == rm.DealStatusBlocksComplete
-	for _, block := range response.Blocks {
-		processed, done, err := environment.ConsumeBlock(ctx.Context(), deal.ID, block)
-		if err != nil {
-			return ctx.Trigger(rm.ClientEventConsumeBlockFailed, err)
-		}
-		totalProcessed += processed
-		if done {
-			completed = true
-			break
+	if !completed {
+		var processed uint64
+		for _, block := range response.Blocks {
+			processed, completed, err = environment.ConsumeBlock(ctx.Context(), deal.ID, block)
+			if err != nil {
+				return ctx.Trigger(rm.ClientEventConsumeBlockFailed, err)
+			}
+			totalProcessed += processed
+			if completed {
+				break
+			}
 		}
 	}
 

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -73,12 +73,12 @@ func NewProvider(paymentAddress address.Address, node retrievalmarket.RetrievalP
 		blockReaders:            make(map[retrievalmarket.ProviderDealIdentifier]blockio.BlockReader),
 	}
 	statemachines, err := fsm.New(namespace.Wrap(ds, datastore.NewKey(ProviderDsPrefix)), fsm.Parameters{
-		Environment:   p,
-		StateType:     retrievalmarket.ProviderDealState{},
-		StateKeyField: "Status",
-		Events:        providerstates.ProviderEvents,
-		StateHandlers: providerstates.ProviderHandlers,
-		Notifier:      p.notifySubscribers,
+		Environment:     p,
+		StateType:       retrievalmarket.ProviderDealState{},
+		StateKeyField:   "Status",
+		Events:          providerstates.ProviderEvents,
+		StateEntryFuncs: providerstates.ProviderStateEntryFuncs,
+		Notifier:        p.notifySubscribers,
 	})
 	p.stateMachines = statemachines
 	if err != nil {

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -59,9 +59,11 @@ func TestHandleQueryStream(t *testing.T) {
 
 	receiveStreamOnProvider := func(qs network.RetrievalQueryStream, pieceStore piecestore.PieceStore) {
 		node := testnodes.NewTestRetrievalProviderNode()
-		bs := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+		ds := dss.MutexWrap(datastore.NewMapDatastore())
+		bs := bstore.NewBlockstore(ds)
 		net := tut.NewTestRetrievalMarketNetwork(tut.TestNetworkParams{})
-		c := retrievalimpl.NewProvider(expectedAddress, node, net, pieceStore, bs)
+		c, err := retrievalimpl.NewProvider(expectedAddress, node, net, pieceStore, bs, ds)
+		require.NoError(t, err)
 		c.SetPricePerByte(expectedPricePerByte)
 		c.SetPaymentInterval(expectedPaymentInterval, expectedPaymentIntervalIncrease)
 		_ = c.Start()

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -1,6 +1,8 @@
 package providerstates
 
 import (
+	"fmt"
+
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
@@ -61,6 +63,7 @@ var ProviderEvents = fsm.Events{
 		FromMany(rm.DealStatusAccepted, rm.DealStatusOngoing).To(rm.DealStatusFundsNeeded).
 		From(rm.DealStatusBlocksComplete).To(rm.DealStatusFundsNeededLastPayment).
 		Action(func(deal *rm.ProviderDealState, totalSent uint64) error {
+			fmt.Println("Requesting payment")
 			deal.TotalSent = totalSent
 			return nil
 		}),

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -1,0 +1,99 @@
+package providerstates
+
+import (
+	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-statemachine/fsm"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"golang.org/x/xerrors"
+)
+
+func recordError(deal *rm.ProviderDealState, err error) error {
+	deal.Message = err.Error()
+	return nil
+}
+
+// ProviderEvents are the events that can happen in a retrieval provider
+var ProviderEvents = fsm.Events{
+	fsm.Event(rm.ProviderEventOpen).
+		From(rm.DealStatusNew).ToNoChange().
+		WithCallback(
+			func(deal *rm.ProviderDealState) error {
+				deal.TotalSent = 0
+				deal.FundsReceived = abi.NewTokenAmount(0)
+				return nil
+			},
+		),
+	fsm.Event(rm.ProviderEventWriteResponseFailed).
+		FromAny().To(rm.DealStatusErrored).
+		WithCallback(func(deal *rm.ProviderDealState, err error) error {
+			deal.Message = xerrors.Errorf("writing deal response: %w", err).Error()
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventReadPaymentFailed).
+		FromAny().To(rm.DealStatusErrored).
+		WithCallback(recordError),
+	fsm.Event(rm.ProviderEventGetPieceSizeErrored).
+		From(rm.DealStatusNew).To(rm.DealStatusFailed).
+		WithCallback(recordError),
+	fsm.Event(rm.ProviderEventDealNotFound).
+		From(rm.DealStatusNew).To(rm.DealStatusDealNotFound).
+		WithCallback(func(deal *rm.ProviderDealState) error {
+			deal.Message = rm.ErrNotFound.Error()
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventDealRejected).
+		From(rm.DealStatusNew).To(rm.DealStatusRejected).
+		WithCallback(recordError),
+	fsm.Event(rm.ProviderEventDealAccepted).
+		From(rm.DealStatusNew).To(rm.DealStatusAccepted).
+		WithCallback(func(deal *rm.ProviderDealState, dealProposal rm.DealProposal) error {
+			deal.DealProposal = dealProposal
+			deal.CurrentInterval = deal.PaymentInterval
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventBlockErrored).
+		FromMany(rm.DealStatusAccepted, rm.DealStatusOngoing).To(rm.DealStatusFailed).
+		WithCallback(recordError),
+	fsm.Event(rm.ProviderEventBlocksCompleted).
+		FromMany(rm.DealStatusAccepted, rm.DealStatusOngoing).To(rm.DealStatusBlocksComplete),
+	fsm.Event(rm.ProviderEventPaymentRequested).
+		FromMany(rm.DealStatusAccepted, rm.DealStatusOngoing).To(rm.DealStatusFundsNeeded).
+		From(rm.DealStatusBlocksComplete).To(rm.DealStatusFundsNeededLastPayment).
+		WithCallback(func(deal *rm.ProviderDealState, totalSent uint64) error {
+			deal.TotalSent = totalSent
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventSaveVoucherFailed).
+		FromMany(rm.DealStatusFundsNeeded, rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFailed).
+		WithCallback(recordError),
+	fsm.Event(rm.ProviderEventPartialPaymentReceived).
+		FromMany(rm.DealStatusFundsNeeded, rm.DealStatusFundsNeededLastPayment).ToNoChange().
+		WithCallback(func(deal *rm.ProviderDealState, fundsReceived abi.TokenAmount) error {
+			deal.FundsReceived = big.Add(deal.FundsReceived, fundsReceived)
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventPaymentReceived).
+		From(rm.DealStatusFundsNeeded).To(rm.DealStatusOngoing).
+		From(rm.DealStatusFundsNeededLastPayment).To(rm.DealStatusFinalizing).
+		WithCallback(func(deal *rm.ProviderDealState, fundsReceived abi.TokenAmount) error {
+			deal.FundsReceived = big.Add(deal.FundsReceived, fundsReceived)
+			deal.CurrentInterval += deal.PaymentIntervalIncrease
+			return nil
+		}),
+	fsm.Event(rm.ProviderEventComplete).
+		From(rm.DealStatusFinalizing).To(rm.DealStatusCompleted),
+}
+
+// ProviderHandlers are the handlers for different states in a retrieval provider
+var ProviderHandlers = fsm.StateHandlers{
+	rm.DealStatusNew:                    ReceiveDeal,
+	rm.DealStatusFailed:                 SendFailResponse,
+	rm.DealStatusRejected:               SendFailResponse,
+	rm.DealStatusDealNotFound:           SendFailResponse,
+	rm.DealStatusOngoing:                SendBlocks,
+	rm.DealStatusAccepted:               SendBlocks,
+	rm.DealStatusFundsNeeded:            ProcessPayment,
+	rm.DealStatusFundsNeededLastPayment: ProcessPayment,
+	rm.DealStatusFinalizing:             Finalize,
+}

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -8,6 +8,7 @@ import (
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 )
@@ -16,155 +17,144 @@ import (
 type ProviderDealEnvironment interface {
 	Node() rm.RetrievalProviderNode
 	GetPieceSize(c cid.Cid) (uint64, error)
-	DealStream() rmnet.RetrievalDealStream
-	NextBlock(context.Context) (rm.Block, bool, error)
+	DealStream(id rm.ProviderDealIdentifier) rmnet.RetrievalDealStream
+	NextBlock(context.Context, rm.ProviderDealIdentifier) (rm.Block, bool, error)
 	CheckDealParams(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64) error
-}
-
-func errorFunc(err error) func(*rm.ProviderDealState) {
-	return func(deal *rm.ProviderDealState) {
-		deal.Status = rm.DealStatusFailed
-		deal.Message = err.Error()
-	}
-}
-
-func responseFailure(stream rmnet.RetrievalDealStream, status rm.DealStatus, message string, id rm.DealID) func(*rm.ProviderDealState) {
-	err := stream.WriteDealResponse(rm.DealResponse{
-		Status:  status,
-		Message: message,
-		ID:      id,
-	})
-	if err != nil {
-		return errorFunc(xerrors.Errorf("writing deal response: %w", err))
-	}
-	return func(deal *rm.ProviderDealState) {
-		deal.Status = status
-		deal.Message = message
-	}
 }
 
 // ProviderHandlerFunc is a function that handles a provider deal being in a specific state
 // It processes the state and returns a modification function for a deal
-type ProviderHandlerFunc func(ctx context.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) func(*rm.ProviderDealState)
+type ProviderHandlerFunc func(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error
 
 // ReceiveDeal receives and evaluates a deal proposal
-func ReceiveDeal(ctx context.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) func(*rm.ProviderDealState) {
-	// read deal proposal (or fail)
-	dealProposal, err := environment.DealStream().ReadDealProposal()
-	if err != nil {
-		return errorFunc(xerrors.Errorf("reading deal proposal: %w", err))
-	}
+func ReceiveDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
+	dealProposal := deal.DealProposal
 
 	// verify we have the piece
-	_, err = environment.GetPieceSize(dealProposal.PayloadCID)
+	_, err := environment.GetPieceSize(dealProposal.PayloadCID)
 	if err != nil {
 		if err == rm.ErrNotFound {
-			return responseFailure(environment.DealStream(), rm.DealStatusDealNotFound, rm.ErrNotFound.Error(), dealProposal.ID)
+			return ctx.Event(rm.ProviderEventDealNotFound)
 		}
-		return responseFailure(environment.DealStream(), rm.DealStatusFailed, err.Error(), dealProposal.ID)
+		return ctx.Event(rm.ProviderEventGetPieceSizeErrored, err)
 	}
 
 	// check that the deal parameters match our required parameters (or reject)
 	err = environment.CheckDealParams(dealProposal.PricePerByte, dealProposal.PaymentInterval, dealProposal.PaymentIntervalIncrease)
 	if err != nil {
-		return responseFailure(environment.DealStream(), rm.DealStatusRejected, err.Error(), dealProposal.ID)
+		return ctx.Event(rm.ProviderEventDealRejected, err)
 	}
 
-	// accept the deal
-	err = environment.DealStream().WriteDealResponse(rm.DealResponse{
+	err = environment.DealStream(deal.Identifier()).WriteDealResponse(rm.DealResponse{
 		Status: rm.DealStatusAccepted,
-		ID:     dealProposal.ID,
+		ID:     deal.ID,
 	})
 	if err != nil {
-		return errorFunc(xerrors.Errorf("writing real response: %w", err))
+		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
 	}
 
-	// update that we are ready to start sending blocks
-	return func(deal *rm.ProviderDealState) {
-		deal.Status = rm.DealStatusAccepted
-		deal.CurrentInterval = dealProposal.PaymentInterval
-		deal.DealProposal = dealProposal
-	}
+	return ctx.Event(rm.ProviderEventDealAccepted, dealProposal)
+
 }
 
 // SendBlocks sends blocks to the client until funds are needed
-func SendBlocks(ctx context.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) func(*rm.ProviderDealState) {
+func SendBlocks(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
 	totalSent := deal.TotalSent
 	totalPaidFor := big.Div(deal.FundsReceived, deal.PricePerByte).Uint64()
-	returnStatus := rm.DealStatusFundsNeeded
 	var blocks []rm.Block
 
 	// read blocks until we reach current interval
+	responseStatus := rm.DealStatusFundsNeeded
 	for totalSent-totalPaidFor < deal.CurrentInterval {
-		block, done, err := environment.NextBlock(ctx)
+		block, done, err := environment.NextBlock(ctx.Context(), deal.Identifier())
 		if err != nil {
-			return responseFailure(environment.DealStream(), rm.DealStatusFailed, err.Error(), deal.ID)
+			return ctx.Event(rm.ProviderEventBlockErrored, err)
 		}
 		blocks = append(blocks, block)
 		totalSent += uint64(len(block.Data))
 		if done {
-			returnStatus = rm.DealStatusFundsNeededLastPayment
+			err := ctx.Event(rm.ProviderEventBlocksCompleted)
+			if err != nil {
+				return err
+			}
+			responseStatus = rm.DealStatusFundsNeededLastPayment
 			break
 		}
 	}
+
 	// send back response of blocks plus payment owed
 	paymentOwed := big.Mul(abi.NewTokenAmount(int64(totalSent-totalPaidFor)), deal.PricePerByte)
-	err := environment.DealStream().WriteDealResponse(rm.DealResponse{
+
+	err := environment.DealStream(deal.Identifier()).WriteDealResponse(rm.DealResponse{
 		ID:          deal.ID,
-		Status:      returnStatus,
+		Status:      responseStatus,
 		PaymentOwed: paymentOwed,
 		Blocks:      blocks,
 	})
+
 	if err != nil {
-		return errorFunc(xerrors.Errorf("writing deal response: %w", err))
+		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
 	}
 
-	// set status to awaiting funds and update amount sent
-	return func(deal *rm.ProviderDealState) {
-		deal.Status = returnStatus
-		deal.TotalSent = totalSent
-	}
+	return ctx.Event(rm.ProviderEventPaymentRequested, totalSent)
 }
 
 // ProcessPayment processes a payment from the client and resumes the deal if successful
-func ProcessPayment(ctx context.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) func(*rm.ProviderDealState) {
+func ProcessPayment(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
 	// read payment, or fail
-	payment, err := environment.DealStream().ReadDealPayment()
+	payment, err := environment.DealStream(deal.Identifier()).ReadDealPayment()
 	if err != nil {
-		return errorFunc(xerrors.Errorf("reading payment: %w", err))
+		return ctx.Event(rm.ProviderEventReadPaymentFailed, xerrors.Errorf("reading payment: %w", err))
 	}
 
 	// attempt to redeem voucher
 	// (totalSent * pricePerbyte) - fundsReceived
 	paymentOwed := big.Sub(big.Mul(abi.NewTokenAmount(int64(deal.TotalSent)), deal.PricePerByte), deal.FundsReceived)
-	received, err := environment.Node().SavePaymentVoucher(ctx, payment.PaymentChannel, payment.PaymentVoucher, nil, paymentOwed)
+	received, err := environment.Node().SavePaymentVoucher(ctx.Context(), payment.PaymentChannel, payment.PaymentVoucher, nil, paymentOwed)
 	if err != nil {
-		return responseFailure(environment.DealStream(), rm.DealStatusFailed, err.Error(), deal.ID)
+		return ctx.Event(rm.ProviderEventSaveVoucherFailed, err)
 	}
 
 	// check if all payments are received to continue the deal, or send updated required payment
 	if received.LessThan(paymentOwed) {
-		err := environment.DealStream().WriteDealResponse(rm.DealResponse{
+		err := environment.DealStream(deal.Identifier()).WriteDealResponse(rm.DealResponse{
 			ID:          deal.ID,
 			Status:      deal.Status,
 			PaymentOwed: big.Sub(paymentOwed, received),
 		})
 		if err != nil {
-			return errorFunc(xerrors.Errorf("writing deal response", err))
+			return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
 		}
-		return func(deal *rm.ProviderDealState) {
-			deal.FundsReceived = big.Add(deal.FundsReceived, received)
-		}
+		return ctx.Event(rm.ProviderEventPartialPaymentReceived, received)
 	}
 
 	// resume deal
-	return func(deal *rm.ProviderDealState) {
-		if deal.Status == rm.DealStatusFundsNeededLastPayment {
-			deal.Status = rm.DealStatusCompleted
-		} else {
-			deal.Status = rm.DealStatusOngoing
-		}
-		deal.FundsReceived = big.Add(deal.FundsReceived, received)
-		deal.CurrentInterval += deal.PaymentIntervalIncrease
+	return ctx.Event(rm.ProviderEventPaymentReceived, received)
+}
+
+// SendFailResponse sends a failure response before closing the deal
+func SendFailResponse(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
+	stream := environment.DealStream(deal.Identifier())
+	err := stream.WriteDealResponse(rm.DealResponse{
+		Status:  deal.Status,
+		Message: deal.Message,
+		ID:      deal.ID,
+	})
+	if err != nil {
+		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
 	}
+	return nil
+}
+
+// Finalize completes a deal
+func Finalize(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
+	err := environment.DealStream(deal.Identifier()).WriteDealResponse(rm.DealResponse{
+		Status: rm.DealStatusCompleted,
+		ID:     deal.ID,
+	})
+	if err != nil {
+		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+	}
+
+	return ctx.Event(rm.ProviderEventComplete)
 }

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -22,10 +22,6 @@ type ProviderDealEnvironment interface {
 	CheckDealParams(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64) error
 }
 
-// ProviderHandlerFunc is a function that handles a provider deal being in a specific state
-// It processes the state and returns a modification function for a deal
-type ProviderHandlerFunc func(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error
-
 // ReceiveDeal receives and evaluates a deal proposal
 func ReceiveDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
 	dealProposal := deal.DealProposal
@@ -34,15 +30,15 @@ func ReceiveDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.P
 	_, err := environment.GetPieceSize(dealProposal.PayloadCID)
 	if err != nil {
 		if err == rm.ErrNotFound {
-			return ctx.Event(rm.ProviderEventDealNotFound)
+			return ctx.Trigger(rm.ProviderEventDealNotFound)
 		}
-		return ctx.Event(rm.ProviderEventGetPieceSizeErrored, err)
+		return ctx.Trigger(rm.ProviderEventGetPieceSizeErrored, err)
 	}
 
 	// check that the deal parameters match our required parameters (or reject)
 	err = environment.CheckDealParams(dealProposal.PricePerByte, dealProposal.PaymentInterval, dealProposal.PaymentIntervalIncrease)
 	if err != nil {
-		return ctx.Event(rm.ProviderEventDealRejected, err)
+		return ctx.Trigger(rm.ProviderEventDealRejected, err)
 	}
 
 	err = environment.DealStream(deal.Identifier()).WriteDealResponse(rm.DealResponse{
@@ -50,10 +46,10 @@ func ReceiveDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.P
 		ID:     deal.ID,
 	})
 	if err != nil {
-		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+		return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 	}
 
-	return ctx.Event(rm.ProviderEventDealAccepted, dealProposal)
+	return ctx.Trigger(rm.ProviderEventDealAccepted, dealProposal)
 
 }
 
@@ -68,12 +64,12 @@ func SendBlocks(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.Pr
 	for totalSent-totalPaidFor < deal.CurrentInterval {
 		block, done, err := environment.NextBlock(ctx.Context(), deal.Identifier())
 		if err != nil {
-			return ctx.Event(rm.ProviderEventBlockErrored, err)
+			return ctx.Trigger(rm.ProviderEventBlockErrored, err)
 		}
 		blocks = append(blocks, block)
 		totalSent += uint64(len(block.Data))
 		if done {
-			err := ctx.Event(rm.ProviderEventBlocksCompleted)
+			err := ctx.Trigger(rm.ProviderEventBlocksCompleted)
 			if err != nil {
 				return err
 			}
@@ -93,10 +89,10 @@ func SendBlocks(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.Pr
 	})
 
 	if err != nil {
-		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+		return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 	}
 
-	return ctx.Event(rm.ProviderEventPaymentRequested, totalSent)
+	return ctx.Trigger(rm.ProviderEventPaymentRequested, totalSent)
 }
 
 // ProcessPayment processes a payment from the client and resumes the deal if successful
@@ -104,7 +100,7 @@ func ProcessPayment(ctx fsm.Context, environment ProviderDealEnvironment, deal r
 	// read payment, or fail
 	payment, err := environment.DealStream(deal.Identifier()).ReadDealPayment()
 	if err != nil {
-		return ctx.Event(rm.ProviderEventReadPaymentFailed, xerrors.Errorf("reading payment: %w", err))
+		return ctx.Trigger(rm.ProviderEventReadPaymentFailed, xerrors.Errorf("reading payment: %w", err))
 	}
 
 	// attempt to redeem voucher
@@ -112,7 +108,7 @@ func ProcessPayment(ctx fsm.Context, environment ProviderDealEnvironment, deal r
 	paymentOwed := big.Sub(big.Mul(abi.NewTokenAmount(int64(deal.TotalSent)), deal.PricePerByte), deal.FundsReceived)
 	received, err := environment.Node().SavePaymentVoucher(ctx.Context(), payment.PaymentChannel, payment.PaymentVoucher, nil, paymentOwed)
 	if err != nil {
-		return ctx.Event(rm.ProviderEventSaveVoucherFailed, err)
+		return ctx.Trigger(rm.ProviderEventSaveVoucherFailed, err)
 	}
 
 	// check if all payments are received to continue the deal, or send updated required payment
@@ -123,13 +119,13 @@ func ProcessPayment(ctx fsm.Context, environment ProviderDealEnvironment, deal r
 			PaymentOwed: big.Sub(paymentOwed, received),
 		})
 		if err != nil {
-			return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+			return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 		}
-		return ctx.Event(rm.ProviderEventPartialPaymentReceived, received)
+		return ctx.Trigger(rm.ProviderEventPartialPaymentReceived, received)
 	}
 
 	// resume deal
-	return ctx.Event(rm.ProviderEventPaymentReceived, received)
+	return ctx.Trigger(rm.ProviderEventPaymentReceived, received)
 }
 
 // SendFailResponse sends a failure response before closing the deal
@@ -141,7 +137,7 @@ func SendFailResponse(ctx fsm.Context, environment ProviderDealEnvironment, deal
 		ID:      deal.ID,
 	})
 	if err != nil {
-		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+		return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 	}
 	return nil
 }
@@ -153,8 +149,8 @@ func Finalize(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.Prov
 		ID:     deal.ID,
 	})
 	if err != nil {
-		return ctx.Event(rm.ProviderEventWriteResponseFailed, err)
+		return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 	}
 
-	return ctx.Event(rm.ProviderEventComplete)
+	return ctx.Trigger(rm.ProviderEventComplete)
 }

--- a/retrievalmarket/network/deal_stream.go
+++ b/retrievalmarket/network/deal_stream.go
@@ -58,6 +58,10 @@ func (d *DealStream) WriteDealPayment(dpy retrievalmarket.DealPayment) error {
 	return cborutil.WriteCborRPC(d.rw, &dpy)
 }
 
+func (d *DealStream) Receiver() peer.ID {
+	return d.p
+}
+
 func (d *DealStream) Close() error {
 	return d.rw.Close()
 }

--- a/retrievalmarket/network/network.go
+++ b/retrievalmarket/network/network.go
@@ -21,6 +21,7 @@ type RetrievalDealStream interface {
 	WriteDealResponse(retrievalmarket.DealResponse) error
 	ReadDealPayment() (retrievalmarket.DealPayment, error)
 	WriteDealPayment(retrievalmarket.DealPayment) error
+	Receiver() peer.ID
 	Close() error
 }
 

--- a/shared_testutil/mocknet.go
+++ b/shared_testutil/mocknet.go
@@ -39,6 +39,8 @@ import (
 
 type Libp2pTestData struct {
 	Ctx         context.Context
+	Ds1         datastore.Batching
+	Ds2         datastore.Batching
 	Bs1         bstore.Blockstore
 	Bs2         bstore.Blockstore
 	DagService1 ipldformat.DAGService
@@ -92,9 +94,11 @@ func NewLibp2pTestData(ctx context.Context, t *testing.T) *Libp2pTestData {
 			return &buf, committer, nil
 		}
 	}
+	testData.Ds1 = dss.MutexWrap(datastore.NewMapDatastore())
+	testData.Ds2 = dss.MutexWrap(datastore.NewMapDatastore())
 	// make a bstore and dag service
-	testData.Bs1 = bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
-	testData.Bs2 = bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
+	testData.Bs1 = bstore.NewBlockstore(testData.Ds1)
+	testData.Bs2 = bstore.NewBlockstore(testData.Ds2)
 
 	testData.DagService1 = merkledag.NewDAGService(blockservice.New(testData.Bs1, offline.Exchange(testData.Bs1)))
 	testData.DagService2 = merkledag.NewDAGService(blockservice.New(testData.Bs2, offline.Exchange(testData.Bs2)))

--- a/shared_testutil/test_network_types.go
+++ b/shared_testutil/test_network_types.go
@@ -196,6 +196,9 @@ func (trds *TestRetrievalDealStream) WriteDealPayment(dealPayment rm.DealPayment
 	return trds.paymentWriter(dealPayment)
 }
 
+// Receiver returns the other peer
+func (trds TestRetrievalDealStream) Receiver() peer.ID { return trds.p }
+
 // Close closes the stream (does nothing for mocked stream)
 func (trds TestRetrievalDealStream) Close() error { return nil }
 


### PR DESCRIPTION
# Goals

- persist retrieval deals on both client and provider
- remove common logic around transitioning states to make code more readable
- make it simply to decouple steps in retrieval market to enable easier resuming of state (not in this PR but coming soon)

# Implementation

- Use go-statemachine and the FSM module defined in this PR https://github.com/filecoin-project/go-statemachine/pull/4
- Define the state machine's event logic in a single place, separate from the state handlers -- see `provider_fsm.go` & `client_fsm.go`
- Simplify state handlers that no longer have to modify state but just dispatch events
- Update provider & client to construct statemachines from a data store so they are saved on disk
- Dispatch several new more informative events for different things that can happen in a retrieval deal
- Add one new extra step to the retrieval deal process -- make sure that once the last payment is sent, the provider receives and processes it (this felt missing from the deal flow)
- Support seperating payment responses from block responses (not implemented here, but feels important on the way to retrieval deal flow v1 w/ graphsync)

# For discussion

- still need tests for Finalize on client and provider
- think ProviderDealIdentifier should be renamed ProviderDealID probably
- need to complete persisting nextDealID or this becomes mostly non-functional :) but didn't want to add to already large PR