### PR TITLE
Add a max piece size to storage asks

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -204,6 +204,10 @@ func (c *Client) ProposeStorageDeal(
 		return nil, xerrors.Errorf("computing commP failed: %w", err)
 	}
 
+	if uint64(pieceSize.Padded()) > info.SectorSize {
+		return nil, xerrors.New("Cannot propose a deal whose piece size is greater than sector size")
+	}
+
 	dealProposal := market.DealProposal{
 		PieceCID:             commP,
 		PieceSize:            pieceSize.Padded(),

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -2,6 +2,7 @@ package storageimpl
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
@@ -205,7 +206,7 @@ func (c *Client) ProposeStorageDeal(
 	}
 
 	if uint64(pieceSize.Padded()) > info.SectorSize {
-		return nil, xerrors.New("Cannot propose a deal whose piece size is greater than sector size")
+		return nil, fmt.Errorf("cannot propose a deal whose piece size (%d) is greater than sector size (%d)", pieceSize.Padded(), info.SectorSize)
 	}
 
 	dealProposal := market.DealProposal{

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -72,6 +72,21 @@ func DealAcceptanceBuffer(buffer abi.ChainEpoch) StorageProviderOption {
 	}
 }
 
+// StorageAskOption allows custom configuration of a storage ask
+type StorageAskOption func(*storagemarket.StorageAsk)
+
+func MinPieceSize(minPieceSize abi.PaddedPieceSize) StorageAskOption {
+	return func(sa *storagemarket.StorageAsk) {
+		sa.MinPieceSize = minPieceSize
+	}
+}
+
+func MaxPieceSize(maxPieceSize abi.PaddedPieceSize) StorageAskOption {
+	return func(sa *storagemarket.StorageAsk) {
+		sa.MaxPieceSize = maxPieceSize
+	}
+}
+
 // NewProvider returns a new storage provider
 func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blockstore.Blockstore, fs filestore.FileStore, pieceStore piecestore.PieceStore, dataTransfer datatransfer.Manager, spn storagemarket.StorageProviderNode, minerAddress address.Address, rt abi.RegisteredProof, options ...StorageProviderOption) (storagemarket.StorageProvider, error) {
 	carIO := cario.NewCarIO()
@@ -262,8 +277,8 @@ func (p *Provider) ListLocalDeals() ([]storagemarket.MinerDeal, error) {
 	return out, nil
 }
 
-func (p *Provider) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error {
-	return p.storedAsk.AddAsk(price, duration)
+func (p *Provider) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...StorageAskOption) error {
+	return p.storedAsk.AddAsk(price, duration, bounds)
 }
 
 func (p *Provider) HandleAskStream(s network.StorageAskStream) {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -72,21 +72,6 @@ func DealAcceptanceBuffer(buffer abi.ChainEpoch) StorageProviderOption {
 	}
 }
 
-// StorageAskOption allows custom configuration of a storage ask
-type StorageAskOption func(*storagemarket.StorageAsk)
-
-func MinPieceSize(minPieceSize abi.PaddedPieceSize) StorageAskOption {
-	return func(sa *storagemarket.StorageAsk) {
-		sa.MinPieceSize = minPieceSize
-	}
-}
-
-func MaxPieceSize(maxPieceSize abi.PaddedPieceSize) StorageAskOption {
-	return func(sa *storagemarket.StorageAsk) {
-		sa.MaxPieceSize = maxPieceSize
-	}
-}
-
 // NewProvider returns a new storage provider
 func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blockstore.Blockstore, fs filestore.FileStore, pieceStore piecestore.PieceStore, dataTransfer datatransfer.Manager, spn storagemarket.StorageProviderNode, minerAddress address.Address, rt abi.RegisteredProof, options ...StorageProviderOption) (storagemarket.StorageProvider, error) {
 	carIO := cario.NewCarIO()
@@ -277,8 +262,8 @@ func (p *Provider) ListLocalDeals() ([]storagemarket.MinerDeal, error) {
 	return out, nil
 }
 
-func (p *Provider) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...StorageAskOption) error {
-	return p.storedAsk.AddAsk(price, duration, bounds)
+func (p *Provider) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
+	return p.storedAsk.AddAsk(price, duration, options...)
 }
 
 func (p *Provider) HandleAskStream(s network.StorageAskStream) {

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -83,6 +83,11 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 			xerrors.Errorf("piece size less than minimum required size: %d < %d", deal.Proposal.PieceSize, environment.Ask().MinPieceSize))
 	}
 
