### PR TITLE
Persist retrieval market counter to disk

### DIFF
--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -76,7 +76,7 @@ func requireSetupTestClientAndProvider(bgCtx context.Context, t *testing.T, payC
 	testData := tut.NewLibp2pTestData(bgCtx, t)
 	nw1 := rmnet.NewFromLibp2pHost(testData.Host1)
 	rcNode1 := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{PayCh: payChAddr})
-	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, rcNode1, &testPeerResolver{}, testData.Ds1)
+	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, rcNode1, &testPeerResolver{}, testData.Ds1, testData.StoredCounter1)
 	require.NoError(t, err)
 	nw2 := rmnet.NewFromLibp2pHost(testData.Host2)
 	providerNode := testnodes.NewTestRetrievalProviderNode()
@@ -293,7 +293,7 @@ CurrentInterval: %d
 
 			// *** Retrieve the piece
 			did, err := client.Retrieve(bgCtx, payloadCID, rmParams, expectedTotal, retrievalPeer.ID, clientPaymentChannel, retrievalPeer.Address)
-			assert.Equal(t, did, retrievalmarket.DealID(1))
+			assert.Equal(t, did, retrievalmarket.DealID(0))
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
@@ -365,7 +365,7 @@ func setupClient(
 		AllocateLaneRecorder:   laneRecorder,
 		PaymentVoucherRecorder: paymentVoucherRecorder,
 	})
-	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, clientNode, &testPeerResolver{}, testData.Ds1)
+	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, clientNode, &testPeerResolver{}, testData.Ds1, testData.StoredCounter1)
 	return &createdChan, &newLaneAddr, &createdVoucher, client, err
 }
 

--- a/shared_testutil/mocknet.go
+++ b/shared_testutil/mocknet.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/filecoin-project/go-fil-markets/storedcounter"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-blockservice"
 	"github.com/ipfs/go-datastore"
@@ -38,25 +39,27 @@ import (
 )
 
 type Libp2pTestData struct {
-	Ctx         context.Context
-	Ds1         datastore.Batching
-	Ds2         datastore.Batching
-	Bs1         bstore.Blockstore
-	Bs2         bstore.Blockstore
-	DagService1 ipldformat.DAGService
-	DagService2 ipldformat.DAGService
-	GraphSync1  graphsync.GraphExchange
-	GraphSync2  graphsync.GraphExchange
-	Loader1     ipld.Loader
-	Loader2     ipld.Loader
-	Storer1     ipld.Storer
-	Storer2     ipld.Storer
-	Host1       host.Host
-	Host2       host.Host
-	Bridge1     ipldbridge.IPLDBridge
-	Bridge2     ipldbridge.IPLDBridge
-	AllSelector ipld.Node
-	OrigBytes   []byte
+	Ctx            context.Context
+	Ds1            datastore.Batching
+	Ds2            datastore.Batching
+	StoredCounter1 *storedcounter.StoredCounter
+	StoredCounter2 *storedcounter.StoredCounter
+	Bs1            bstore.Blockstore
+	Bs2            bstore.Blockstore
+	DagService1    ipldformat.DAGService
+	DagService2    ipldformat.DAGService
+	GraphSync1     graphsync.GraphExchange
+	GraphSync2     graphsync.GraphExchange
+	Loader1        ipld.Loader
+	Loader2        ipld.Loader
+	Storer1        ipld.Storer
+	Storer2        ipld.Storer
+	Host1          host.Host
+	Host2          host.Host
+	Bridge1        ipldbridge.IPLDBridge
+	Bridge2        ipldbridge.IPLDBridge
+	AllSelector    ipld.Node
+	OrigBytes      []byte
 }
 
 func NewLibp2pTestData(ctx context.Context, t *testing.T) *Libp2pTestData {
@@ -96,6 +99,10 @@ func NewLibp2pTestData(ctx context.Context, t *testing.T) *Libp2pTestData {
 	}
 	testData.Ds1 = dss.MutexWrap(datastore.NewMapDatastore())
 	testData.Ds2 = dss.MutexWrap(datastore.NewMapDatastore())
+
+	testData.StoredCounter1 = storedcounter.New(testData.Ds1, datastore.NewKey("nextDealID"))
+	testData.StoredCounter2 = storedcounter.New(testData.Ds2, datastore.NewKey("nextDealID"))
+
 	// make a bstore and dag service
 	testData.Bs1 = bstore.NewBlockstore(testData.Ds1)
 	testData.Bs2 = bstore.NewBlockstore(testData.Ds2)

--- a/storedcounter/storedcounter.go
+++ b/storedcounter/storedcounter.go
@@ -1,0 +1,41 @@
+package storedcounter
+
+import (
+	"encoding/binary"
+
+	"github.com/ipfs/go-datastore"
+)
+
+// StoredCounter is a counter that persists to a datastore as it increments
+type StoredCounter struct {
+	ds   datastore.Datastore
+	name datastore.Key
+}
+
+// New returns a new StoredCounter for the given datastore and key
+func New(ds datastore.Datastore, name datastore.Key) *StoredCounter {
+	return &StoredCounter{ds, name}
+}
+
+// Next returns the next counter value, updating it on disk in the process
+// if no counter is present, it creates one and returns a 0 value
+func (sc *StoredCounter) Next() (uint64, error) {
+	has, err := sc.ds.Has(sc.name)
+	if err != nil {
+		return 0, err
+	}
+
+	var next uint64 = 0
+	if has {
+		curBytes, err := sc.ds.Get(sc.name)
+		if err != nil {
+			return 0, err
+		}
+		cur, _ := binary.Uvarint(curBytes)
+		next = cur + 1
+	}
+	buf := make([]byte, binary.MaxVarintLen64)
+	size := binary.PutUvarint(buf, next)
+
+	return next, sc.ds.Put(sc.name, buf[:size])
+}

--- a/storedcounter/storedcounter_test.go
+++ b/storedcounter/storedcounter_test.go
@@ -1,0 +1,61 @@
+package storedcounter_test
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-fil-markets/storedcounter"
+)
+
+
+func TestStoredCounter(t * testing.T) {
+	ds := datastore.NewMapDatastore()
+
+	t.Run("test two instances with same data store and key count together", func(t *testing.T) {
+		key := datastore.NewKey("counter")
+		sc1 := storedcounter.New(ds, key)
+		next, err := sc1.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(0))
+
+		sc2 := storedcounter.New(ds, key)
+		next, err = sc2.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(1))
+
+		next, err = sc1.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(2))
+
+		next, err = sc2.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(3))
+	})
+
+
+	t.Run("test two instances with same data store but different keys count seperate", func(t *testing.T) {
+		
+		key1 := datastore.NewKey("counter 1")
+		key2 := datastore.NewKey("counter 2")
+
+		sc1 := storedcounter.New(ds, key1)
+		next, err := sc1.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(0))
+
+		sc2 := storedcounter.New(ds, key2)
+		next, err = sc2.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(0))
+
+		next, err = sc1.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(1))
+
+		next, err = sc2.Next()
+		require.NoError(t, err)
+		require.Equal(t, next, uint64(1))
+	})
+}


### PR DESCRIPTION
# Goals

Make retrieval deal id incrementing survive restarts so they can serve as unique deal ids for a single retrieval client (fix #66 )

# Implementation

- Create a simple stored counter interface that saves an incrementing counter on top of a data store
- Use it in retrieval market

# For Discussion

- The integration test recreates all the test data on each retrieval and therefore does not test the counter -- should it?
- This should go in after #124 cause it's on top of it (I currently set that branch as the base)