### PR TITLE
send tipset identifier to node when interacting with chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: build
 SUBMODULES=
 
 FFI_PATH:=./extern/filecoin-ffi/
-FFI_DEPS:=libfilecoin.a filecoin.pc filecoin.h
+FFI_DEPS:=libfilcrypto.a filcrypto.pc filcrypto.h
 FFI_DEPS:=$(addprefix $(FFI_PATH),$(FFI_DEPS))
 
 $(FFI_DEPS): .filecoin-build ;

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-data-transfer v0.0.0-20191219005021-4accf56bd2ce
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
-	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200319233206-2a7435bc45d9
+	github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200326160829-51775363aa18
 	github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:9
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200319233206-2a7435bc45d9 h1:XNMl75DtSR7yp41WfeN7Ezu41v7H5wSS0I6E7g15Pi8=
-github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200319233206-2a7435bc45d9/go.mod h1:xAd/X905Ncgj8kkHsP2pmQUf6MQT2qJTDcOEfkwCjYc=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200326160829-51775363aa18 h1:k0lIN4y3JM8aFd02+1h2MdST3cCAFBO4vaZ7PARXyzo=
+github.com/filecoin-project/go-sectorbuilder v0.0.2-0.20200326160829-51775363aa18/go.mod h1:xAd/X905Ncgj8kkHsP2pmQUf6MQT2qJTDcOEfkwCjYc=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
 github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-fil-markets/pieceio"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 )
@@ -38,18 +39,23 @@ func CommP(ctx context.Context, pieceIO pieceio.PieceIO, rt abi.RegisteredProof,
 }
 
 // VerifyFunc is a function that can validate a signature for a given address and bytes
-type VerifyFunc func(crypto.Signature, address.Address, []byte) bool
+type VerifyFunc func(context.Context, crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error)
 
 // VerifyResponse verifies the signature on the given signed response matches
 // the given miner address, using the given signature verification function
-func VerifyResponse(resp network.SignedResponse, minerAddr address.Address, verifier VerifyFunc) error {
+func VerifyResponse(ctx context.Context, resp network.SignedResponse, minerAddr address.Address, tok shared.TipSetToken, verifier VerifyFunc) error {
 	b, err := cborutil.Dump(&resp.Response)
 	if err != nil {
 		return err
 	}
-	verified := verifier(*resp.Signature, minerAddr, b)
+	verified, err := verifier(ctx, *resp.Signature, minerAddr, b, tok)
+	if err != nil {
+		return err
+	}
+
 	if !verified {
 		return xerrors.New("could not verify signature")
 	}
+
 	return nil
 }

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -223,16 +225,16 @@ func (p *Provider) ListAsks(addr address.Address) []*storagemarket.SignedStorage
 	return nil
 }
 
-func (p *Provider) ListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error) {
-	return p.spn.ListProviderDeals(ctx, p.actor)
+func (p *Provider) ListDeals(ctx context.Context, tok shared.TipSetToken) ([]storagemarket.StorageDeal, error) {
+	return p.spn.ListProviderDeals(ctx, p.actor, tok)
 }
 
 func (p *Provider) AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error {
 	return p.spn.AddFunds(ctx, p.actor, amount)
 }
 
-func (p *Provider) GetStorageCollateral(ctx context.Context) (storagemarket.Balance, error) {
-	return p.spn.GetBalance(ctx, p.actor)
+func (p *Provider) GetStorageCollateral(ctx context.Context, tok shared.TipSetToken) (storagemarket.Balance, error) {
+	return p.spn.GetBalance(ctx, p.actor, tok)
 }
 
 func (p *Provider) ListIncompleteDeals() ([]storagemarket.MinerDeal, error) {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
-
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -225,7 +223,12 @@ func (p *Provider) ListAsks(addr address.Address) []*storagemarket.SignedStorage
 	return nil
 }
 
-func (p *Provider) ListDeals(ctx context.Context, tok shared.TipSetToken) ([]storagemarket.StorageDeal, error) {
+func (p *Provider) ListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error) {
+	tok, _, err := p.spn.GetChainHead(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	return p.spn.ListProviderDeals(ctx, p.actor, tok)
 }
 
@@ -233,7 +236,12 @@ func (p *Provider) AddStorageCollateral(ctx context.Context, amount abi.TokenAmo
 	return p.spn.AddFunds(ctx, p.actor, amount)
 }
 
-func (p *Provider) GetStorageCollateral(ctx context.Context, tok shared.TipSetToken) (storagemarket.Balance, error) {
+func (p *Provider) GetStorageCollateral(ctx context.Context) (storagemarket.Balance, error) {
+	tok, _, err := p.spn.GetChainHead(ctx)
+	if err != nil {
+		return storagemarket.Balance{}, err
+	}
+
 	return p.spn.GetBalance(ctx, p.actor, tok)
 }
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -47,8 +47,12 @@ type ProviderStateEntryFunc func(ctx fsm.Context, environment ProviderDealEnviro
 
 // ValidateDealProposal validates a proposed deal against the provider criteria
 func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, deal storagemarket.MinerDeal) error {
+	tok, _, err := environment.Node().GetChainHead(ctx.Context())
+	if err != nil {
+		return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("getting most recent state id: %w", err))
+	}
 
-	if err := providerutils.VerifyProposal(deal.ClientDealProposal, environment.Node().VerifySignature); err != nil {
+	if err := providerutils.VerifyProposal(deal.ClientDealProposal, tok, environment.Node().VerifySignature); err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("verifying StorageDealProposal: %w", err))
 	}
 
@@ -56,7 +60,7 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("incorrect provider for deal"))
 	}
 
-	_, height, err := environment.Node().GetChainHead(ctx.Context())
+	tok, height, err := environment.Node().GetChainHead(ctx.Context())
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("getting most recent state id: %w", err))
 	}
