### PR TITLE
Support specifying PieceCID in retrievals

### DIFF
--- a/piecestore/types_cbor_gen.go
+++ b/piecestore/types_cbor_gen.go
@@ -111,24 +111,29 @@ func (t *DealInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.DealID))); err != nil {
 		return err
 	}
 
 	// t.SectorID (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SectorID))); err != nil {
 		return err
 	}
 
 	// t.Offset (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Offset))); err != nil {
 		return err
 	}
 
 	// t.Length (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Length))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -149,44 +154,60 @@ func (t *DealInfo) UnmarshalCBOR(r io.Reader) error {
 
 	// t.DealID (abi.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealID = abi.DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.DealID = abi.DealID(extra)
 	// t.SectorID (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SectorID = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.SectorID = uint64(extra)
 	// t.Offset (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Offset = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Offset = uint64(extra)
 	// t.Length (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Length = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Length = uint64(extra)
 	return nil
 }
 
@@ -200,14 +221,17 @@ func (t *BlockLocation) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.RelOffset (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.RelOffset))); err != nil {
 		return err
 	}
 
 	// t.BlockSize (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.BlockSize))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -228,24 +252,32 @@ func (t *BlockLocation) UnmarshalCBOR(r io.Reader) error {
 
 	// t.RelOffset (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.RelOffset = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.RelOffset = uint64(extra)
 	// t.BlockSize (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.BlockSize = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.BlockSize = uint64(extra)
 	return nil
 }
 
@@ -292,7 +324,7 @@ func (t *PieceBlockLocation) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.BlockLocation.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.BlockLocation: %w", err)
 		}
 
 	}

--- a/retrievalmarket/impl/blockunsealing/blockunsealing.go
+++ b/retrievalmarket/impl/blockunsealing/blockunsealing.go
@@ -26,6 +26,7 @@ type loaderWithUnsealing struct {
 	pieceStore piecestore.PieceStore
 	carIO      pieceio.CarIO
 	unsealer   UnsealingFunc
+	pieceCid   *cid.Cid
 }
 
 // UnsealingFunc is a function that unseals sectors at a given offset and length
