### PR TITLE
add multiple peers per payloadCID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200402171437-3d27c146c105
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+	gotest.tools v2.2.0+incompatible
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/retrievalmarket/discovery/local_test.go
+++ b/retrievalmarket/discovery/local_test.go
@@ -1,0 +1,57 @@
+package discovery_test
+
+import (
+	"testing"
+
+	specst "github.com/filecoin-project/specs-actors/support/testing"
+	"github.com/ipfs/go-datastore"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/discovery"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
+)
+
+func TestLocal_AddPeer(t *testing.T) {
+
+	peer1 := retrievalmarket.RetrievalPeer{
+		Address: specst.NewIDAddr(t, 1),
+		ID:      peer.NewPeerRecord().PeerID,
+	}
+	peer2 := retrievalmarket.RetrievalPeer{
+		Address: specst.NewIDAddr(t, 2),
+		ID:      peer.NewPeerRecord().PeerID,
+	}
+	testCases := []struct {
+		name      string
+		peers2add []retrievalmarket.RetrievalPeer
+		expPeers  []retrievalmarket.RetrievalPeer
+	}{
+		{
+			name:      "can add 3 peers",
+			peers2add: []retrievalmarket.RetrievalPeer{peer1, peer2},
+			expPeers:  []retrievalmarket.RetrievalPeer{peer1, peer2},
+		},
+		{
+			name:      "can add same peer without duping",
+			peers2add: []retrievalmarket.RetrievalPeer{peer1, peer1},
+			expPeers:  []retrievalmarket.RetrievalPeer{peer1},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := datastore.NewMapDatastore()
+			l := discovery.NewLocal(ds)
+			payloadCID := shared_testutil.GenerateCids(1)[0]
+			for _, testpeer := range tc.peers2add {
+				require.NoError(t, l.AddPeer(payloadCID, testpeer))
+			}
+			actualPeers, err := l.GetPeers(payloadCID)
+			require.NoError(t, err)
+			assert.Equal(t, len(tc.expPeers), len(actualPeers))
+			assert.Equal(t, tc.expPeers[0], actualPeers[0])
+		})
+	}
+}


### PR DESCRIPTION
Closes #101 

Amend storage record of payloadCIDs to  store a list of retrieval peers instead of just one.