+	if deal.Proposal.PieceSize > environment.Ask().MaxPieceSize {
+		return ctx.Trigger(storagemarket.ProviderEventDealRejected,
+			xerrors.Errorf("piece size more than maximum allowed size: %d > %d", deal.Proposal.PieceSize, environment.Ask().MaxPieceSize))
+	}
+
 	// check market funds
 	clientMarketBalance, err := environment.Node().GetBalance(ctx.Context(), deal.Proposal.Client, tok)
 	if err != nil {

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -578,6 +578,7 @@ var defaultClientMarketBalance = abi.NewTokenAmount(200 * 10000)
 var defaultAsk = storagemarket.StorageAsk{
 	Price:        abi.NewTokenAmount(10000000),
 	MinPieceSize: abi.PaddedPieceSize(256),
+	MaxPieceSize: 1 << 20,
 }
 
 var testData = tut.NewTestIPLDTree()

--- a/storagemarket/impl/storedask/storedask.go
+++ b/storagemarket/impl/storedask/storedask.go
@@ -3,7 +3,6 @@ package storedask
 import (
 	"bytes"
 	"context"
-	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"sync"
 
 	"github.com/filecoin-project/go-address"
@@ -49,14 +48,14 @@ func NewStoredAsk(ds datastore.Batching, spn storagemarket.StorageProviderNode, 
 	if s.ask == nil {
 		// TODO: we should be fine with this state, and just say it means 'not actively accepting deals'
 		// for now... lets just set a price
-		if err := s.AddAsk(defaultPrice, defaultDuration, nil); err != nil {
+		if err := s.AddAsk(defaultPrice, defaultDuration); err != nil {
 			return nil, xerrors.Errorf("failed setting a default price: %w", err)
 		}
 	}
 	return s, nil
 }
 
-func (s *StoredAsk) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storageimpl.StorageAskOption) error {
+func (s *StoredAsk) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
 	s.askLk.Lock()
 	defer s.askLk.Unlock()
 	var seqno uint64

--- a/storagemarket/impl/storedask/storedask_test.go
+++ b/storagemarket/impl/storedask/storedask_test.go
@@ -32,7 +32,7 @@ func TestStoredAsk(t *testing.T) {
 		require.NotNil(t, ask)
 	})
 	t.Run("setting ask price", func(t *testing.T) {
-		err := storedAsk.AddAsk(testPrice, testDuration)
+		err := storedAsk.AddAsk(testPrice, testDuration, nil)
 		require.NoError(t, err)
 		ask := storedAsk.GetAsk(actor)
 		require.Equal(t, ask.Ask.Price, testPrice)
@@ -61,7 +61,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err := storedask.NewStoredAsk(ds, spnStateIDErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.AddAsk(testPrice, testDuration, nil)
 		require.Error(t, err)
 
 		spnMinerWorkerErr := &testnodes.FakeProviderNode{
@@ -73,7 +73,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, spnMinerWorkerErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.AddAsk(testPrice, testDuration, nil)
 		require.Error(t, err)
 
 		spnSignBytesErr := &testnodes.FakeProviderNode{
@@ -85,7 +85,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, spnSignBytesErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.AddAsk(testPrice, testDuration, nil)
 		require.Error(t, err)
 	})
 }

--- a/storagemarket/impl/storedask/storedask_test.go
+++ b/storagemarket/impl/storedask/storedask_test.go
@@ -10,6 +10,7 @@ import (
 	dss "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/require"
 
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
 )
@@ -32,11 +33,13 @@ func TestStoredAsk(t *testing.T) {
 		require.NotNil(t, ask)
 	})
 	t.Run("setting ask price", func(t *testing.T) {
-		err := storedAsk.AddAsk(testPrice, testDuration, nil)
+		minPieceSize := abi.PaddedPieceSize(1024)
+		err := storedAsk.AddAsk(testPrice, testDuration, storagemarket.MinPieceSize(minPieceSize))
 		require.NoError(t, err)
 		ask := storedAsk.GetAsk(actor)
 		require.Equal(t, ask.Ask.Price, testPrice)
 		require.Equal(t, ask.Ask.Expiry-ask.Ask.Timestamp, testDuration)
+		require.Equal(t, ask.Ask.MinPieceSize, minPieceSize)
 	})
 	t.Run("querying incorrect address", func(t *testing.T) {
 		otherAddr, err := address.NewActorAddress([]byte("other"))
@@ -61,7 +64,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err := storedask.NewStoredAsk(ds, spnStateIDErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration, nil)
+		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)
 
 		spnMinerWorkerErr := &testnodes.FakeProviderNode{
@@ -73,7 +76,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, spnMinerWorkerErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration, nil)
+		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)
 
 		spnSignBytesErr := &testnodes.FakeProviderNode{
@@ -85,7 +88,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, spnSignBytesErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration, nil)
+		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)
 	})
 }

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -96,7 +96,7 @@ func TestMakeDeal(t *testing.T) {
 		Address:    providerAddr,
 		Owner:      providerAddr,
 		Worker:     providerAddr,
-		SectorSize: 32,
+		SectorSize: 1 << 20,
 		PeerID:     td.Host2.ID(),
 	}
 