@@ -80,7 +84,7 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 	}
 
 	// check market funds
-	clientMarketBalance, err := environment.Node().GetBalance(ctx.Context(), deal.Proposal.Client)
+	clientMarketBalance, err := environment.Node().GetBalance(ctx.Context(), deal.Proposal.Client, tok)
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("getting client market balance failed: %w", err))
 	}
@@ -163,7 +167,7 @@ func PublishDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 	}
 
 	// TODO: check StorageCollateral (may be too large (or too small))
-	if err := environment.Node().EnsureFunds(ctx.Context(), deal.Proposal.Provider, waddr, deal.Proposal.ProviderCollateral); err != nil {
+	if err := environment.Node().EnsureFunds(ctx.Context(), deal.Proposal.Provider, waddr, deal.Proposal.ProviderCollateral, tok); err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("ensuring funds: %w", err))
 	}
 

--- a/storagemarket/impl/providerutils/providerutils.go
+++ b/storagemarket/impl/providerutils/providerutils.go
@@ -32,17 +32,17 @@ var (
 )
 
 // VerifyFunc is a function that can validate a signature for a given address and bytes
-type VerifyFunc func(crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error)
+type VerifyFunc func(context.Context, crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error)
 
 // VerifyProposal verifies the signature on the given signed proposal matches
 // the client addres for the proposal, using the given signature verification function