@@ -33,8 +34,8 @@ type UnsealingFunc func(ctx context.Context, sectorId uint64, offset uint64, len
 
 // NewLoaderWithUnsealing creates a loader that will attempt to read blocks from the blockstore but unseal the piece
 // as needed using the passed unsealing function
-func NewLoaderWithUnsealing(ctx context.Context, bs blockstore.Blockstore, pieceStore piecestore.PieceStore, carIO pieceio.CarIO, unsealer UnsealingFunc) LoaderWithUnsealing {
-	return &loaderWithUnsealing{ctx, bs, pieceStore, carIO, unsealer}
+func NewLoaderWithUnsealing(ctx context.Context, bs blockstore.Blockstore, pieceStore piecestore.PieceStore, carIO pieceio.CarIO, unsealer UnsealingFunc, pieceCid *cid.Cid) LoaderWithUnsealing {
+	return &loaderWithUnsealing{ctx, bs, pieceStore, carIO, unsealer, pieceCid}
 }
 
 func (lu *loaderWithUnsealing) Load(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
@@ -66,13 +67,21 @@ func (lu *loaderWithUnsealing) Load(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.
 }
 
 func (lu *loaderWithUnsealing) attemptUnseal(c cid.Cid) error {
+	var err error
+	var reader io.Reader
+	var cidInfo piecestore.CIDInfo
 
-	cidInfo, err := lu.pieceStore.GetCIDInfo(c)
-	if err != nil {
-		return xerrors.Errorf("error looking up information on CID: %w", err)
+	// if the deal proposal specified a Piece CID, only check that piece
+	if lu.pieceCid != nil {
+		reader, err = lu.firstSuccessfulUnsealByPieceCID(*lu.pieceCid)
+	} else {
+		cidInfo, err = lu.pieceStore.GetCIDInfo(c)
+		if err != nil {
+			return xerrors.Errorf("error looking up information on CID: %w", err)
+		}
+
+		reader, err = lu.firstSuccessfulUnseal(cidInfo)
 	}
-
-	reader, err := lu.firstSuccessfulUnseal(cidInfo)
 	// no successful unseal
 	if err != nil {
 		return xerrors.Errorf("Unable to unseal piece: %w", err)
@@ -87,21 +96,32 @@ func (lu *loaderWithUnsealing) attemptUnseal(c cid.Cid) error {
 	return nil
 }
 
-func (lu *loaderWithUnsealing) firstSuccessfulUnseal(cidInfo piecestore.CIDInfo) (io.ReadCloser, error) {
+func (lu *loaderWithUnsealing) firstSuccessfulUnseal(payloadCidInfo piecestore.CIDInfo) (io.ReadCloser, error) {
+	var lastErr error
+	for _, pieceBlockLocation := range payloadCidInfo.PieceBlockLocations {
+		reader, err := lu.firstSuccessfulUnsealByPieceCID(pieceBlockLocation.PieceCID)
+		if err == nil {
+			return reader, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func (lu *loaderWithUnsealing) firstSuccessfulUnsealByPieceCID(pieceCID cid.Cid) (io.ReadCloser, error) {
+	pieceInfo, err := lu.pieceStore.GetPieceInfo(pieceCID)
+	if err != nil {
+		return nil, err
+	}
+
 	// try to unseal data from all pieces
 	lastErr := xerrors.New("no sectors found to unseal from")
-	for _, pieceBlockLocation := range cidInfo.PieceBlockLocations {
-		pieceInfo, err := lu.pieceStore.GetPieceInfo(pieceBlockLocation.PieceCID)
-		if err != nil {
-			continue
+	for _, deal := range pieceInfo.Deals {
+		reader, err := lu.unsealer(lu.ctx, deal.SectorID, deal.Offset, deal.Length)
+		if err == nil {
+			return reader, nil
 		}
-		for _, deal := range pieceInfo.Deals {
-			reader, err := lu.unsealer(lu.ctx, deal.SectorID, deal.Offset, deal.Length)
-			if err == nil {
-				return reader, nil
-			}
-			lastErr = err
-		}
+		lastErr = err
 	}
 	return nil, lastErr
 }

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -236,7 +236,7 @@ func (p *provider) newProviderDeal(stream rmnet.RetrievalDealStream) error {
 
 	p.dealStreams[pds.Identifier()] = stream
 
-	loaderWithUnsealing := blockunsealing.NewLoaderWithUnsealing(context.TODO(), p.bs, p.pieceStore, cario.NewCarIO(), p.node.UnsealSector)
+	loaderWithUnsealing := blockunsealing.NewLoaderWithUnsealing(context.TODO(), p.bs, p.pieceStore, cario.NewCarIO(), p.node.UnsealSector, dealProposal.PieceCID)
 
 	br := blockio.NewSelectorBlockReader(cidlink.Link{Cid: dealProposal.PayloadCID}, allSelector(), loaderWithUnsealing.Load)
 	p.blockReaders[pds.Identifier()] = br

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -525,6 +525,7 @@ func IsTerminalStatus(status DealStatus) bool {
 // Params are the parameters requested for a retrieval deal proposal
 type Params struct {
 	Selector                *cbg.Deferred // V1
+	PieceCID                *cid.Cid
 	PricePerByte            abi.TokenAmount
 	PaymentInterval         uint64 // when to request payment
 	PaymentIntervalIncrease uint64 //
@@ -540,7 +541,7 @@ func NewParamsV0(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIn
 }
 
 // NewParamsV1 generates parameters for a retrieval deal, including a selector
-func NewParamsV1(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64, sel ipld.Node) Params {
+func NewParamsV1(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIntervalIncrease uint64, sel ipld.Node, pieceCid *cid.Cid) Params {
 	var buffer bytes.Buffer
 	err := dagcbor.Encoder(sel, &buffer)
 	if err != nil {
@@ -549,6 +550,7 @@ func NewParamsV1(pricePerByte abi.TokenAmount, paymentInterval uint64, paymentIn
 
 	return Params{
 		Selector:                &cbg.Deferred{Raw: buffer.Bytes()},
+		PieceCID:                pieceCid,
 		PricePerByte:            pricePerByte,
 		PaymentInterval:         paymentInterval,
 		PaymentIntervalIncrease: paymentIntervalIncrease,

--- a/retrievalmarket/types_cbor_gen.go
+++ b/retrievalmarket/types_cbor_gen.go
@@ -68,7 +68,7 @@ func (t *Query) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.QueryParams.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.QueryParams: %w", err)
 		}
 
 	}
@@ -85,16 +85,19 @@ func (t *QueryResponse) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Status (retrievalmarket.QueryResponseStatus) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Status))); err != nil {
 		return err
 	}
 
 	// t.PieceCIDFound (retrievalmarket.QueryItemStatus) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PieceCIDFound))); err != nil {
 		return err
 	}
 
 	// t.Size (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Size))); err != nil {
 		return err
 	}
@@ -110,11 +113,13 @@ func (t *QueryResponse) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.MaxPaymentInterval (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.MaxPaymentInterval))); err != nil {
 		return err
 	}
 
 	// t.MaxPaymentIntervalIncrease (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.MaxPaymentIntervalIncrease))); err != nil {
 		return err
 	}
@@ -150,40 +155,52 @@ func (t *QueryResponse) UnmarshalCBOR(r io.Reader) error {
 
 	// t.Status (retrievalmarket.QueryResponseStatus) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Status = QueryResponseStatus(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Status = QueryResponseStatus(extra)
 	// t.PieceCIDFound (retrievalmarket.QueryItemStatus) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.PieceCIDFound = QueryItemStatus(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.PieceCIDFound = QueryItemStatus(extra)
 	// t.Size (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Size = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Size = uint64(extra)
 	// t.PaymentAddress (address.Address) (struct)
 
 	{
 
 		if err := t.PaymentAddress.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PaymentAddress: %w", err)
 		}
 
 	}
@@ -192,30 +209,38 @@ func (t *QueryResponse) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.MinPricePerByte.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.MinPricePerByte: %w", err)
 		}
 
 	}
 	// t.MaxPaymentInterval (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.MaxPaymentInterval = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.MaxPaymentInterval = uint64(extra)
 	// t.MaxPaymentIntervalIncrease (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.MaxPaymentIntervalIncrease = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.MaxPaymentIntervalIncrease = uint64(extra)
 	// t.Message (string) (string)
 
 	{
@@ -245,6 +270,7 @@ func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ID))); err != nil {
 		return err
 	}
@@ -285,20 +311,24 @@ func (t *DealProposal) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.ID (retrievalmarket.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.ID = DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.ID = DealID(extra)
 	// t.Params (retrievalmarket.Params) (struct)
 
 	{
 
 		if err := t.Params.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Params: %w", err)
 		}
 
 	}
@@ -315,11 +345,13 @@ func (t *DealResponse) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Status))); err != nil {
 		return err
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ID))); err != nil {
 		return err
 	}
@@ -374,30 +406,38 @@ func (t *DealResponse) UnmarshalCBOR(r io.Reader) error {
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Status = DealStatus(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Status = DealStatus(extra)
 	// t.ID (retrievalmarket.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.ID = DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.ID = DealID(extra)
 	// t.PaymentOwed (big.Int) (struct)
 
 	{
 
 		if err := t.PaymentOwed.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PaymentOwed: %w", err)
 		}
 
 	}
@@ -446,7 +486,7 @@ func (t *Params) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{132}); err != nil {
+	if _, err := w.Write([]byte{133}); err != nil {
 		return err
 	}
 
@@ -455,20 +495,35 @@ func (t *Params) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.PieceCID (cid.Cid) (struct)
+
+	if t.PieceCID == nil {
+		if _, err := w.Write(cbg.CborNull); err != nil {
+			return err
+		}
+	} else {
+		if err := cbg.WriteCid(w, *t.PieceCID); err != nil {
+			return xerrors.Errorf("failed to write cid field t.PieceCID: %w", err)
+		}
+	}
+
 	// t.PricePerByte (big.Int) (struct)
 	if err := t.PricePerByte.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PaymentInterval (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PaymentInterval))); err != nil {
 		return err
 	}
 
 	// t.PaymentIntervalIncrease (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PaymentIntervalIncrease))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -483,7 +538,7 @@ func (t *Params) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 4 {
