### PR TITLE
Feat/configure start epoch buffer

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -30,6 +30,7 @@ import (
 )
 
 var ProviderDsPrefix = "/deals/provider"
+var DefaultDealAcceptanceBuffer = abi.ChainEpoch(100)
 var _ storagemarket.StorageProvider = &Provider{}
 
 // Provider is a storage provider implementation
@@ -92,7 +93,7 @@ func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blo
 		storedAsk:            storedAsk,
 		actor:                minerAddress,
 		dataTransfer:         dataTransfer,
-		dealAcceptanceBuffer: abi.ChainEpoch(100),
+		dealAcceptanceBuffer: DefaultDealAcceptanceBuffer,
 	}
 
 	deals, err := fsm.New(namespace.Wrap(ds, datastore.NewKey(ProviderDsPrefix)), fsm.Parameters{

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -108,9 +108,7 @@ func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blo
 
 	h.deals = deals
 
-	for _, option := range options {
-		option(h)
-	}
+	h.Configure(options...)
 
 	// register a data transfer event handler -- this will move deals from
 	// accepted to staged
@@ -283,6 +281,20 @@ func (p *Provider) HandleAskStream(s network.StorageAskStream) {
 		log.Errorf("failed to write ask response: %s", err)
 		return
 	}
+}
+
+func (p *Provider) Configure(options ...StorageProviderOption) {
+	for _, option := range options {
+		option(p)
+	}
+}
+
+func (p *Provider) DealAcceptanceBuffer() abi.ChainEpoch {
+	return p.dealAcceptanceBuffer
+}
+
+func (p *Provider) UniversalRetrievalEnabled() bool {
+	return p.universalRetrievalEnabled
 }
 
 type providerDealEnvironment struct {

--- a/storagemarket/impl/provider_test.go
+++ b/storagemarket/impl/provider_test.go
@@ -1,0 +1,25 @@
+package storageimpl_test
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/stretchr/testify/assert"
+
+	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
+)
+
+func TestConfigure(t *testing.T) {
+	p := &storageimpl.Provider{}
+
+	assert.False(t, p.UniversalRetrievalEnabled())
+	assert.Equal(t, abi.ChainEpoch(0), p.DealAcceptanceBuffer())
+
+	p.Configure(
+		storageimpl.EnableUniversalRetrieval(),
+		storageimpl.DealAcceptanceBuffer(abi.ChainEpoch(123)),
+	)
+
+	assert.True(t, p.UniversalRetrievalEnabled())
+	assert.Equal(t, abi.ChainEpoch(123), p.DealAcceptanceBuffer())
+}

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -47,7 +47,7 @@ func TestValidateDealProposal(t *testing.T) {
 	}{
 		"succeeds": {
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealProposalAccepted)
+				require.Equal(t, storagemarket.StorageDealProposalAccepted, deal.State)
 			},
 		},
 		"verify signature fails": {
@@ -55,8 +55,8 @@ func TestValidateDealProposal(t *testing.T) {
 				VerifySignatureFails: true,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: verifying StorageDealProposal: could not verify signature")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: verifying StorageDealProposal: could not verify signature", deal.Message)
 			},
 		},
 		"provider address does not match": {
@@ -64,8 +64,8 @@ func TestValidateDealProposal(t *testing.T) {
 				Address: otherAddr,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: incorrect provider for deal")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: incorrect provider for deal", deal.Message)
 			},
 		},
 		"MostRecentStateID errors": {
@@ -73,8 +73,8 @@ func TestValidateDealProposal(t *testing.T) {
 				MostRecentStateIDError: errors.New("couldn't get id"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error calling node: getting most recent state id: couldn't get id")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error calling node: getting most recent state id: couldn't get id", deal.Message)
 			},
 		},
 		"CurrentHeight <= StartEpoch - DealAcceptanceBuffer() succeeds": {
@@ -82,7 +82,7 @@ func TestValidateDealProposal(t *testing.T) {
 			dealParams:        dealParams{StartEpoch: 200},
 			nodeParams:        nodeParams{Height: 190},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealProposalAccepted)
+				require.Equal(t, storagemarket.StorageDealProposalAccepted, deal.State)
 			},
 		},
 		"CurrentHeight > StartEpoch - DealAcceptanceBuffer() fails": {
@@ -90,8 +90,8 @@ func TestValidateDealProposal(t *testing.T) {
 			dealParams:        dealParams{StartEpoch: 200},
 			nodeParams:        nodeParams{Height: 191},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: deal start epoch is too soon or deal already expired")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: deal start epoch is too soon or deal already expired", deal.Message)
 			},
 		},
 		"PricePerEpoch too low": {
@@ -99,8 +99,8 @@ func TestValidateDealProposal(t *testing.T) {
 				StoragePricePerEpoch: abi.NewTokenAmount(5000),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: storage price per epoch less than asking price: 5000 < 9765")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: storage price per epoch less than asking price: 5000 < 9765", deal.Message)
 			},
 		},
 		"PieceSize < MinPieceSize": {
@@ -108,8 +108,8 @@ func TestValidateDealProposal(t *testing.T) {
 				PieceSize: abi.PaddedPieceSize(128),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: piece size less than minimum required size: 128 < 256")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: piece size less than minimum required size: 128 < 256", deal.Message)
 			},
 		},
 		"Get balance error": {
@@ -117,8 +117,8 @@ func TestValidateDealProposal(t *testing.T) {
 				ClientMarketBalanceError: errors.New("could not get balance"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error calling node: getting client market balance failed: could not get balance")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error calling node: getting client market balance failed: could not get balance", deal.Message)
 			},
 		},
 		"Not enough funds": {
@@ -126,8 +126,8 @@ func TestValidateDealProposal(t *testing.T) {
 				ClientMarketBalance: abi.NewTokenAmount(150 * 10000),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: clientMarketBalance.Available too small")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: clientMarketBalance.Available too small", deal.Message)
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestTransferData(t *testing.T) {
 	}{
 		"succeeds": {
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealTransferring)
+				require.Equal(t, storagemarket.StorageDealTransferring, deal.State)
 			},
 		},
 		"manual transfer": {
@@ -163,7 +163,7 @@ func TestTransferData(t *testing.T) {
 				},
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealWaitingForData)
+				require.Equal(t, storagemarket.StorageDealWaitingForData, deal.State)
 			},
 		},
 		"data transfer failure": {
@@ -171,8 +171,8 @@ func TestTransferData(t *testing.T) {
 				DataTransferError: errors.New("could not initiate"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error transferring data: failed to open pull data channel: could not initiate")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error transferring data: failed to open pull data channel: could not initiate", deal.Message)
 			},
 		},
 	}
