### PR TITLE
Add TipSetToken to SavePaymentVoucher

### DIFF
--- a/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
+++ b/retrievalmarket/impl/testnodes/test_retrieval_provider_node.go
@@ -101,7 +101,8 @@ func (trpn *TestRetrievalProviderNode) SavePaymentVoucher(
 	paymentChannel address.Address,
 	voucher *paych.SignedVoucher,
 	proof []byte,
-	expectedAmount abi.TokenAmount) (abi.TokenAmount, error) {
+	expectedAmount abi.TokenAmount,
+	tok shared.TipSetToken) (abi.TokenAmount, error) {
 	key, err := trpn.toExpectedVoucherKey(paymentChannel, voucher, proof, expectedAmount)
 	if err != nil {
 		return abi.TokenAmount{}, err

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -319,7 +319,7 @@ type RetrievalProviderNode interface {
 	// returns the worker address associated with a miner
 	GetMinerWorkerAddress(ctx context.Context, miner address.Address, tok shared.TipSetToken) (address.Address, error)
 	UnsealSector(ctx context.Context, sectorID uint64, offset uint64, length uint64) (io.ReadCloser, error)
-	SavePaymentVoucher(ctx context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expectedAmount abi.TokenAmount) (abi.TokenAmount, error)
+	SavePaymentVoucher(ctx context.Context, paymentChannel address.Address, voucher *paych.SignedVoucher, proof []byte, expectedAmount abi.TokenAmount, tok shared.TipSetToken) (abi.TokenAmount, error)
 }
 
 // PeerResolver is an interface for looking up providers that may have a piece


### PR DESCRIPTION
## Why does this PR exist?

Implementations of the `SavePaymentVoucher` will need to inspect payment channel actor state in order to load the payment channel parties. It has historically used the chain head (implicitly) but should accept a tipset identifier.