### PR TITLE
One line change: do not initialize test SignedVoucher with Timelock field

### DIFF
--- a/shared_testutil/test_types.go
+++ b/shared_testutil/test_types.go
@@ -22,7 +22,6 @@ import (
 // MakeTestSignedVoucher generates a random SignedVoucher that has all non-zero fields
 func MakeTestSignedVoucher() *paych.SignedVoucher {
 	return &paych.SignedVoucher{
-		TimeLock:       abi.ChainEpoch(rand.Int63()),
 		SecretPreimage: []byte("secret-preimage"),
 		Extra:          MakeTestModVerifyParams(),
 		Lane:           rand.Uint64(),


### PR DESCRIPTION
In the latest specs-actors, which go-filecoin is using, `paych.SignedVoucher` does not have a `Timelock` field. This was causing tests in my go-filecoin branch to fail. Since we don't use the field in testing anyway in go-fil-markets, I have deleted the line that uses it in `MakeTestSignedVoucher`, which also removes the need to use another version of specs-actors in stable.