+	if extra != 5 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -503,8 +558,32 @@ func (t *Params) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Selector = new(cbg.Deferred)
 			if err := t.Selector.UnmarshalCBOR(br); err != nil {
+				return xerrors.Errorf("unmarshaling t.Selector pointer: %w", err)
+			}
+		}
+
+	}
+	// t.PieceCID (cid.Cid) (struct)
+
+	{
+
+		pb, err := br.PeekByte()
+		if err != nil {
+			return err
+		}
+		if pb == cbg.CborNull[0] {
+			var nbuf [1]byte
+			if _, err := br.Read(nbuf[:]); err != nil {
 				return err
 			}
+		} else {
+
+			c, err := cbg.ReadCid(br)
+			if err != nil {
+				return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+			}
+
+			t.PieceCID = &c
 		}
 
 	}
@@ -513,30 +592,38 @@ func (t *Params) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.PricePerByte.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PricePerByte: %w", err)
 		}
 
 	}
 	// t.PaymentInterval (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.PaymentInterval = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.PaymentInterval = uint64(extra)
 	// t.PaymentIntervalIncrease (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.PaymentIntervalIncrease = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.PaymentIntervalIncrease = uint64(extra)
 	return nil
 }
 
@@ -616,6 +703,7 @@ func (t *DealPayment) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.ID))); err != nil {
 		return err
 	}