@@ -204,9 +204,9 @@ func TestVerifyData(t *testing.T) {
 				MetadataPath: expMetaPath,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealPublishing)
-				require.Equal(t, deal.PiecePath, expPath)
-				require.Equal(t, deal.MetadataPath, expMetaPath)
+				require.Equal(t, storagemarket.StorageDealPublishing, deal.State)
+				require.Equal(t, expPath, deal.PiecePath)
+				require.Equal(t, expMetaPath, deal.MetadataPath)
 			},
 		},
 		"generate piece CID fails": {
@@ -214,8 +214,8 @@ func TestVerifyData(t *testing.T) {
 				GenerateCommPError: errors.New("could not generate CommP"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "generating piece committment: could not generate CommP")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "generating piece committment: could not generate CommP", deal.Message)
 			},
 		},
 		"piece CIDs do not match": {
@@ -223,8 +223,8 @@ func TestVerifyData(t *testing.T) {
 				PieceCid: tut.GenerateCids(1)[0],
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "deal rejected: proposal CommP doesn't match calculated CommP")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "deal rejected: proposal CommP doesn't match calculated CommP", deal.Message)
 			},
 		},
 	}
@@ -254,9 +254,9 @@ func TestPublishDeal(t *testing.T) {
 				PublishDealID: expDealID,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealStaged)
