### PR TITLE
feat(retrievalmarket): support wallet address

### DIFF
--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -113,6 +113,11 @@ func (trpn *TestRetrievalProviderNode) SavePaymentVoucher(
 	return abi.TokenAmount{}, errors.New("SavePaymentVoucher failed")
 }
 
+// GetMinerWorker translates an address
+func (trpn *TestRetrievalProviderNode) GetMinerWorker(ctx context.Context, addr address.Address) (address.Address, error) {
+	return addr, nil
+}
+
 // --- Non-interface Functions
 
 // to ExpectedVoucherKey creates a lookup key for expected vouchers.

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -312,6 +312,8 @@ type RetrievalProvider interface {
 
 // RetrievalProviderNode are the node depedencies for a RetrevalProvider
 type RetrievalProviderNode interface {
+	// returns the worker address associated with a miner
+	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)
 	UnsealSector(ctx context.Context, sectorID uint64, offset uint64, length uint64) (io.ReadCloser, error)
 	SavePaymentVoucher(ctx context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expectedAmount abi.TokenAmount) (abi.TokenAmount, error)
 }


### PR DESCRIPTION
# Goals

In order to setup payment channel, we need to return the actual address of the wallet for the miner in response to queries, not just the storage miner actors address

# Implementation

Add a node method similar to the one on StorageProviderNode to look up the wallet address, translate that address when responding to queries