@@ -649,20 +737,24 @@ func (t *DealPayment) UnmarshalCBOR(r io.Reader) error {
 
 	// t.ID (retrievalmarket.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.ID = DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.ID = DealID(extra)
 	// t.PaymentChannel (address.Address) (struct)
 
 	{
 
 		if err := t.PaymentChannel.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PaymentChannel: %w", err)
 		}
 
 	}
@@ -682,7 +774,7 @@ func (t *DealPayment) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.PaymentVoucher = new(paych.SignedVoucher)
 			if err := t.PaymentVoucher.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.PaymentVoucher pointer: %w", err)
 			}
 		}
 
@@ -812,6 +904,7 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Status))); err != nil {
 		return err
 	}
@@ -829,6 +922,7 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.TotalReceived (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.TotalReceived))); err != nil {
 		return err
 	}
@@ -846,11 +940,13 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.BytesPaidFor (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.BytesPaidFor))); err != nil {
 		return err
 	}
 
 	// t.CurrentInterval (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.CurrentInterval))); err != nil {
 		return err
 	}
@@ -887,7 +983,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
 		}
 
 	}
@@ -896,7 +992,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.TotalFunds.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.TotalFunds: %w", err)
 		}
 
 	}
@@ -905,7 +1001,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.ClientWallet.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.ClientWallet: %w", err)
 		}
 
 	}
@@ -914,7 +1010,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.MinerWallet.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.MinerWallet: %w", err)
 		}
 
 	}