-				require.Equal(t, deal.DealID, expDealID)
-				require.Equal(t, deal.ConnectionClosed, true)
+				require.Equal(t, storagemarket.StorageDealStaged, deal.State)
+				require.Equal(t, expDealID, deal.DealID)
+				require.Equal(t, true, deal.ConnectionClosed)
 			},
 		},
 		"get miner worker fails": {
@@ -264,8 +264,8 @@ func TestPublishDeal(t *testing.T) {
 				MinerWorkerError: errors.New("could not get worker"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error calling node: looking up miner worker: could not get worker")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error calling node: looking up miner worker: could not get worker", deal.Message)
 			},
 		},
 		"ensureFunds errors": {
@@ -273,8 +273,8 @@ func TestPublishDeal(t *testing.T) {
 				EnsureFundsError: errors.New("not enough funds"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error calling node: ensuring funds: not enough funds")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error calling node: ensuring funds: not enough funds", deal.Message)
 			},
 		},
 		"PublishDealsErrors errors": {
@@ -282,8 +282,8 @@ func TestPublishDeal(t *testing.T) {
 				PublishDealsError: errors.New("could not post to chain"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error calling node: publishing deal: could not post to chain")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error calling node: publishing deal: could not post to chain", deal.Message)
 			},
 		},
 		"SendSignedResponse errors": {
@@ -291,8 +291,8 @@ func TestPublishDeal(t *testing.T) {
 				SendSignedResponseError: errors.New("could not send"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealError)
-				require.Equal(t, deal.Message, "sending response to deal: could not send")
+				require.Equal(t, storagemarket.StorageDealError, deal.State)
+				require.Equal(t, "sending response to deal: could not send", deal.Message)
 			},
 		},
 	}
@@ -325,7 +325,7 @@ func TestHandoffDeal(t *testing.T) {
 				ExpectedOpens: []filestore.Path{defaultPath},
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealSealing)
+				require.Equal(t, storagemarket.StorageDealSealing, deal.State)
 			},
 		},
 		"opening file errors": {
@@ -333,8 +333,8 @@ func TestHandoffDeal(t *testing.T) {
 				PiecePath: filestore.Path("missing.txt"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, fmt.Sprintf("accessing file store: reading piece at path missing.txt: %s", tut.TestErrNotFound.Error()))
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, fmt.Sprintf("accessing file store: reading piece at path missing.txt: %s", tut.TestErrNotFound.Error()), deal.Message)
 			},
 		},
 		"OnDealComplete errors": {
@@ -349,8 +349,8 @@ func TestHandoffDeal(t *testing.T) {
 				OnDealCompleteError: errors.New("failed building sector"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "handing off deal to node: failed building sector")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "handing off deal to node: failed building sector", deal.Message)
 			},
 		},
 	}
@@ -376,7 +376,7 @@ func TestVerifyDealActivated(t *testing.T) {
 	}{
 		"succeeds": {
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealActive)
+				require.Equal(t, storagemarket.StorageDealActive, deal.State)
 			},
 		},
 		"sync error": {
@@ -384,8 +384,8 @@ func TestVerifyDealActivated(t *testing.T) {
 				DealCommittedSyncError: errors.New("couldn't check deal commitment"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error activating deal: couldn't check deal commitment")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error activating deal: couldn't check deal commitment", deal.Message)
 			},
 		},
 		"async error": {
@@ -393,8 +393,8 @@ func TestVerifyDealActivated(t *testing.T) {
 				DealCommittedAsyncError: errors.New("deal did not appear on chain"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "error activating deal: deal did not appear on chain")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "error activating deal: deal did not appear on chain", deal.Message)
 			},
 		},
 	}
