### PR TITLE
Storagemarket/provider allows subscription to events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/filecoin-project/sector-storage v0.0.0-20200411000242-61616264b16d
 	github.com/filecoin-project/specs-actors v1.0.0
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099
+	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,8 @@ github.com/hannahhoward/cbor-gen-for v0.0.0-20191216214420-3e450425c40c h1:+MSf4
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191216214420-3e450425c40c/go.mod h1:WVPCl0HO/0RAL5+vBH2GMxBomlxBF70MAS78+Lu1//k=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099 h1:vQqOW42RRM5LoM/1K5dK940VipLqpH8lEVGrMz+mNjU=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099/go.mod h1:WVPCl0HO/0RAL5+vBH2GMxBomlxBF70MAS78+Lu1//k=
+github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e h1:3YKHER4nmd7b5qy5t0GWDTwSn4OyRgfAXSmo6VnryBY=
+github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e/go.mod h1:I8h3MITA53gN9OnWGCgaMa0JWVRdXthWw4M3CPM54OY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=

--- a/shared/types.go
+++ b/shared/types.go
@@ -3,5 +3,5 @@ package shared
 // TipSetToken is the implementation-nonspecific identity for a tipset.
 type TipSetToken []byte
 
-// Unsubscribe is a function that gets called to unsubscribe from data transfer events
+// Unsubscribe is a function that gets called to unsubscribe from (storage|retrieval)market events
 type Unsubscribe func()

--- a/shared/types.go
+++ b/shared/types.go
@@ -2,3 +2,6 @@ package shared
 
 // TipSetToken is the implementation-nonspecific identity for a tipset.
 type TipSetToken []byte