@@ -934,21 +1030,25 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.PaymentInfo = new(PaymentInfo)
 			if err := t.PaymentInfo.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.PaymentInfo pointer: %w", err)
 			}
 		}
 
 	}
 	// t.Status (retrievalmarket.DealStatus) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Status = DealStatus(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Status = DealStatus(extra)
 	// t.Sender (peer.ID) (string)
 
 	{
@@ -961,14 +1061,18 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.TotalReceived (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.TotalReceived = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.TotalReceived = uint64(extra)
 	// t.Message (string) (string)
 
 	{
@@ -981,30 +1085,38 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.BytesPaidFor (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.BytesPaidFor = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.BytesPaidFor = uint64(extra)
 	// t.CurrentInterval (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.CurrentInterval = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.CurrentInterval = uint64(extra)
 	// t.PaymentRequested (big.Int) (struct)
 
 	{
 
 		if err := t.PaymentRequested.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PaymentRequested: %w", err)
 		}
 
 	}
@@ -1013,7 +1125,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.FundsSpent.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.FundsSpent: %w", err)
 		}
 
 	}
@@ -1035,6 +1147,7 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Status))); err != nil {
 		return err
 	}
@@ -1052,6 +1165,7 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.TotalSent (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.TotalSent))); err != nil {
 		return err
 	}
@@ -1074,9 +1188,11 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.CurrentInterval (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.CurrentInterval))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -1100,20 +1216,24 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
 		}
 
 	}
 	// t.Status (retrievalmarket.DealStatus) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Status = DealStatus(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Status = DealStatus(extra)
 	// t.Receiver (peer.ID) (string)
 
 	{
@@ -1126,20 +1246,24 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.TotalSent (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.TotalSent = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.TotalSent = uint64(extra)
 	// t.FundsReceived (big.Int) (struct)
 
 	{
 
 		if err := t.FundsReceived.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.FundsReceived: %w", err)
 		}
 
 	}
@@ -1155,14 +1279,18 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.CurrentInterval (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.CurrentInterval = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.CurrentInterval = uint64(extra)
 	return nil
 }
 
@@ -1181,9 +1309,11 @@ func (t *PaymentInfo) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Lane (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Lane))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -1207,19 +1337,23 @@ func (t *PaymentInfo) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.PayCh.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.PayCh: %w", err)
 		}
 
 	}
 	// t.Lane (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Lane = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Lane = uint64(extra)
 	return nil
 }