@@ -427,7 +427,7 @@ func TestRecordPieceInfo(t *testing.T) {
 				ExpectedDeletions: []filestore.Path{defaultPath},
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealCompleted)
+				require.Equal(t, storagemarket.StorageDealCompleted, deal.State)
 			},
 		},
 		"succeeds w metadata": {
@@ -441,7 +441,7 @@ func TestRecordPieceInfo(t *testing.T) {
 				ExpectedDeletions: []filestore.Path{defaultMetadataPath, defaultPath},
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealCompleted)
+				require.Equal(t, storagemarket.StorageDealCompleted, deal.State)
 			},
 		},
 		"locate piece fails": {
@@ -452,8 +452,8 @@ func TestRecordPieceInfo(t *testing.T) {
 				LocatePieceForDealWithinSectorError: errors.New("could not find piece"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "locating piece for deal ID 1234 in sector: could not find piece")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "locating piece for deal ID 1234 in sector: could not find piece", deal.Message)
 			},
 		},
 		"reading metadata fails": {
@@ -461,8 +461,8 @@ func TestRecordPieceInfo(t *testing.T) {
 				MetadataPath: filestore.Path("Missing.txt"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, fmt.Sprintf("error reading piece metadata: %s", tut.TestErrNotFound.Error()))
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, fmt.Sprintf("error reading piece metadata: %s", tut.TestErrNotFound.Error()), deal.Message)
 			},
 		},
 		"add piece block locations errors": {
@@ -470,8 +470,8 @@ func TestRecordPieceInfo(t *testing.T) {
 				AddPieceBlockLocationsError: errors.New("could not add block locations"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "accessing piece store: adding piece block locations: could not add block locations")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "accessing piece store: adding piece block locations: could not add block locations", deal.Message)
 			},
 		},
 		"add deal for piece errors": {
@@ -479,8 +479,8 @@ func TestRecordPieceInfo(t *testing.T) {
 				AddDealForPieceError: errors.New("could not add deal info"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealFailing)
-				require.Equal(t, deal.Message, "accessing piece store: adding deal info for piece: could not add deal info")
+				require.Equal(t, storagemarket.StorageDealFailing, deal.State)
+				require.Equal(t, "accessing piece store: adding deal info for piece: could not add deal info", deal.Message)
 			},
 		},
 	}
@@ -506,7 +506,7 @@ func TestFailDeal(t *testing.T) {
 	}{
 		"succeeds": {
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealError)
+				require.Equal(t, storagemarket.StorageDealError, deal.State)
 			},
 		},
 		"succeeds, skips response": {
@@ -519,9 +519,9 @@ func TestFailDeal(t *testing.T) {
 				ConnectionClosed: true,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealError)
+				require.Equal(t, storagemarket.StorageDealError, deal.State)
 				// should not have additional error message
-				require.Equal(t, deal.Message, "")
+				require.Equal(t, "", deal.Message)
 			},
 		},
 		"succeeds, file deletions": {
@@ -534,7 +534,7 @@ func TestFailDeal(t *testing.T) {
 				ExpectedDeletions: []filestore.Path{defaultPath, defaultMetadataPath},
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealError)
+				require.Equal(t, storagemarket.StorageDealError, deal.State)
 			},
 		},
 		"SendSignedResponse errors": {
@@ -542,8 +542,8 @@ func TestFailDeal(t *testing.T) {
 				SendSignedResponseError: errors.New("could not send"),
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, deal.State, storagemarket.StorageDealError)
-				require.Equal(t, deal.Message, "sending response to deal: could not send")
+				require.Equal(t, storagemarket.StorageDealError, deal.State)
+				require.Equal(t, "sending response to deal: could not send", deal.Message)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
Add a configurable `DealAcceptanceBuffer`, which can be used by storage providers to adjust how far in the future a deal's `StartEpoch` must be in order to be accepted.  This is to account for time required for data transfer, deal publishing, sealing, committing, etc.

Resolves #139 