### PR TITLE
add TipSet identity-producing method to various Node interfaces

### DIFF
--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -120,7 +120,7 @@ func (trpn *TestRetrievalProviderNode) GetMinerWorker(ctx context.Context, addr 
 }
 
 func (trpn *TestRetrievalProviderNode) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
-	panic("implement me")
+	return []byte{42}, 0, nil
 }
 
 // --- Non-interface Functions

--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 type expectedVoucherKey struct {
@@ -118,7 +119,7 @@ func (trpn *TestRetrievalProviderNode) GetMinerWorker(ctx context.Context, addr 
 	return addr, nil
 }
 
-func (trpn *TestRetrievalProviderNode) MostRecentStateId(ctx context.Context) (retrievalmarket.StateKey, error) {
+func (trpn *TestRetrievalProviderNode) MostRecentStateId(ctx context.Context) (shared.StateKey, error) {
 	panic("implement me")
 }
 

--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -119,7 +119,7 @@ func (trpn *TestRetrievalProviderNode) GetMinerWorker(ctx context.Context, addr 
 	return addr, nil
 }
 
-func (trpn *TestRetrievalProviderNode) MostRecentStateId(ctx context.Context) (shared.StateKey, error) {
+func (trpn *TestRetrievalProviderNode) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
 	panic("implement me")
 }
 

--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -118,6 +118,10 @@ func (trpn *TestRetrievalProviderNode) GetMinerWorker(ctx context.Context, addr 
 	return addr, nil
 }
 
+func (trpn *TestRetrievalProviderNode) MostRecentStateId(ctx context.Context) (retrievalmarket.StateKey, error) {
+	panic("implement me")
+}
+
 // --- Non-interface Functions
 
 // to ExpectedVoucherKey creates a lookup key for expected vouchers.

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -309,17 +311,9 @@ type RetrievalProvider interface {
 	ListDeals() map[ProviderDealID]ProviderDealState
 }
 
-// TipSetToken is the implementation-nonspecific identity for a tipset.
-type TipSetToken []byte
-
-type StateKey interface {
-	TipSetToken() TipSetToken
-	Height() abi.ChainEpoch
-}
-
 // RetrievalProviderNode are the node depedencies for a RetrevalProvider
 type RetrievalProviderNode interface {
-	MostRecentStateId(ctx context.Context) (StateKey, error)
+	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
 
 	// returns the worker address associated with a miner
 	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -313,7 +313,7 @@ type RetrievalProvider interface {
 
 // RetrievalProviderNode are the node depedencies for a RetrevalProvider
 type RetrievalProviderNode interface {
-	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
+	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// returns the worker address associated with a miner
 	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -309,8 +309,18 @@ type RetrievalProvider interface {
 	ListDeals() map[ProviderDealID]ProviderDealState
 }
 
+// TipSetToken is the implementation-nonspecific identity for a tipset.
+type TipSetToken []byte
+
+type StateKey interface {
+	TipSetToken() TipSetToken
+	Height() abi.ChainEpoch
+}
+
 // RetrievalProviderNode are the node depedencies for a RetrevalProvider
 type RetrievalProviderNode interface {
+	MostRecentStateId(ctx context.Context) (StateKey, error)
+
 	// returns the worker address associated with a miner
 	GetMinerWorker(ctx context.Context, miner address.Address) (address.Address, error)
 	UnsealSector(ctx context.Context, sectorID uint64, offset uint64, length uint64) (io.ReadCloser, error)

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,0 +1,11 @@
+package shared
+
+import "github.com/filecoin-project/specs-actors/actors/abi"
+
+// TipSetToken is the implementation-nonspecific identity for a tipset.
+type TipSetToken []byte
+
+type StateKey interface {
+	TipSetToken() TipSetToken
+	Height() abi.ChainEpoch
+}

--- a/shared/types.go
+++ b/shared/types.go
@@ -1,11 +1,4 @@
 package shared
 
-import "github.com/filecoin-project/specs-actors/actors/abi"
-
 // TipSetToken is the implementation-nonspecific identity for a tipset.
 type TipSetToken []byte
-
-type StateKey interface {
-	TipSetToken() TipSetToken
-	Height() abi.ChainEpoch
-}

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -58,14 +58,13 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("incorrect provider for deal"))
 	}
 
-	head, err := environment.Node().MostRecentStateId(ctx.Context())
-
+	_, height, err := environment.Node().GetChainHead(ctx.Context())
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("getting most recent state id: %w", err))
 	}
 
 	// TODO: set configurable value for how many epochs in the future StartEpoch must be
-	if head.Height() >= deal.Proposal.StartEpoch {
+	if height >= deal.Proposal.StartEpoch {
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("deal proposal already expired"))
 	}
 

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/providerstates"
@@ -495,7 +496,7 @@ type nodeParams struct {
 	MinerWorkerError                    error
 	EnsureFundsError                    error
 	Height                              abi.ChainEpoch
-	TipSetToken                         storagemarket.TipSetToken
+	TipSetToken                         shared.TipSetToken
 	ClientMarketBalance                 abi.TokenAmount
 	ClientMarketBalanceError            error
 	VerifySignatureFails                bool

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -467,6 +467,7 @@ func TestFailDeal(t *testing.T) {
 
 // all of these default parameters are setup to allow a deal to complete each handler with no errors
 var defaultHeight = abi.ChainEpoch(50)
+var defaultTipSetToken = []byte{1, 2, 3}
 var defaultStoragePricePerEpoch = abi.NewTokenAmount(10000)
 var defaultPieceSize = abi.PaddedPieceSize(1048576)
 var defaultStartEpoch = abi.ChainEpoch(200)
@@ -494,6 +495,7 @@ type nodeParams struct {
 	MinerWorkerError                    error
 	EnsureFundsError                    error
 	Height                              abi.ChainEpoch
+	TipSetToken                         storagemarket.TipSetToken
 	ClientMarketBalance                 abi.TokenAmount
 	ClientMarketBalanceError            error
 	VerifySignatureFails                bool
@@ -553,8 +555,10 @@ func makeExecutor(ctx context.Context,
 		smstate := testnodes.NewStorageMarketState()
 		if nodeParams.Height != abi.ChainEpoch(0) {
 			smstate.Epoch = nodeParams.Height
+			smstate.TipSetToken = nodeParams.TipSetToken
 		} else {
 			smstate.Epoch = defaultHeight
+			smstate.TipSetToken = defaultTipSetToken
 		}
 		if !nodeParams.ClientMarketBalance.Nil() {
 			smstate.AddFunds(defaultClientAddress, nodeParams.ClientMarketBalance)

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -568,11 +568,11 @@ func makeExecutor(ctx context.Context,
 		}
 
 		common := testnodes.FakeCommonNode{
-			SMState:                smstate,
-			MostRecentStateIDError: nodeParams.MostRecentStateIDError,
-			GetBalanceError:        nodeParams.ClientMarketBalanceError,
-			VerifySignatureFails:   nodeParams.VerifySignatureFails,
-			EnsureFundsError:       nodeParams.EnsureFundsError,
+			SMState:              smstate,
+			GetChainHeadError:    nodeParams.MostRecentStateIDError,
+			GetBalanceError:      nodeParams.ClientMarketBalanceError,
+			VerifySignatureFails: nodeParams.VerifySignatureFails,
+			EnsureFundsError:     nodeParams.EnsureFundsError,
 		}
 
 		node := &testnodes.FakeProviderNode{

--- a/storagemarket/impl/storedask/storedask.go
+++ b/storagemarket/impl/storedask/storedask.go
@@ -60,14 +60,14 @@ func (s *StoredAsk) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error
 		seqno = s.ask.Ask.SeqNo + 1
 	}
 
-	stateKey, err := s.spn.MostRecentStateId(context.TODO())
+	_, height, err := s.spn.GetChainHead(context.TODO())
 	if err != nil {
 		return err
 	}
 	ask := &storagemarket.StorageAsk{
 		Price:        price,
-		Timestamp:    stateKey.Height(),
-		Expiry:       stateKey.Height() + duration,
+		Timestamp:    height,
+		Expiry:       height + duration,
 		Miner:        s.actor,
 		SeqNo:        seqno,
 		MinPieceSize: defaultMinPieceSize,

--- a/storagemarket/impl/storedask/storedask_test.go
+++ b/storagemarket/impl/storedask/storedask_test.go
@@ -54,8 +54,8 @@ func TestStoredAsk(t *testing.T) {
 	t.Run("node errors", func(t *testing.T) {
 		spnStateIDErr := &testnodes.FakeProviderNode{
 			FakeCommonNode: testnodes.FakeCommonNode{
-				MostRecentStateIDError: errors.New("something went wrong"),
-				SMState:                testnodes.NewStorageMarketState(),
+				GetChainHeadError: errors.New("something went wrong"),
+				SMState:           testnodes.NewStorageMarketState(),
 			},
 		}
 		// should load cause ask is is still in data store

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -18,7 +18,14 @@ import (
 // Below fake node implementations
 
 // TestStateKey is just a stubbed state key that returns a preset height
-type TestStateKey struct{ Epoch abi.ChainEpoch }
+type TestStateKey struct {
+	Epoch abi.ChainEpoch
+	Token storagemarket.TipSetToken
+}
+
+func (k *TestStateKey) TipSetToken() storagemarket.TipSetToken {
+	return k.Token
+}
 
 // Height returns the value specified by Epoch
 func (k *TestStateKey) Height() abi.ChainEpoch {
@@ -28,6 +35,7 @@ func (k *TestStateKey) Height() abi.ChainEpoch {
 // StorageMarketState represents a state for the storage market that can be inspected
 // - methods on the provider nodes will affect this state
 type StorageMarketState struct {
+	TipSetToken  storagemarket.TipSetToken
 	Epoch        abi.ChainEpoch
 	DealId       abi.DealID
 	Balances     map[address.Address]abi.TokenAmount
@@ -73,7 +81,7 @@ func (sma *StorageMarketState) Deals(addr address.Address) []storagemarket.Stora
 
 // StateKey returns a state key with the storage market states set Epoch
 func (sma *StorageMarketState) StateKey() storagemarket.StateKey {
-	return &TestStateKey{sma.Epoch}
+	return &TestStateKey{sma.Epoch, sma.TipSetToken}
 }
 
 // AddDeal adds a deal to the current state of the storage market

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -86,21 +86,21 @@ func (sma *StorageMarketState) AddDeal(deal storagemarket.StorageDeal) (shared.T
 
 // FakeCommonNode has the common methods for the storage & client node adapters
 type FakeCommonNode struct {
-	SMState                *StorageMarketState
-	EnsureFundsError       error
-	VerifySignatureFails   bool
-	GetBalanceError        error
-	MostRecentStateIDError error
+	SMState              *StorageMarketState
+	EnsureFundsError     error
+	VerifySignatureFails bool
+	GetBalanceError      error
+	GetChainHeadError    error
 }
 
 // GetChainHead returns the state id in the storage market state
 func (n *FakeCommonNode) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
-	if n.MostRecentStateIDError == nil {
+	if n.GetChainHeadError == nil {
 		key, epoch := n.SMState.StateKey()
 		return key, epoch, nil
 	}
 
-	return []byte{}, 0, n.MostRecentStateIDError
+	return []byte{}, 0, n.GetChainHeadError
 }
 
 // AddFunds adds funds to the given actor in the storage market state

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -20,10 +22,10 @@ import (
 // TestStateKey is just a stubbed state key that returns a preset height
 type TestStateKey struct {
 	Epoch abi.ChainEpoch
-	Token storagemarket.TipSetToken
+	Token shared.TipSetToken
 }
 
-func (k *TestStateKey) TipSetToken() storagemarket.TipSetToken {
+func (k *TestStateKey) TipSetToken() shared.TipSetToken {
 	return k.Token
 }
 
@@ -35,7 +37,7 @@ func (k *TestStateKey) Height() abi.ChainEpoch {
 // StorageMarketState represents a state for the storage market that can be inspected
 // - methods on the provider nodes will affect this state
 type StorageMarketState struct {
-	TipSetToken  storagemarket.TipSetToken
+	TipSetToken  shared.TipSetToken
 	Epoch        abi.ChainEpoch
 	DealId       abi.DealID
 	Balances     map[address.Address]abi.TokenAmount
@@ -80,12 +82,12 @@ func (sma *StorageMarketState) Deals(addr address.Address) []storagemarket.Stora
 }
 
 // StateKey returns a state key with the storage market states set Epoch
-func (sma *StorageMarketState) StateKey() storagemarket.StateKey {
+func (sma *StorageMarketState) StateKey() shared.StateKey {
 	return &TestStateKey{sma.Epoch, sma.TipSetToken}
 }
 
 // AddDeal adds a deal to the current state of the storage market
-func (sma *StorageMarketState) AddDeal(deal storagemarket.StorageDeal) storagemarket.StateKey {
+func (sma *StorageMarketState) AddDeal(deal storagemarket.StorageDeal) shared.StateKey {
 	for _, addr := range []address.Address{deal.Client, deal.Provider} {
 		if existing, ok := sma.StorageDeals[addr]; ok {
 			sma.StorageDeals[addr] = append(existing, deal)
@@ -106,7 +108,7 @@ type FakeCommonNode struct {
 }
 
 // MostRecentStateId returns the state id in the storage market state
-func (n *FakeCommonNode) MostRecentStateId(ctx context.Context) (storagemarket.StateKey, error) {
+func (n *FakeCommonNode) MostRecentStateId(ctx context.Context) (shared.StateKey, error) {
 	if n.MostRecentStateIDError == nil {
 		return n.SMState.StateKey(), nil
 	}

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -96,7 +96,11 @@ type StorageAsk struct {
 
 var StorageAskUndefined = StorageAsk{}
 
+// TipSetToken is the implementation-nonspecific identity for a tipset.
+type TipSetToken []byte
+
 type StateKey interface {
+	TipSetToken() TipSetToken
 	Height() abi.ChainEpoch
 }
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -284,7 +284,7 @@ type StorageProvider interface {
 
 // Node dependencies for a StorageProvider
 type StorageProviderNode interface {
-	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
+	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
 	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool
@@ -323,7 +323,7 @@ type DealSectorCommittedCallback func(err error)
 
 // Node dependencies for a StorageClient
 type StorageClientNode interface {
-	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
+	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
 	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 //go:generate cbor-gen-for ClientDeal MinerDeal Balance SignedStorageAsk StorageAsk StorageDeal DataRef
@@ -95,14 +96,6 @@ type StorageAsk struct {
 }
 
 var StorageAskUndefined = StorageAsk{}
-
-// TipSetToken is the implementation-nonspecific identity for a tipset.
-type TipSetToken []byte
-
-type StateKey interface {
-	TipSetToken() TipSetToken
-	Height() abi.ChainEpoch
-}
 
 type MinerDeal struct {
 	market.ClientDealProposal
@@ -291,7 +284,7 @@ type StorageProvider interface {
 
 // Node dependencies for a StorageProvider
 type StorageProviderNode interface {
-	MostRecentStateId(ctx context.Context) (StateKey, error)
+	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
 
 	// Verify a signature against an address + data
 	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool
@@ -330,7 +323,7 @@ type DealSectorCommittedCallback func(err error)
 
 // Node dependencies for a StorageClient
 type StorageClientNode interface {
-	MostRecentStateId(ctx context.Context) (StateKey, error)
+	MostRecentStateId(ctx context.Context) (shared.StateKey, error)
 
 	// Verify a signature against an address + data
 	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool


### PR DESCRIPTION
This PR makes incremental progress towards [completing this ZenHub issue](https://app.zenhub.com/workspaces/markets-shared-components-5daa144a7046a60001c6e253/issues/filecoin-project/go-fil-markets/148).

## Why does this PR exist?

When a provider or client needs information from the chain, they need to provide a chain state identifier to which their query is scoped. Due to potential reorgs, chain height does not serve as identity for a tipset.

## What's in this PR?

This PR changes the signature and name of the existing chain state identity-acquiring method, and adds that method to all `*Node` interfaces which query for (or will query for, in the short future) chain state.