### PR TITLE
ci(codecov): ignore cbor gen files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,8 @@ coverage:
   precision: 2
   round: up
   range: "50...90"
+  ignore:
+    - "*_cbor_gen.go"
   status:
     project: off
     patch: off


### PR DESCRIPTION
We should not be tracking coverage on CBOR gen files