--- a/retrievalmarket/types_test.go
+++ b/retrievalmarket/types_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
 func TestParamsMarshalUnmarshal(t *testing.T) {
+	pieceCid := tut.GenerateCids(1)[0]
+
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
 	node := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-	params := retrievalmarket.NewParamsV1(abi.NewTokenAmount(123), 456, 789, node)
+	params := retrievalmarket.NewParamsV1(abi.NewTokenAmount(123), 456, 789, node, &pieceCid)
 
 	buf := new(bytes.Buffer)
 	err := params.MarshalCBOR(buf)

--- a/shared_testutil/test_piecestore.go
+++ b/shared_testutil/test_piecestore.go
@@ -15,6 +15,7 @@ import (
 type TestPieceStore struct {
 	addPieceBlockLocationsError error
 	addDealForPieceError        error
+	getPieceInfoError           error
 	piecesStubbed               map[cid.Cid]piecestore.PieceInfo
 	piecesExpected              map[cid.Cid]struct{}
 	piecesReceived              map[cid.Cid]struct{}
@@ -27,6 +28,7 @@ type TestPieceStore struct {
 type TestPieceStoreParams struct {
 	AddDealForPieceError        error
 	AddPieceBlockLocationsError error
+	GetPieceInfoError           error
 }
 
 var _ piecestore.PieceStore = &TestPieceStore{}
@@ -41,6 +43,7 @@ func NewTestPieceStoreWithParams(params TestPieceStoreParams) *TestPieceStore {
 	return &TestPieceStore{
 		addDealForPieceError:        params.AddDealForPieceError,
 		addPieceBlockLocationsError: params.AddPieceBlockLocationsError,
+		getPieceInfoError:           params.GetPieceInfoError,
 		piecesStubbed:               make(map[cid.Cid]piecestore.PieceInfo),
 		piecesExpected:              make(map[cid.Cid]struct{}),
 		piecesReceived:              make(map[cid.Cid]struct{}),
@@ -102,6 +105,10 @@ func (tps *TestPieceStore) AddPieceBlockLocations(pieceCID cid.Cid, blockLocatio
 
 // GetPieceInfo returns a piece info if it's been stubbed
 func (tps *TestPieceStore) GetPieceInfo(pieceCID cid.Cid) (piecestore.PieceInfo, error) {
+	if tps.getPieceInfoError != nil {
+		return piecestore.PieceInfoUndefined, tps.getPieceInfoError
+	}
+
 	tps.piecesReceived[pieceCID] = struct{}{}
 
 	pio, ok := tps.piecesStubbed[pieceCID]

--- a/storagemarket/impl/blockrecorder/blockrecorder_cbor_gen.go
+++ b/storagemarket/impl/blockrecorder/blockrecorder_cbor_gen.go
@@ -28,14 +28,17 @@ func (t *PieceBlockMetadata) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Offset (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Offset))); err != nil {
 		return err
 	}
 
 	// t.Size (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.Size))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -68,23 +71,31 @@ func (t *PieceBlockMetadata) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.Offset (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Offset = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Offset = uint64(extra)
 	// t.Size (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.Size = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.Size = uint64(extra)
 	return nil
 }

--- a/storagemarket/network/types_cbor_gen.go
+++ b/storagemarket/network/types_cbor_gen.go
@@ -51,7 +51,7 @@ func (t *AskRequest) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.Miner.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
 		}
 
 	}
@@ -105,7 +105,7 @@ func (t *AskResponse) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Ask = new(storagemarket.SignedStorageAsk)
 			if err := t.Ask.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
 			}
 		}
 
@@ -165,7 +165,7 @@ func (t *Proposal) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.DealProposal = new(market.ClientDealProposal)
 			if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.DealProposal pointer: %w", err)
 			}
 		}
 
@@ -186,7 +186,7 @@ func (t *Proposal) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Piece = new(storagemarket.DataRef)
 			if err := t.Piece.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Piece pointer: %w", err)
 			}
 		}
 
@@ -204,6 +204,7 @@ func (t *Response) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.State (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.State))); err != nil {
 		return err
 	}
@@ -258,14 +259,18 @@ func (t *Response) UnmarshalCBOR(r io.Reader) error {
 
 	// t.State (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.State = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.State = uint64(extra)
 	// t.Message (string) (string)
 
 	{
@@ -356,7 +361,7 @@ func (t *SignedResponse) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.Response.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Response: %w", err)
 		}
 
 	}
@@ -376,7 +381,7 @@ func (t *SignedResponse) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Signature = new(crypto.Signature)
 			if err := t.Signature.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
 			}
 		}
 

--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -37,6 +37,7 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.State (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.State))); err != nil {
 		return err
 	}
@@ -59,6 +60,7 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.DealID))); err != nil {
 		return err
 	}
@@ -115,7 +117,7 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
 		}
 
 	}
@@ -133,14 +135,18 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.State (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.State = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.State = uint64(extra)
 	// t.Miner (peer.ID) (string)
 
 	{
@@ -156,20 +162,24 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.MinerWorker.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.MinerWorker: %w", err)
 		}
 
 	}
 	// t.DealID (abi.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealID = abi.DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.DealID = abi.DealID(extra)
 	// t.DataRef (storagemarket.DataRef) (struct)
 
 	{
@@ -186,7 +196,7 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.DataRef = new(DataRef)
 			if err := t.DataRef.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.DataRef pointer: %w", err)
 			}
 		}
 