+
+// Unsubscribe is a function that gets called to unsubscribe from data transfer events
+type Unsubscribe func()

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -42,7 +42,6 @@ type Client struct {
 	// implementation, there's no validation or events on the client side
 	dataTransfer datatransfer.Manager
 	bs           blockstore.Blockstore
-	//fs           filestore.FileStore
 	pio          pieceio.PieceIO
 	discovery    *discovery.Local
 

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -17,7 +17,6 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-fil-markets/filestore"
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
@@ -43,7 +42,7 @@ type Client struct {
 	// implementation, there's no validation or events on the client side
 	dataTransfer datatransfer.Manager
 	bs           blockstore.Blockstore
-	fs           filestore.FileStore
+	//fs           filestore.FileStore
 	pio          pieceio.PieceIO
 	discovery    *discovery.Local
 

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -320,7 +320,6 @@ func (p *Provider) dispatch(eventName fsm.EventName, deal fsm.StateType) {
 	}
 	pubSubEvt := internalEvent{evt, &realDeal}
 
-	// because pubSub uses a thread lock
 	go func() {
 		if err := p.pubSub.Publish(pubSubEvt); err != nil {
 			log.Errorf("failed to publish event %d", evt)

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -318,18 +318,16 @@ func (p *Provider) dispatch(eventName fsm.EventName, deal fsm.StateType) {
 	if !ok {
 		log.Errorf("not a deal %v", deal)
 	}
-	pubSubEvt := internalEvent{evt, &realDeal}
+	pubSubEvt := internalEvent{evt, realDeal}
 
-	go func() {
-		if err := p.pubSub.Publish(pubSubEvt); err != nil {
-			log.Errorf("failed to publish event %d", evt)
-		}
-	}()
+	if err := p.pubSub.Publish(pubSubEvt); err != nil {
+		log.Errorf("failed to publish event %d", evt)
+	}
 }
 
 type internalEvent struct {
 	evt  storagemarket.ProviderEvent
-	deal *storagemarket.MinerDeal
+	deal storagemarket.MinerDeal
 }
 
 func dispatcher(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -9,6 +9,7 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/hannahhoward/go-pubsub"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -21,6 +22,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/pieceio"
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/connmanager"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/providerstates"
@@ -49,6 +51,7 @@ type Provider struct {
 	dataTransfer              datatransfer.Manager
 	universalRetrievalEnabled bool
 	dealAcceptanceBuffer      abi.ChainEpoch
+	pubSub                    *pubsub.PubSub
 
 	deals fsm.Group
 }
@@ -94,6 +97,7 @@ func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blo
 		actor:                minerAddress,
 		dataTransfer:         dataTransfer,
 		dealAcceptanceBuffer: DefaultDealAcceptanceBuffer,
+		pubSub:               pubsub.New(dispatcher),
 	}
 
 	deals, err := fsm.New(namespace.Wrap(ds, datastore.NewKey(ProviderDsPrefix)), fsm.Parameters{
@@ -102,6 +106,7 @@ func NewProvider(net network.StorageMarketNetwork, ds datastore.Batching, bs blo
 		StateKeyField:   "State",
 		Events:          providerstates.ProviderEvents,
 		StateEntryFuncs: providerstates.ProviderStateEntryFuncs,
+		Notifier:        h.dispatch,
 	})
 	if err != nil {
 		return nil, err
@@ -297,6 +302,54 @@ func (p *Provider) DealAcceptanceBuffer() abi.ChainEpoch {
 func (p *Provider) UniversalRetrievalEnabled() bool {
 	return p.universalRetrievalEnabled
 }
+
+func (p *Provider) SubscribeToEvents(subscriber storagemarket.ProviderSubscriber) shared.Unsubscribe {
+	return shared.Unsubscribe(p.pubSub.Subscribe(subscriber))
+}
+
+// dispatch puts the fsm event into a form that pubSub can consume,
+// then publishes the event
+func (p *Provider) dispatch(eventName fsm.EventName, deal fsm.StateType) {
+	evt, ok := eventName.(storagemarket.ProviderEvent)
+	if !ok {
+		log.Errorf("dropped bad event %s", eventName)
+	}
+	realDeal, ok := deal.(storagemarket.MinerDeal)
+	if !ok {
+		log.Errorf("not a deal %v", deal)
+	}
+	pubSubEvt := internalEvent{evt, &realDeal}
+
+	// because pubSub uses a thread lock
+	go func() {
+		if err := p.pubSub.Publish(pubSubEvt); err != nil {
+			log.Errorf("failed to publish event %d", evt)
+		}
+	}()
+}
+
+type internalEvent struct {
+	evt  storagemarket.ProviderEvent
+	deal *storagemarket.MinerDeal
+}
+
+func dispatcher(evt pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
+	ie, ok := evt.(internalEvent)
+	if !ok {
+		return xerrors.New("wrong type of event")
+	}
+	cb, ok := subscriberFn.(storagemarket.ProviderSubscriber)
+	if !ok {
+		return xerrors.New("wrong type of event")
+	}
+	log.Infof("dispatcher called with valid evt %d", ie.evt)
+	cb(ie.evt, ie.deal)
+	return nil
+}
+
+// -------
+// providerDealEnvironment
+// -------
 
 type providerDealEnvironment struct {
 	p *Provider

--- a/storagemarket/impl/provider_test.go
+++ b/storagemarket/impl/provider_test.go
@@ -3,7 +3,11 @@ package storageimpl_test
 import (
 	"testing"
 
+	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
@@ -23,3 +27,14 @@ func TestConfigure(t *testing.T) {
 	assert.True(t, p.UniversalRetrievalEnabled())
 	assert.Equal(t, abi.ChainEpoch(123), p.DealAcceptanceBuffer())
 }
+
+type fakeDTValidator struct{}
+
+func (f fakeDTValidator) ValidatePush(_ peer.ID, _ datatransfer.Voucher, _ cid.Cid, _ ipld.Node) error {
+	return nil
+}
+func (f fakeDTValidator) ValidatePull(_ peer.ID, _ datatransfer.Voucher, _ cid.Cid, _ ipld.Node) error {
+	return nil
+}
+
+var _ datatransfer.RequestValidator = (*fakeDTValidator)(nil)

--- a/storagemarket/impl/provider_test.go
+++ b/storagemarket/impl/provider_test.go
@@ -3,11 +3,7 @@ package storageimpl_test
 import (
 	"testing"
 
-	datatransfer "github.com/filecoin-project/go-data-transfer"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-ipld-prime"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
@@ -27,14 +23,3 @@ func TestConfigure(t *testing.T) {
 	assert.True(t, p.UniversalRetrievalEnabled())
 	assert.Equal(t, abi.ChainEpoch(123), p.DealAcceptanceBuffer())
 }
-
-type fakeDTValidator struct{}
-
-func (f fakeDTValidator) ValidatePush(_ peer.ID, _ datatransfer.Voucher, _ cid.Cid, _ ipld.Node) error {
-	return nil
-}
-func (f fakeDTValidator) ValidatePull(_ peer.ID, _ datatransfer.Voucher, _ cid.Cid, _ ipld.Node) error {
-	return nil
-}
-
-var _ datatransfer.RequestValidator = (*fakeDTValidator)(nil)

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -277,6 +277,9 @@ type StorageDeal struct {
 	market.DealState
 }
 
+// Subscriber is a callback that is called when events are emitted
+type ProviderSubscriber func(event ProviderEvent, deal *MinerDeal)
+
 // StorageProvider is the interface provided for storage providers
 type StorageProvider interface {
 	Start(ctx context.Context) error
@@ -301,6 +304,8 @@ type StorageProvider interface {
 	GetStorageCollateral(ctx context.Context) (Balance, error)
 
 	ImportDataForDeal(ctx context.Context, propCid cid.Cid, data io.Reader) error
+
+	SubscribeToEvents(subscriber ProviderSubscriber) shared.Unsubscribe
 }
 
 // Node dependencies for a StorageProvider

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -278,7 +278,7 @@ type StorageDeal struct {
 }
 
 // Subscriber is a callback that is called when events are emitted
-type ProviderSubscriber func(event ProviderEvent, deal *MinerDeal)
+type ProviderSubscriber func(event ProviderEvent, deal MinerDeal)
 
 // StorageProvider is the interface provided for storage providers
 type StorageProvider interface {


### PR DESCRIPTION
### WAT
closes #77 

### HAO 
* Allow consumers to subscribe to StorageProvider events.
* Use @hannahhoward  new generic threadsafe pubsub for subscription management

### Questions
I'm sending the entire deal to the subscriber. Not sure if that's what we really want though.