### PR TITLE
fix(cborgen): update cbor gen for dataref

### DIFF
--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -748,7 +748,7 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{130}); err != nil {
+	if _, err := w.Write([]byte{132}); err != nil {
 		return err
 	}
 
@@ -770,6 +770,22 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 		return xerrors.Errorf("failed to write cid field t.Root: %w", err)
 	}
 
+	// t.PieceCid (cid.Cid) (struct)
+
+	if t.PieceCid == nil {
+		if _, err := w.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteCid(w, *t.PieceCid); err != nil {
+			return xerrors.Errorf("failed to write cid field t.PieceCid: %w", err)
+		}
+	}
+
+	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
+	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PieceSize))); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -784,7 +800,7 @@ func (t *DataRef) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 4 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -810,5 +826,39 @@ func (t *DataRef) UnmarshalCBOR(r io.Reader) error {
 		t.Root = c
 
 	}
+	// t.PieceCid (cid.Cid) (struct)
+
+	{
+
+		pb, err := br.PeekByte()
+		if err != nil {
+			return err
+		}
+		if pb == cbg.CborNull[0] {
+			var nbuf [1]byte
+			if _, err := br.Read(nbuf[:]); err != nil {
+				return err
+			}
+		} else {
+
+			c, err := cbg.ReadCid(br)
+			if err != nil {
+				return xerrors.Errorf("failed to read cid field t.PieceCid: %w", err)
+			}
+
+			t.PieceCid = &c
+		}
+
+	}
+	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajUnsignedInt {
+		return fmt.Errorf("wrong type for uint64 field")
+	}
+	t.PieceSize = abi.UnpaddedPieceSize(extra)
 	return nil
 }


### PR DESCRIPTION
Just reruns cbor-gen -- looks like it did not get run when we added PieceCid & PieceSize to DataRef