@@ -190,7 +190,7 @@ func TestMakeDealOffline(t *testing.T) {
 		Address:    providerAddr,
 		Owner:      providerAddr,
 		Worker:     providerAddr,
-		SectorSize: 32,
+		SectorSize: 1 << 20,
 		PeerID:     td.Host2.ID(),
 	}
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -89,6 +89,7 @@ type StorageAsk struct {
 	Price abi.TokenAmount
 
 	MinPieceSize abi.PaddedPieceSize
+	MaxPieceSize abi.PaddedPieceSize
 	Miner        address.Address
 	Timestamp    abi.ChainEpoch
 	Expiry       abi.ChainEpoch
@@ -267,7 +268,7 @@ type StorageProvider interface {
 
 	Stop() error
 
-	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch) error
+	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, bounds ...abi.PaddedPieceSize) error
 
 	// ListAsks lists current asks
 	ListAsks(addr address.Address) []*SignedStorageAsk

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -96,6 +96,21 @@ type StorageAsk struct {
 	SeqNo        uint64
 }
 
+// StorageAskOption allows custom configuration of a storage ask
+type StorageAskOption func(*StorageAsk)
+
+func MinPieceSize(minPieceSize abi.PaddedPieceSize) StorageAskOption {
+	return func(sa *StorageAsk) {
+		sa.MinPieceSize = minPieceSize
+	}
+}
+
+func MaxPieceSize(maxPieceSize abi.PaddedPieceSize) StorageAskOption {
+	return func(sa *StorageAsk) {
+		sa.MaxPieceSize = maxPieceSize
+	}
+}
+
 var StorageAskUndefined = StorageAsk{}
 
 type MinerDeal struct {
@@ -268,7 +283,7 @@ type StorageProvider interface {
 
 	Stop() error
 
-	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, bounds ...abi.PaddedPieceSize) error
+	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...StorageAskOption) error
 
 	// ListAsks lists current asks
 	ListAsks(addr address.Address) []*SignedStorageAsk


### PR DESCRIPTION
We should probably put something in that ensures that the new max piece size is less than or equal to the sector size.

This PR also includes a commit that makes the Storage Market client refuse to propose a deal if piece size > sector size.