### PR TITLE
Support selectors on retrieval

### DIFF
--- a/retrievalmarket/common.go
+++ b/retrievalmarket/common.go
@@ -1,0 +1,15 @@
+package retrievalmarket
+
+import (
+	"bytes"
+
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/encoding/dagcbor"
+	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
+func DecodeNode(defnode *cbg.Deferred) (ipld.Node, error) {
+	reader := bytes.NewReader(defnode.Raw)
+	return dagcbor.Decoder(ipldfree.NodeBuilder(), reader)
+}

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -317,7 +317,7 @@ CurrentInterval: %d
 
 			var rmParams retrievalmarket.Params
 			if testCase.paramsV1 {
-				rmParams = retrievalmarket.NewParamsV1(pricePerByte, paymentInterval, paymentIntervalIncrease, testCase.selector)
+				rmParams = retrievalmarket.NewParamsV1(pricePerByte, paymentInterval, paymentIntervalIncrease, testCase.selector, nil)
 
 			} else {
 				rmParams = retrievalmarket.NewParamsV0(pricePerByte, paymentInterval, paymentIntervalIncrease)

--- a/shared_testutil/mocknet.go
+++ b/shared_testutil/mocknet.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -198,7 +197,7 @@ func (ltd *Libp2pTestData) LoadUnixFSFile(t *testing.T, filename string, useSeco
 }
 
 // VerifyFileTransferred checks that the fixture file was sent from one node to the other.
-func (ltd *Libp2pTestData) VerifyFileTransferred(t *testing.T, link ipld.Link, useSecondNode bool) {
+func (ltd *Libp2pTestData) VerifyFileTransferred(t *testing.T, link ipld.Link, useSecondNode bool, readLen uint64) {
 	var dagService ipldformat.DAGService
 	if useSecondNode {
 		dagService = ltd.DagService2
@@ -220,9 +219,10 @@ func (ltd *Libp2pTestData) VerifyFileTransferred(t *testing.T, link ipld.Link, u
 	require.True(t, ok)
 
 	// Read the bytes for the UnixFS File
-	finalBytes, err := ioutil.ReadAll(fn)
+	finalBytes := make([]byte, readLen)
+	_, err = fn.Read(finalBytes)
 	require.NoError(t, err)
 
 	// verify original bytes match final bytes!
-	require.EqualValues(t, ltd.OrigBytes, finalBytes)
+	require.EqualValues(t, ltd.OrigBytes[:readLen], finalBytes)
 }


### PR DESCRIPTION
Closes #170 

### Change summary
* Decode selector in client.Receive and if valid, pass to the block SelectorVerifier
* Decode selector when creating a new provider, and if valid, pass to the SelctorBlockReader
* Add 2 unit tests, one that uses the allselector and one that selects some