### PR TITLE
allow specification of 'wallet' for ensure funds calls

### DIFF
--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -84,7 +84,7 @@ func NewClient(
 func (c *client) FindProviders(payloadCID cid.Cid) []retrievalmarket.RetrievalPeer {
 	peers, err := c.resolver.GetPeers(payloadCID)
 	if err != nil {
-		log.Error(err)
+		log.Errorf("failed to get peers: %s", err)
 		return []retrievalmarket.RetrievalPeer{}
 	}
 	return peers

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -50,7 +50,7 @@ func TestClientCanMakeQueryToProvider(t *testing.T) {
 	t.Run("when there is some other error, returns error", func(t *testing.T) {
 		unknownPiece := tut.GenerateCids(1)[0]
 		expectedQR.Status = retrievalmarket.QueryResponseError
-		expectedQR.Message = "GetCIDInfo failed"
+		expectedQR.Message = "get cid info: GetCIDInfo failed"
 		actualQR, err := client.Query(bgCtx, retrievalPeer, unknownPiece, retrievalmarket.QueryParams{})
 		assert.NoError(t, err)
 		assert.Equal(t, expectedQR, actualQR)

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
@@ -274,7 +275,7 @@ func (p *provider) GetPieceSize(c cid.Cid) (uint64, error) {
 func getPieceInfoFromCid(pieceStore piecestore.PieceStore, c cid.Cid) (piecestore.PieceInfo, error) {
 	cidInfo, err := pieceStore.GetCIDInfo(c)
 	if err != nil {
-		return piecestore.PieceInfoUndefined, err
+		return piecestore.PieceInfoUndefined, xerrors.Errorf("get cid info: %w", err)
 	}
 	var lastErr error
 	for _, pieceBlockLocation := range cidInfo.PieceBlockLocations {
@@ -284,5 +285,5 @@ func getPieceInfoFromCid(pieceStore piecestore.PieceStore, c cid.Cid) (piecestor
 		}
 		lastErr = err
 	}
-	return piecestore.PieceInfoUndefined, lastErr
+	return piecestore.PieceInfoUndefined, xerrors.Errorf("could not locate piece: %w", lastErr)
 }

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -180,7 +180,7 @@ func (p *provider) HandleQueryStream(stream rmnet.RetrievalQueryStream) {
 		answer.Size = uint64(pieceInfo.Deals[0].Length) // TODO: verify on intermediate
 	}
 
-	if err != nil && err != retrievalmarket.ErrNotFound {
+	if err != nil && !xerrors.Is(err, retrievalmarket.ErrNotFound) {
 		log.Errorf("Retrieval query: GetRefs: %s", err)
 		answer.Status = retrievalmarket.QueryResponseError
 		answer.Message = err.Error()

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -209,7 +209,7 @@ func (c *Client) Start(ctx context.Context, p ClientDealProposal) (cid.Cid, erro
 		ClientCollateral:     big.Zero(),
 	}
 
-	if err := c.node.EnsureFunds(ctx, p.Client, dealProposal.ClientBalanceRequirement()); err != nil {
+	if err := c.node.EnsureFunds(ctx, p.Client, p.Client, dealProposal.ClientBalanceRequirement()); err != nil {
 		return cid.Undef, xerrors.Errorf("adding market funds failed: %w", err)
 	}
 

--- a/storagemarket/impl/client_cbor_gen.go
+++ b/storagemarket/impl/client_cbor_gen.go
@@ -63,7 +63,7 @@ func (t *ClientDealProposal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{136}); err != nil {
+	if _, err := w.Write([]byte{137}); err != nil {
 		return err
 	}
 
@@ -104,6 +104,17 @@ func (t *ClientDealProposal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.ProofType (abi.RegisteredProof) (int64)
+	if t.ProofType >= 0 {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ProofType))); err != nil {
+			return err
+		}
+	} else {
+		if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajNegativeInt, uint64(-t.ProofType)-1)); err != nil {
+			return err
+		}
+	}
+
 	// t.Client (address.Address) (struct)
 	if err := t.Client.MarshalCBOR(w); err != nil {
 		return err
@@ -139,7 +150,7 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 8 {
+	if extra != 9 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -231,6 +242,31 @@ func (t *ClientDealProposal) UnmarshalCBOR(r io.Reader) error {
 			return err
 		}
 
+	}
+	// t.ProofType (abi.RegisteredProof) (int64)
+	{
+		maj, extra, err := cbg.CborReadHeader(br)
+		var extraI int64
+		if err != nil {
+			return err
+		}
+		switch maj {
+		case cbg.MajUnsignedInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 positive overflow")
+			}
+		case cbg.MajNegativeInt:
+			extraI = int64(extra)
+			if extraI < 0 {
+				return fmt.Errorf("int64 negative oveflow")
+			}
+			extraI = -1 - extraI
+		default:
+			return fmt.Errorf("wrong type for int64 field: %d", maj)
+		}
+
+		t.ProofType = abi.RegisteredProof(extraI)
 	}
 	// t.Client (address.Address) (struct)
 

--- a/storagemarket/impl/provider_states.go
+++ b/storagemarket/impl/provider_states.go
@@ -138,7 +138,7 @@ func (p *Provider) publishing(ctx context.Context, deal MinerDeal) (func(*MinerD
 	}
 
 	// TODO: check StorageCollateral (may be too large (or too small))
-	if err := p.spn.EnsureFunds(ctx, waddr, deal.Proposal.ProviderCollateral); err != nil {
+	if err := p.spn.EnsureFunds(ctx, deal.Proposal.Provider, waddr, deal.Proposal.ProviderCollateral); err != nil {
 		return nil, err
 	}
 

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -338,7 +338,7 @@ func (n *fakeCommon) AddFunds(ctx context.Context, addr address.Address, amount 
 	return nil
 }
 
-func (n *fakeCommon) EnsureFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error {
+func (n *fakeCommon) EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error {
 	balance := n.SMState.Balance(addr)
 	if balance.Available.LessThan(amount) {
 		n.SMState.AddFunds(addr, big.Sub(amount, balance.Available))

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -173,7 +173,8 @@ type StorageProviderNode interface {
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
 
 	// Ensures that a storage market participant has a certain amount of available funds
-	EnsureFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
+	// If additional funds are needed, they will be sent from the 'wallet' address
+	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error
 
 	// GetBalance returns locked/unlocked for a storage participant.  Used by both providers and clients.
 	GetBalance(ctx context.Context, addr address.Address) (Balance, error)

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -211,7 +211,7 @@ type StorageClientNode interface {
 	// Adds funds with the StorageMinerActor for a storage participant.  Used by both providers and clients.
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
 
-	EnsureFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
+	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error
 
 	// GetBalance returns locked/unlocked for a storage participant.  Used by both providers and clients.
 	GetBalance(ctx context.Context, addr address.Address) (Balance, error)


### PR DESCRIPTION
When trying to ensure funds for a miner, we were just adding funds to the worker key, which doesnt really help much (its not associated with the miner on chain in that way). Switching that over, things then tried to send money from the miner actor, which obviously doesnt work, so now we pass the address you want to ensure has funds on the market, and the address to send funds from.