-func VerifyProposal(sdp market.ClientDealProposal, tok shared.TipSetToken, verifier VerifyFunc) error {
+func VerifyProposal(ctx context.Context, sdp market.ClientDealProposal, tok shared.TipSetToken, verifier VerifyFunc) error {
 	b, err := cborutil.Dump(&sdp.Proposal)
 	if err != nil {
 		return err
 	}
 
-	verified, err := verifier(sdp.ClientSignature, sdp.Proposal.Client, b, tok)
+	verified, err := verifier(ctx, sdp.ClientSignature, sdp.Proposal.Client, b, tok)
 	if err != nil {
 		return xerrors.Errorf("verifying: %w", err)
 	}

--- a/storagemarket/impl/providerutils/providerutils.go
+++ b/storagemarket/impl/providerutils/providerutils.go
@@ -32,19 +32,25 @@ var (
 )
 
 // VerifyFunc is a function that can validate a signature for a given address and bytes
-type VerifyFunc func(crypto.Signature, address.Address, []byte) bool
+type VerifyFunc func(crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error)
 
 // VerifyProposal verifies the signature on the given signed proposal matches
 // the client addres for the proposal, using the given signature verification function
-func VerifyProposal(sdp market.ClientDealProposal, verifier VerifyFunc) error {
+func VerifyProposal(sdp market.ClientDealProposal, tok shared.TipSetToken, verifier VerifyFunc) error {
 	b, err := cborutil.Dump(&sdp.Proposal)
 	if err != nil {
 		return err
 	}
-	verified := verifier(sdp.ClientSignature, sdp.Proposal.Client, b)
+
+	verified, err := verifier(sdp.ClientSignature, sdp.Proposal.Client, b, tok)
+	if err != nil {
+		return xerrors.Errorf("verifying: %w", err)
+	}
+
 	if !verified {
 		return xerrors.New("could not verify signature")
 	}
+
 	return nil
 }
 

--- a/storagemarket/impl/providerutils/providerutils_test.go
+++ b/storagemarket/impl/providerutils/providerutils_test.go
@@ -38,8 +38,10 @@ func TestVerifyProposal(t *testing.T) {
 		shouldErr bool
 	}{
 		"successful verification": {
-			proposal:  *shared_testutil.MakeTestClientDealProposal(),
-			verifier:  func(crypto.Signature, address.Address, []byte) bool { return true },
+			proposal: *shared_testutil.MakeTestClientDealProposal(),
+			verifier: func(context.Context, crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error) {
+				return true, nil
+			},
 			shouldErr: false,
 		},
 		"bad proposal": {
@@ -47,18 +49,22 @@ func TestVerifyProposal(t *testing.T) {
 				Proposal:        market.DealProposal{},
 				ClientSignature: *shared_testutil.MakeTestSignature(),
 			},
-			verifier:  func(crypto.Signature, address.Address, []byte) bool { return true },
+			verifier: func(context.Context, crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error) {
+				return true, nil
+			},
 			shouldErr: true,
 		},
 		"verification fails": {
-			proposal:  *shared_testutil.MakeTestClientDealProposal(),
-			verifier:  func(crypto.Signature, address.Address, []byte) bool { return false },
+			proposal: *shared_testutil.MakeTestClientDealProposal(),
+			verifier: func(context.Context, crypto.Signature, address.Address, []byte, shared.TipSetToken) (bool, error) {
+				return false, nil
+			},
 			shouldErr: true,
 		},
 	}
 	for name, data := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := providerutils.VerifyProposal(data.proposal, data.verifier)
+			err := providerutils.VerifyProposal(context.Background(), data.proposal, shared.TipSetToken{}, data.verifier)
 			require.Equal(t, err != nil, data.shouldErr)
 		})
 	}

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -109,7 +109,7 @@ func (n *FakeCommonNode) AddFunds(ctx context.Context, addr address.Address, amo
 }
 
 // EnsureFunds adds funds to the given actor in the storage market state to insure it has at least the given amount