@@ -273,6 +283,7 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.State (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.State))); err != nil {
 		return err
 	}
@@ -324,9 +335,11 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.DealID))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -350,7 +363,7 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
 		}
 
 	}
@@ -388,14 +401,18 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.State (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.State = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.State = uint64(extra)
 	// t.PiecePath (filestore.Path) (string)
 
 	{
@@ -459,21 +476,25 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Ref = new(DataRef)
 			if err := t.Ref.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Ref pointer: %w", err)
 			}
 		}
 
 	}
 	// t.DealID (abi.DealID) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.DealID = abi.DealID(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.DealID = abi.DealID(extra)
 	return nil
 }
 
@@ -518,7 +539,7 @@ func (t *Balance) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.Locked.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Locked: %w", err)
 		}
 
 	}
@@ -527,7 +548,7 @@ func (t *Balance) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.Available.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Available: %w", err)
 		}
 
 	}
@@ -586,7 +607,7 @@ func (t *SignedStorageAsk) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Ask = new(StorageAsk)
 			if err := t.Ask.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
 			}
 		}
 
@@ -607,7 +628,7 @@ func (t *SignedStorageAsk) UnmarshalCBOR(r io.Reader) error {
 		} else {
 			t.Signature = new(crypto.Signature)
 			if err := t.Signature.UnmarshalCBOR(br); err != nil {
-				return err
+				return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
 			}
 		}
 
@@ -630,6 +651,7 @@ func (t *StorageAsk) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.MinPieceSize (abi.PaddedPieceSize) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.MinPieceSize))); err != nil {
 		return err
 	}
@@ -662,9 +684,11 @@ func (t *StorageAsk) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.SeqNo (uint64) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.SeqNo))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -688,26 +712,30 @@ func (t *StorageAsk) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.Price.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Price: %w", err)
 		}
 
 	}
 	// t.MinPieceSize (abi.PaddedPieceSize) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.MinPieceSize = abi.PaddedPieceSize(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.MinPieceSize = abi.PaddedPieceSize(extra)
 	// t.Miner (address.Address) (struct)
 
 	{
 
 		if err := t.Miner.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
 		}
 
 	}
@@ -763,14 +791,18 @@ func (t *StorageAsk) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.SeqNo (uint64) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.SeqNo = uint64(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.SeqNo = uint64(extra)
 	return nil
 }
 
@@ -815,7 +847,7 @@ func (t *StorageDeal) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
 		}
 
 	}
@@ -824,7 +856,7 @@ func (t *StorageDeal) UnmarshalCBOR(r io.Reader) error {
 	{
 
 		if err := t.DealState.UnmarshalCBOR(br); err != nil {
-			return err
+			return xerrors.Errorf("unmarshaling t.DealState: %w", err)
 		}
 
 	}
@@ -871,9 +903,11 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
+
 	if _, err := w.Write(cbg.CborEncodeMajorType(cbg.MajUnsignedInt, uint64(t.PieceSize))); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -940,13 +974,17 @@ func (t *DataRef) UnmarshalCBOR(r io.Reader) error {
 	}
 	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
 
-	maj, extra, err = cbg.CborReadHeader(br)
-	if err != nil {
-		return err
+	{
+
+		maj, extra, err = cbg.CborReadHeader(br)
+		if err != nil {
+			return err
+		}
+		if maj != cbg.MajUnsignedInt {
+			return fmt.Errorf("wrong type for uint64 field")
+		}
+		t.PieceSize = abi.UnpaddedPieceSize(extra)
+
 	}
-	if maj != cbg.MajUnsignedInt {
-		return fmt.Errorf("wrong type for uint64 field")
-	}
-	t.PieceSize = abi.UnpaddedPieceSize(extra)
 	return nil
 }


### PR DESCRIPTION
## Summary
Add a `PieceCid` field to the block unsealer struct, which will restrict which piece it will try to unseal from.

Resolves #179 