### PR TITLE
fix(storagemarket): set miner peer id on deals

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -157,6 +157,7 @@ func (p *Provider) receiveDeal(s network.StorageDealStream) error {
 
 	deal := &storagemarket.MinerDeal{
 		Client:             s.RemotePeer(),
+		Miner:              p.net.ID(),
 		ClientDealProposal: *proposal.DealProposal,
 		ProposalCid:        proposalNd.Cid(),
 		State:              storagemarket.StorageDealUnknown,

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -83,3 +83,7 @@ func (impl *libp2pStorageMarketNetwork) handleNewDealStream(s network.Stream) {
 	ds := &dealStream{remotePID, s, buffered}
 	impl.receiver.HandleDealStream(ds)
 }
+
+func (impl *libp2pStorageMarketNetwork) ID() peer.ID {
+	return impl.host.ID()
+}

--- a/storagemarket/network/network.go
+++ b/storagemarket/network/network.go
@@ -38,4 +38,5 @@ type StorageMarketNetwork interface {
 	NewDealStream(peer.ID) (StorageDealStream, error)
 	SetDelegate(StorageReceiver) error
 	StopHandlingRequests() error
+	ID() peer.ID
 }


### PR DESCRIPTION
Set the local miner peer id on MinerDeal and verify JSON marshall/unmarshal works