-func (n *FakeCommonNode) EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error {
+func (n *FakeCommonNode) EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount, tok shared.TipSetToken) error {
 	if n.EnsureFundsError == nil {
 		balance := n.SMState.Balance(addr)
 		if balance.Available.LessThan(amount) {
@@ -120,7 +120,7 @@ func (n *FakeCommonNode) EnsureFunds(ctx context.Context, addr, wallet address.A
 }
 
 // GetBalance returns the funds in the storage market state
-func (n *FakeCommonNode) GetBalance(ctx context.Context, addr address.Address) (storagemarket.Balance, error) {
+func (n *FakeCommonNode) GetBalance(ctx context.Context, addr address.Address, tok shared.TipSetToken) (storagemarket.Balance, error) {
 	if n.GetBalanceError == nil {
 		return n.SMState.Balance(addr), nil
 	}
@@ -128,8 +128,8 @@ func (n *FakeCommonNode) GetBalance(ctx context.Context, addr address.Address) (
 }
 
 // VerifySignature just always returns true, for now
-func (n *FakeCommonNode) VerifySignature(signature crypto.Signature, addr address.Address, data []byte) bool {
-	return !n.VerifySignatureFails
+func (n *FakeCommonNode) VerifySignature(signature crypto.Signature, addr address.Address, data []byte, tok shared.TipSetToken) (bool, error) {
+	return !n.VerifySignatureFails, nil
 }
 
 // FakeClientNode implements functions specific to the StorageClientNode
@@ -144,7 +144,7 @@ type FakeClientNode struct {
 }
 
 // ListClientDeals just returns the deals in the storage market state
-func (n *FakeClientNode) ListClientDeals(ctx context.Context, addr address.Address) ([]storagemarket.StorageDeal, error) {
+func (n *FakeClientNode) ListClientDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]storagemarket.StorageDeal, error) {
 	return n.SMState.Deals(addr), nil
 }
 
@@ -218,7 +218,7 @@ func (n *FakeProviderNode) PublishDeals(ctx context.Context, deal storagemarket.
 }
 
 // ListProviderDeals returns the deals in the storage market state
-func (n *FakeProviderNode) ListProviderDeals(ctx context.Context, addr address.Address) ([]storagemarket.StorageDeal, error) {
+func (n *FakeProviderNode) ListProviderDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]storagemarket.StorageDeal, error) {
 	return n.SMState.Deals(addr), nil
 }
 

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -128,7 +128,7 @@ func (n *FakeCommonNode) GetBalance(ctx context.Context, addr address.Address, t
 }
 
 // VerifySignature just always returns true, for now
-func (n *FakeCommonNode) VerifySignature(signature crypto.Signature, addr address.Address, data []byte, tok shared.TipSetToken) (bool, error) {
+func (n *FakeCommonNode) VerifySignature(ctx context.Context, signature crypto.Signature, addr address.Address, data []byte, tok shared.TipSetToken) (bool, error) {
 	return !n.VerifySignatureFails, nil
 }
 
@@ -149,7 +149,7 @@ func (n *FakeClientNode) ListClientDeals(ctx context.Context, addr address.Addre
 }
 
 // ListStorageProviders lists the providers in the storage market state
-func (n *FakeClientNode) ListStorageProviders(ctx context.Context) ([]*storagemarket.StorageProviderInfo, error) {
+func (n *FakeClientNode) ListStorageProviders(ctx context.Context, tok shared.TipSetToken) ([]*storagemarket.StorageProviderInfo, error) {
 	return n.SMState.Providers, nil
 }
 
@@ -180,8 +180,8 @@ func (n *FakeClientNode) OnDealSectorCommitted(ctx context.Context, provider add
 }
 
 // ValidateAskSignature returns the stubbed validation error
-func (n *FakeClientNode) ValidateAskSignature(ask *storagemarket.SignedStorageAsk) error {
-	return n.ValidationError
+func (n *FakeClientNode) ValidateAskSignature(ctx context.Context, ask *storagemarket.SignedStorageAsk, tok shared.TipSetToken) (bool, error) {
+	return n.ValidationError == nil, n.ValidationError
 }
 
 var _ storagemarket.StorageClientNode = (*FakeClientNode)(nil)
@@ -252,7 +252,7 @@ func (n *FakeProviderNode) OnDealSectorCommitted(ctx context.Context, provider a
 }
 
 // LocatePieceForDealWithinSector returns stubbed data for a pieces location in a sector
-func (n *FakeProviderNode) LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID) (sectorID uint64, offset uint64, length uint64, err error) {
+func (n *FakeProviderNode) LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID, tok shared.TipSetToken) (sectorID uint64, offset uint64, length uint64, err error) {
 	if n.LocatePieceForDealWithinSectorError == nil {
 		return n.PieceSectorID, 0, n.PieceLength, nil
 	}

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -179,7 +179,8 @@ func (n *FakeClientNode) OnDealSectorCommitted(ctx context.Context, provider add
 	return n.DealCommittedSyncError
 }
 
-// ValidateAskSignature returns the stubbed validation error
+// ValidateAskSignature returns the stubbed validation error and a boolean value
+// communicating the validity of the provided signature
 func (n *FakeClientNode) ValidateAskSignature(ctx context.Context, ask *storagemarket.SignedStorageAsk, tok shared.TipSetToken) (bool, error) {
 	return n.ValidationError == nil, n.ValidationError
 }

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -273,7 +273,7 @@ type StorageProvider interface {
 	ListAsks(addr address.Address) []*SignedStorageAsk
 
 	// ListDeals lists on-chain deals associated with this provider
-	ListDeals(ctx context.Context) ([]StorageDeal, error)
+	ListDeals(ctx context.Context, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// ListIncompleteDeals lists deals that are in progress or rejected
 	ListIncompleteDeals() ([]MinerDeal, error)
@@ -282,7 +282,7 @@ type StorageProvider interface {
 	AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error
 
 	// GetStorageCollateral returns the current collateral balance
-	GetStorageCollateral(ctx context.Context) (Balance, error)
+	GetStorageCollateral(ctx context.Context, tok shared.TipSetToken) (Balance, error)
 
 	ImportDataForDeal(ctx context.Context, propCid cid.Cid, data io.Reader) error
 }
@@ -292,7 +292,7 @@ type StorageProviderNode interface {
 	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
-	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
+	VerifySignature(ctx context.Context, signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
 
 	// Adds funds with the StorageMinerActor for a storage participant.  Used by both providers and clients.
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
@@ -321,7 +321,7 @@ type StorageProviderNode interface {
 
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, cb DealSectorCommittedCallback) error
 
-	LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID) (sectorID uint64, offset uint64, length uint64, err error)
+	LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID, tok shared.TipSetToken) (sectorID uint64, offset uint64, length uint64, err error)
 }
 
 type DealSectorCommittedCallback func(err error)
@@ -331,7 +331,7 @@ type StorageClientNode interface {
 	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
-	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
+	VerifySignature(ctx context.Context, signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
 
 	// Adds funds with the StorageMinerActor for a storage participant.  Used by both providers and clients.
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
@@ -348,7 +348,7 @@ type StorageClientNode interface {
 	//GetProviderInfo(stateId StateID, addr Address) *StorageProviderInfo
 
 	// GetStorageProviders returns information about known miners
-	ListStorageProviders(ctx context.Context) ([]*StorageProviderInfo, error)
+	ListStorageProviders(ctx context.Context, tok shared.TipSetToken) ([]*StorageProviderInfo, error)
 
 	// Subscribes to storage market actor state changes for a given address.
 	// TODO: Should there be a timeout option for this?  In the case that we are waiting for funds to be deposited and it never happens?
@@ -365,7 +365,7 @@ type StorageClientNode interface {
 
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, cb DealSectorCommittedCallback) error
 
-	ValidateAskSignature(ask *SignedStorageAsk) error
+	ValidateAskSignature(ctx context.Context, ask *SignedStorageAsk, tok shared.TipSetToken) (bool, error)
 }
 
 type StorageClientProofs interface {
@@ -406,10 +406,10 @@ type StorageClient interface {
 	Stop()
 
 	// ListProviders queries chain state and returns active storage providers
-	ListProviders(ctx context.Context) (<-chan StorageProviderInfo, error)
+	ListProviders(ctx context.Context, tok shared.TipSetToken) (<-chan StorageProviderInfo, error)
 
 	// ListDeals lists on-chain deals associated with this provider
-	ListDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
+	ListDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// ListInProgressDeals lists deals that are in progress or rejected
 	ListInProgressDeals(ctx context.Context) ([]ClientDeal, error)
@@ -418,7 +418,7 @@ type StorageClient interface {
 	GetInProgressDeal(ctx context.Context, cid cid.Cid) (ClientDeal, error)
 
 	// GetAsk returns the current ask for a storage provider
-	GetAsk(ctx context.Context, info StorageProviderInfo) (*SignedStorageAsk, error)
+	GetAsk(ctx context.Context, info StorageProviderInfo, tok shared.TipSetToken) (*SignedStorageAsk, error)
 
 	//// FindStorageOffers lists providers and queries them to find offers that satisfy some criteria based on price, duration, etc.
 	//FindStorageOffers(criteria AskCriteria, limit uint) []*StorageOffer
@@ -427,7 +427,7 @@ type StorageClient interface {
 	ProposeStorageDeal(ctx context.Context, addr address.Address, info *StorageProviderInfo, data *DataRef, startEpoch abi.ChainEpoch, endEpoch abi.ChainEpoch, price abi.TokenAmount, collateral abi.TokenAmount, rt abi.RegisteredProof) (*ProposeStorageDealResult, error)
 
 	// GetPaymentEscrow returns the current funds available for deal payment
-	GetPaymentEscrow(ctx context.Context, addr address.Address) (Balance, error)
+	GetPaymentEscrow(ctx context.Context, addr address.Address, tok shared.TipSetToken) (Balance, error)
 
 	// AddStorageCollateral adds storage collateral
 	AddPaymentEscrow(ctx context.Context, addr address.Address, amount abi.TokenAmount) error

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -273,7 +273,7 @@ type StorageProvider interface {
 	ListAsks(addr address.Address) []*SignedStorageAsk
 
 	// ListDeals lists on-chain deals associated with this provider
-	ListDeals(ctx context.Context, tok shared.TipSetToken) ([]StorageDeal, error)
+	ListDeals(ctx context.Context) ([]StorageDeal, error)
 
 	// ListIncompleteDeals lists deals that are in progress or rejected
 	ListIncompleteDeals() ([]MinerDeal, error)
@@ -282,7 +282,7 @@ type StorageProvider interface {
 	AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error
 
 	// GetStorageCollateral returns the current collateral balance
-	GetStorageCollateral(ctx context.Context, tok shared.TipSetToken) (Balance, error)
+	GetStorageCollateral(ctx context.Context) (Balance, error)
 
 	ImportDataForDeal(ctx context.Context, propCid cid.Cid, data io.Reader) error
 }
@@ -406,10 +406,10 @@ type StorageClient interface {
 	Stop()
 
 	// ListProviders queries chain state and returns active storage providers
-	ListProviders(ctx context.Context, tok shared.TipSetToken) (<-chan StorageProviderInfo, error)
+	ListProviders(ctx context.Context) (<-chan StorageProviderInfo, error)
 
 	// ListDeals lists on-chain deals associated with this provider
-	ListDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
+	ListDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
 
 	// ListInProgressDeals lists deals that are in progress or rejected
 	ListInProgressDeals(ctx context.Context) ([]ClientDeal, error)
@@ -418,7 +418,7 @@ type StorageClient interface {
 	GetInProgressDeal(ctx context.Context, cid cid.Cid) (ClientDeal, error)
 
 	// GetAsk returns the current ask for a storage provider
-	GetAsk(ctx context.Context, info StorageProviderInfo, tok shared.TipSetToken) (*SignedStorageAsk, error)
+	GetAsk(ctx context.Context, info StorageProviderInfo) (*SignedStorageAsk, error)
 
 	//// FindStorageOffers lists providers and queries them to find offers that satisfy some criteria based on price, duration, etc.
 	//FindStorageOffers(criteria AskCriteria, limit uint) []*StorageOffer
@@ -427,7 +427,7 @@ type StorageClient interface {
 	ProposeStorageDeal(ctx context.Context, addr address.Address, info *StorageProviderInfo, data *DataRef, startEpoch abi.ChainEpoch, endEpoch abi.ChainEpoch, price abi.TokenAmount, collateral abi.TokenAmount, rt abi.RegisteredProof) (*ProposeStorageDealResult, error)
 
 	// GetPaymentEscrow returns the current funds available for deal payment
-	GetPaymentEscrow(ctx context.Context, addr address.Address, tok shared.TipSetToken) (Balance, error)
+	GetPaymentEscrow(ctx context.Context, addr address.Address) (Balance, error)
 
 	// AddStorageCollateral adds storage collateral
 	AddPaymentEscrow(ctx context.Context, addr address.Address, amount abi.TokenAmount) error

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -292,23 +292,23 @@ type StorageProviderNode interface {
 	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
-	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool
+	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
 
 	// Adds funds with the StorageMinerActor for a storage participant.  Used by both providers and clients.
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
 
 	// Ensures that a storage market participant has a certain amount of available funds
 	// If additional funds are needed, they will be sent from the 'wallet' address
-	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error
+	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount, tok shared.TipSetToken) error
 
 	// GetBalance returns locked/unlocked for a storage participant.  Used by both providers and clients.
-	GetBalance(ctx context.Context, addr address.Address) (Balance, error)
+	GetBalance(ctx context.Context, addr address.Address, tok shared.TipSetToken) (Balance, error)
 
 	// Publishes deal on chain
 	PublishDeals(ctx context.Context, deal MinerDeal) (abi.DealID, cid.Cid, error)
 
 	// ListProviderDeals lists all deals associated with a storage provider
-	ListProviderDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
+	ListProviderDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// Called when a deal is complete and on chain, and data has been transferred and is ready to be added to a sector
 	OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize abi.UnpaddedPieceSize, pieceReader io.Reader) error
@@ -331,18 +331,18 @@ type StorageClientNode interface {
 	GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 
 	// Verify a signature against an address + data
-	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte) bool
+	VerifySignature(signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
 
 	// Adds funds with the StorageMinerActor for a storage participant.  Used by both providers and clients.
 	AddFunds(ctx context.Context, addr address.Address, amount abi.TokenAmount) error
 
-	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount) error
+	EnsureFunds(ctx context.Context, addr, wallet address.Address, amount abi.TokenAmount, tok shared.TipSetToken) error
 
 	// GetBalance returns locked/unlocked for a storage participant.  Used by both providers and clients.
-	GetBalance(ctx context.Context, addr address.Address) (Balance, error)
+	GetBalance(ctx context.Context, addr address.Address, tok shared.TipSetToken) (Balance, error)
 
 	//// ListClientDeals lists all on-chain deals associated with a storage client
-	ListClientDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
+	ListClientDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// GetProviderInfo returns information about a single storage provider
 	//GetProviderInfo(stateId StateID, addr Address) *StorageProviderInfo


### PR DESCRIPTION
## Why does this PR exist?

This is the last (hopefully) PR in a chain of PRs which pass chain state identifiers to methods on the `Node*` interfaces.