### PR TITLE
retrieval client node interface passes tipset identifier to node

### DIFF
--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -20,7 +20,12 @@ type ClientDealEnvironment interface {
 
 // SetupPaymentChannel sets up a payment channel for a deal
 func SetupPaymentChannel(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
-	paych, err := environment.Node().GetOrCreatePaymentChannel(ctx.Context(), deal.ClientWallet, deal.MinerWallet, deal.TotalFunds)
+	tok, _, err := environment.Node().GetChainHead(ctx.Context())
+	if err != nil {
+		return ctx.Trigger(rm.ClientEventPaymentChannelErrored, err)
+	}
+
+	paych, err := environment.Node().GetOrCreatePaymentChannel(ctx.Context(), deal.ClientWallet, deal.MinerWallet, deal.TotalFunds, tok)
 	if err != nil {
 		return ctx.Trigger(rm.ClientEventPaymentChannelErrored, err)
 	}

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -61,7 +61,6 @@ func ProposeDeal(ctx fsm.Context, environment ClientDealEnvironment, deal rm.Cli
 
 // ProcessPaymentRequested processes a request for payment from the provider
 func ProcessPaymentRequested(ctx fsm.Context, environment ClientDealEnvironment, deal rm.ClientDealState) error {
-
 	// check that fundsSpent + paymentRequested <= totalFunds, or fail
 	if big.Add(deal.FundsSpent, deal.PaymentRequested).GreaterThan(deal.TotalFunds) {
 		expectedTotal := deal.TotalFunds.String()
@@ -79,10 +78,15 @@ func ProcessPaymentRequested(ctx fsm.Context, environment ClientDealEnvironment,
 		return ctx.Trigger(rm.ClientEventBadPaymentRequested, "too much money requested for bytes sent")
 	}
 
+	tok, _, err := environment.Node().GetChainHead(ctx.Context())
+	if err != nil {
+		return ctx.Trigger(rm.ClientEventCreateVoucherFailed, err)
+	}
+
 	// create payment voucher with node (or fail) for (fundsSpent + paymentRequested)
 	// use correct payCh + lane
 	// (node will do subtraction back to paymentRequested... slightly odd behavior but... well anyway)
-	voucher, err := environment.Node().CreatePaymentVoucher(ctx.Context(), deal.PaymentInfo.PayCh, big.Add(deal.FundsSpent, deal.PaymentRequested), deal.PaymentInfo.Lane)
+	voucher, err := environment.Node().CreatePaymentVoucher(ctx.Context(), deal.PaymentInfo.PayCh, big.Add(deal.FundsSpent, deal.PaymentRequested), deal.PaymentInfo.Lane, tok)
 	if err != nil {
 		return ctx.Trigger(rm.ClientEventCreateVoucherFailed, err)
 	}

--- a/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
@@ -3,6 +3,8 @@ package testnodes
 import (
 	"context"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
@@ -56,7 +58,7 @@ func NewTestRetrievalClientNode(params TestRetrievalClientNodeParams) *TestRetri
 }
 
 // GetOrCreatePaymentChannel returns a mocked payment channel
-func (trcn *TestRetrievalClientNode) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount) (address.Address, error) {
+func (trcn *TestRetrievalClientNode) GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount, tok shared.TipSetToken) (address.Address, error) {
 	if trcn.getCreatePaymentChannelRecorder != nil {
 		trcn.getCreatePaymentChannelRecorder(clientAddress, minerAddress, clientFundsAvailable)
 	}
@@ -77,4 +79,8 @@ func (trcn *TestRetrievalClientNode) CreatePaymentVoucher(ctx context.Context, p
 		trcn.createPaymentVoucherRecorder(trcn.voucher)
 	}
 	return trcn.voucher, trcn.voucherError
+}
+
+func (trcn *TestRetrievalClientNode) GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error) {
+	return shared.TipSetToken{}, 0, nil
 }

--- a/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
@@ -74,7 +74,7 @@ func (trcn *TestRetrievalClientNode) AllocateLane(paymentChannel address.Address
 }
 
 // CreatePaymentVoucher creates a mock payment voucher based on a channel and lane
-func (trcn *TestRetrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64) (*paych.SignedVoucher, error) {
+func (trcn *TestRetrievalClientNode) CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64, tok shared.TipSetToken) (*paych.SignedVoucher, error) {
 	if trcn.createPaymentVoucherRecorder != nil {
 		trcn.createPaymentVoucherRecorder(trcn.voucher)
 	}

--- a/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_client_node.go
@@ -3,13 +3,12 @@ package testnodes
 import (
 	"context"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 // TestRetrievalClientNode is a node adapter for a retrieval client whose responses

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -175,10 +175,11 @@ type RetrievalClient interface {
 
 // RetrievalClientNode are the node dependencies for a RetrievalClient
 type RetrievalClientNode interface {
+	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// GetOrCreatePaymentChannel sets up a new payment channel if one does not exist
 	// between a client and a miner and insures the client has the given amount of funds available in the channel
-	GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount) (address.Address, error)
+	GetOrCreatePaymentChannel(ctx context.Context, clientAddress address.Address, minerAddress address.Address, clientFundsAvailable abi.TokenAmount, tok shared.TipSetToken) (address.Address, error)
 
 	// Allocate late creates a lane within a payment channel so that calls to
 	// CreatePaymentVoucher will automatically make vouchers only for the difference

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -189,7 +189,7 @@ type RetrievalClientNode interface {
 	// CreatePaymentVoucher creates a new payment voucher in the given lane for a
 	// given payment channel so that all the payment vouchers in the lane add up
 	// to the given amount (so the payment voucher will be for the difference)
-	CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64) (*paych.SignedVoucher, error)
+	CreatePaymentVoucher(ctx context.Context, paymentChannel address.Address, amount abi.TokenAmount, lane uint64, tok shared.TipSetToken) (*paych.SignedVoucher, error)
 }
 
 // ProviderDealState is the current state of a deal from the point of view


### PR DESCRIPTION
## Why does this PR exist?

This PR makes incremental progress towards the larger goal of providing a tipset identifier to the node to which it scopes all chain queries.