### PR TITLE
rename list deals interface & impls

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -131,7 +131,7 @@ func (c *Client) ListDeals(ctx context.Context, addr address.Address) ([]storage
 	return c.node.ListClientDeals(ctx, addr, tok)
 }
 
-func (c *Client) ListInProgressDeals(ctx context.Context) ([]storagemarket.ClientDeal, error) {
+func (c *Client) ListLocalDeals(ctx context.Context) ([]storagemarket.ClientDeal, error) {
 	var out []storagemarket.ClientDeal
 	if err := c.statemachines.List(&out); err != nil {
 		return nil, err

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -139,7 +139,7 @@ func (c *Client) ListLocalDeals(ctx context.Context) ([]storagemarket.ClientDeal
 	return out, nil
 }
 
-func (c *Client) GetInProgressDeal(ctx context.Context, cid cid.Cid) (storagemarket.ClientDeal, error) {
+func (c *Client) GetLocalDeal(ctx context.Context, cid cid.Cid) (storagemarket.ClientDeal, error) {
 	var out storagemarket.ClientDeal
 	if err := c.statemachines.Get(cid).Get(&out); err != nil {
 		return storagemarket.ClientDeal{}, err

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -254,7 +254,7 @@ func (p *Provider) GetStorageCollateral(ctx context.Context) (storagemarket.Bala
 	return p.spn.GetBalance(ctx, p.actor, tok)
 }
 
-func (p *Provider) ListIncompleteDeals() ([]storagemarket.MinerDeal, error) {
+func (p *Provider) ListLocalDeals() ([]storagemarket.MinerDeal, error) {
 	var out []storagemarket.MinerDeal
 	if err := p.deals.List(&out); err != nil {
 		return nil, err

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -114,7 +114,7 @@ func TestMakeDeal(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	cd, err := client.GetInProgressDeal(ctx, proposalCid)
+	cd, err := client.GetLocalDeal(ctx, proposalCid)
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealActive)
 
@@ -208,7 +208,7 @@ func TestMakeDealOffline(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	cd, err := client.GetInProgressDeal(ctx, proposalCid)
+	cd, err := client.GetLocalDeal(ctx, proposalCid)
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealValidating)
 
@@ -228,7 +228,7 @@ func TestMakeDealOffline(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 100)
 
-	cd, err = client.GetInProgressDeal(ctx, proposalCid)
+	cd, err = client.GetLocalDeal(ctx, proposalCid)
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealActive)
 

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -118,7 +118,7 @@ func TestMakeDeal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealActive)
 
-	providerDeals, err := provider.ListIncompleteDeals()
+	providerDeals, err := provider.ListLocalDeals()
 	assert.NoError(t, err)
 
 	pd := providerDeals[0]
@@ -212,7 +212,7 @@ func TestMakeDealOffline(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealValidating)
 
-	providerDeals, err := provider.ListIncompleteDeals()
+	providerDeals, err := provider.ListLocalDeals()
 	assert.NoError(t, err)
 
 	pd := providerDeals[0]
@@ -232,7 +232,7 @@ func TestMakeDealOffline(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cd.State, storagemarket.StorageDealActive)
 
-	providerDeals, err = provider.ListIncompleteDeals()
+	providerDeals, err = provider.ListLocalDeals()
 	assert.NoError(t, err)
 
 	pd = providerDeals[0]

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -275,8 +275,8 @@ type StorageProvider interface {
 	// ListDeals lists on-chain deals associated with this provider
 	ListDeals(ctx context.Context) ([]StorageDeal, error)
 
-	// ListIncompleteDeals lists deals that are in progress or rejected
-	ListIncompleteDeals() ([]MinerDeal, error)
+	// ListLocalDeals lists deals that are in progress or rejected
+	ListLocalDeals() ([]MinerDeal, error)
 
 	// AddStorageCollateral adds storage collateral
 	AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error
@@ -411,10 +411,10 @@ type StorageClient interface {
 	// ListDeals lists on-chain deals associated with this provider
 	ListDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
 
-	// ListInProgressDeals lists deals that are in progress or rejected
-	ListInProgressDeals(ctx context.Context) ([]ClientDeal, error)
+	// ListLocalDeals lists deals that are in progress or rejected
+	ListLocalDeals(ctx context.Context) ([]ClientDeal, error)
 
-	// ListInProgressDeals lists deals that are in progress or rejected
+	// ListLocalDeals lists deals that are in progress or rejected
 	GetInProgressDeal(ctx context.Context, cid cid.Cid) (ClientDeal, error)
 
 	// GetAsk returns the current ask for a storage provider

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -414,8 +414,8 @@ type StorageClient interface {
 	// ListLocalDeals lists deals that are in progress or rejected
 	ListLocalDeals(ctx context.Context) ([]ClientDeal, error)
 
-	// ListLocalDeals lists deals that are in progress or rejected
-	GetInProgressDeal(ctx context.Context, cid cid.Cid) (ClientDeal, error)
+	// GetLocalDeal lists deals that are in progress or rejected
+	GetLocalDeal(ctx context.Context, cid cid.Cid) (ClientDeal, error)
 
 	// GetAsk returns the current ask for a storage provider
 	GetAsk(ctx context.Context, info StorageProviderInfo) (*SignedStorageAsk, error)

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -272,10 +272,10 @@ type StorageProvider interface {
 	// ListAsks lists current asks
 	ListAsks(addr address.Address) []*SignedStorageAsk
 
-	// ListDeals lists on-chain deals associated with this provider
+	// ListDeals lists on-chain deals associated with this storage provider
 	ListDeals(ctx context.Context) ([]StorageDeal, error)
 
-	// ListLocalDeals lists deals that are in progress or rejected
+	// ListLocalDeals lists deals processed by this storage provider
 	ListLocalDeals() ([]MinerDeal, error)
 
 	// AddStorageCollateral adds storage collateral
@@ -341,7 +341,7 @@ type StorageClientNode interface {
 	// GetBalance returns locked/unlocked for a storage participant.  Used by both providers and clients.
 	GetBalance(ctx context.Context, addr address.Address, tok shared.TipSetToken) (Balance, error)
 
-	//// ListClientDeals lists all on-chain deals associated with a storage client
+	// ListClientDeals lists all on-chain deals associated with a storage client
 	ListClientDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// GetProviderInfo returns information about a single storage provider
@@ -408,10 +408,10 @@ type StorageClient interface {
 	// ListProviders queries chain state and returns active storage providers
 	ListProviders(ctx context.Context) (<-chan StorageProviderInfo, error)
 
-	// ListDeals lists on-chain deals associated with this provider
+	// ListDeals lists on-chain deals associated with this storage client
 	ListDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
 
-	// ListLocalDeals lists deals that are in progress or rejected
+	// ListLocalDeals lists deals initiated by this storage client
 	ListLocalDeals(ctx context.Context) ([]ClientDeal, error)
 
 	// GetLocalDeal lists deals that are in progress or rejected


### PR DESCRIPTION
Closes #173, Cleanup: Rename ListInProgressDeals, ListIncompleteDeals to ListLocalDeals

> Rename StorageClient.ListInProgressDeals -> StorageClient.ListLocalDeals
> Rename StorageProvider.ListIncompleteDeals -> StorageProvider.ListLocalDeals
> Change in implementations and get tests passing as needed