### PR TITLE
Round-trip storage/retrieval test

### DIFF
--- a/retrievalmarket/impl/blockio/reader_test.go
+++ b/retrievalmarket/impl/blockio/reader_test.go
@@ -6,12 +6,10 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockio"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -19,11 +17,8 @@ func TestSelectorReader(t *testing.T) {
 	ctx := context.Background()
 	testdata := tut.NewTestIPLDTree()
 
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	sel := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
 	t.Run("reads correctly", func(t *testing.T) {
-		reader := blockio.NewSelectorBlockReader(testdata.RootNodeLnk, sel, testdata.Loader)
+		reader := blockio.NewSelectorBlockReader(testdata.RootNodeLnk, shared.AllSelector(), testdata.Loader)
 
 		checkReadSequence(ctx, t, reader, []blocks.Block{
 			testdata.RootBlock,

--- a/retrievalmarket/impl/blockio/traverser_test.go
+++ b/retrievalmarket/impl/blockio/traverser_test.go
@@ -7,12 +7,10 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockio"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -20,11 +18,8 @@ func TestTraverser(t *testing.T) {
 	ctx := context.Background()
 	testdata := tut.NewTestIPLDTree()
 
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	sel := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
 	t.Run("traverses correctly", func(t *testing.T) {
-		traverser := blockio.NewTraverser(testdata.RootNodeLnk, sel)
+		traverser := blockio.NewTraverser(testdata.RootNodeLnk, shared.AllSelector())
 		traverser.Start(ctx)
 		checkTraverseSequence(ctx, t, traverser, []blocks.Block{
 			testdata.RootBlock,

--- a/retrievalmarket/impl/blockio/verify_test.go
+++ b/retrievalmarket/impl/blockio/verify_test.go
@@ -5,22 +5,17 @@ import (
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockio"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
 func TestSelectorVerifier(t *testing.T) {
 	ctx := context.Background()
 	testdata := tut.NewTestIPLDTree()
-
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	sel := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
+	sel := shared.AllSelector()
 	t.Run("verifies correctly", func(t *testing.T) {
 		verifier := blockio.NewSelectorVerifier(testdata.RootNodeLnk, sel)
 		checkVerifySequence(ctx, t, verifier, false, []blocks.Block{

--- a/retrievalmarket/impl/blockunsealing/blockunsealing_test.go
+++ b/retrievalmarket/impl/blockunsealing/blockunsealing_test.go
@@ -14,15 +14,13 @@ import (
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockunsealing"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -30,11 +28,8 @@ func TestNewLoaderWithUnsealing(t *testing.T) {
 	ctx := context.Background()
 	cio := cario.NewCarIO()
 	testdata := tut.NewTestIPLDTree()
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
-		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 	var carBuffer bytes.Buffer
-	err := cio.WriteCar(ctx, testdata, testdata.RootNodeLnk.(cidlink.Link).Cid, allSelector, &carBuffer)
+	err := cio.WriteCar(ctx, testdata, testdata.RootNodeLnk.(cidlink.Link).Cid, shared.AllSelector(), &carBuffer)
 	require.NoError(t, err)
 	carData := carBuffer.Bytes()
 

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -22,6 +22,8 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockio"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
+
 	"github.com/filecoin-project/go-storedcounter"
 )
 
@@ -151,7 +153,7 @@ func (c *client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrie
 
 	c.dealStreams[dealID] = s
 
-	sel := AllSelector()
+	sel := shared.AllSelector()
 	if params.Selector != nil {
 		sel, err = retrievalmarket.DecodeNode(params.Selector)
 		if err != nil {

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -151,7 +151,7 @@ func (c *client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrie
 
 	c.dealStreams[dealID] = s
 
-	sel := allSelector()
+	sel := AllSelector()
 	if params.Selector != nil {
 		sel, err = retrievalmarket.DecodeNode(params.Selector)
 		if err != nil {
@@ -207,15 +207,15 @@ func (c *client) SubscribeToEvents(subscriber retrievalmarket.ClientSubscriber) 
 }
 
 // V1
-func (c *client) AddMoreFunds(id retrievalmarket.DealID, amount abi.TokenAmount) error {
+func (c *client) AddMoreFunds(retrievalmarket.DealID, abi.TokenAmount) error {
 	panic("not implemented")
 }
 
-func (c *client) CancelDeal(id retrievalmarket.DealID) error {
+func (c *client) CancelDeal(retrievalmarket.DealID) error {
 	panic("not implemented")
 }
 
-func (c *client) RetrievalStatus(id retrievalmarket.DealID) {
+func (c *client) RetrievalStatus(retrievalmarket.DealID) {
 	panic("not implemented")
 }
 
@@ -237,12 +237,12 @@ func (c *client) ConsumeBlock(ctx context.Context, dealID retrievalmarket.DealID
 		return 0, false, err
 	}
 
-	cid, err := prefix.Sum(block.Data)
+	scid, err := prefix.Sum(block.Data)
 	if err != nil {
 		return 0, false, err
 	}
 
-	blk, err := blocks.NewBlockWithCid(block.Data, cid)
+	blk, err := blocks.NewBlockWithCid(block.Data, scid)
 	if err != nil {
 		return 0, false, err
 	}

--- a/retrievalmarket/impl/client_test.go
+++ b/retrievalmarket/impl/client_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dss "github.com/ipfs/go-datastore/sync"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
@@ -65,7 +64,7 @@ func TestClient_Query(t *testing.T) {
 			net,
 			bs,
 			testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-			&testPeerResolver{},
+			&tut.TestPeerResolver{},
 			ds,
 			storedCounter)
 		require.NoError(t, err)
@@ -84,7 +83,7 @@ func TestClient_Query(t *testing.T) {
 			net,
 			bs,
 			testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-			&testPeerResolver{},
+			&tut.TestPeerResolver{},
 			ds,
 			storedCounter)
 		require.NoError(t, err)
@@ -110,7 +109,7 @@ func TestClient_Query(t *testing.T) {
 			net,
 			bs,
 			testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-			&testPeerResolver{},
+			&tut.TestPeerResolver{},
 			ds,
 			storedCounter)
 		require.NoError(t, err)
@@ -135,7 +134,7 @@ func TestClient_Query(t *testing.T) {
 			net,
 			bs,
 			testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-			&testPeerResolver{},
+			&tut.TestPeerResolver{},
 			ds,
 			storedCounter)
 		require.NoError(t, err)
@@ -164,7 +163,7 @@ func TestClient_FindProviders(t *testing.T) {
 
 	t.Run("when providers are found, returns providers", func(t *testing.T) {
 		peers := tut.RequireGenerateRetrievalPeers(t, 3)
-		testResolver := testPeerResolver{peers: peers}
+		testResolver := tut.TestPeerResolver{Peers: peers}
 
 		c, err := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
 		require.NoError(t, err)
@@ -174,7 +173,7 @@ func TestClient_FindProviders(t *testing.T) {
 	})
 
 	t.Run("when there is an error, returns empty provider list", func(t *testing.T) {
-		testResolver := testPeerResolver{peers: []retrievalmarket.RetrievalPeer{}, resolverError: errors.New("boom")}
+		testResolver := tut.TestPeerResolver{Peers: []retrievalmarket.RetrievalPeer{}, ResolverError: errors.New("boom")}
 		c, err := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
 		require.NoError(t, err)
 
@@ -183,22 +182,11 @@ func TestClient_FindProviders(t *testing.T) {
 	})
 
 	t.Run("when there are no providers", func(t *testing.T) {
-		testResolver := testPeerResolver{peers: []retrievalmarket.RetrievalPeer{}}
+		testResolver := tut.TestPeerResolver{Peers: []retrievalmarket.RetrievalPeer{}}
 		c, err := retrievalimpl.NewClient(net, bs, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
 		require.NoError(t, err)
 
 		testCid := tut.GenerateCids(1)[0]
 		assert.Len(t, c.FindProviders(testCid), 0)
 	})
-}
-
-type testPeerResolver struct {
-	peers         []retrievalmarket.RetrievalPeer
-	resolverError error
-}
-
-var _ retrievalmarket.PeerResolver = &testPeerResolver{}
-
-func (tpr testPeerResolver) GetPeers(cid.Cid) ([]retrievalmarket.RetrievalPeer, error) {
-	return tpr.peers, tpr.resolverError
 }

--- a/retrievalmarket/impl/common.go
+++ b/retrievalmarket/impl/common.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 )
 
-func allSelector() ipld.Node {
+func AllSelector() ipld.Node {
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 	return ssb.ExploreRecursive(selector.RecursionLimitNone(),
 		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -26,6 +26,7 @@ import (
 	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -205,7 +206,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			// Inject a unixFS file on the provider side to its blockstore
 			// obtained via `ls -laf` on this file
 
-			fpath := filepath.Join("retrievalmarket","impl","fixtures",testCase.filename)
+			fpath := filepath.Join("retrievalmarket", "impl", "fixtures", testCase.filename)
 
 			pieceLink := testData.LoadUnixFSFile(t, fpath, true)
 			c, ok := pieceLink.(cidlink.Link)
@@ -230,7 +231,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			if testCase.unsealing {
 				cio := cario.NewCarIO()
 				var buf bytes.Buffer
-				err := cio.WriteCar(bgCtx, testData.Bs2, payloadCID, testData.AllSelector, &buf)
+				err := cio.WriteCar(bgCtx, testData.Bs2, payloadCID, shared.AllSelector(), &buf)
 				require.NoError(t, err)
 				carData := buf.Bytes()
 				sectorID := uint64(100000)

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,9 +136,6 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 
-	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
-		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
 	partialSelector := ssb.ExploreFields(func(specBuilder builder.ExploreFieldsSpecBuilder) {
 		specBuilder.Insert("Links", ssb.ExploreIndex(0, ssb.ExploreFields(func(specBuilder builder.ExploreFieldsSpecBuilder) {
 			specBuilder.Insert("Hash", ssb.Matcher())
@@ -184,7 +180,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			filesize:    19000,
 			voucherAmts: []abi.TokenAmount{abi.NewTokenAmount(10136000), abi.NewTokenAmount(9784000)},
 			paramsV1:    true,
-			selector:    allSelector,
+			selector:    shared.AllSelector(),
 			unsealing:   false},
 		{name: "partial file retrieval succeeds with V1 params and selector recursion depth 1",
 			filename:    "lorem.txt",

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -3,6 +3,7 @@ package retrievalimpl_test
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -85,7 +86,7 @@ func requireSetupTestClientAndProvider(bgCtx context.Context, t *testing.T, payC
 		CreatePaychCID: cids[0],
 		AddFundsCID:    cids[1],
 	})
-	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, rcNode1, &testPeerResolver{}, testData.Ds1, testData.RetrievalStoredCounter1)
+	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, rcNode1, &tut.TestPeerResolver{}, testData.Ds1, testData.RetrievalStoredCounter1)
 	require.NoError(t, err)
 	nw2 := rmnet.NewFromLibp2pHost(testData.Host2)
 	providerNode := testnodes.NewTestRetrievalProviderNode()
@@ -177,7 +178,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			filesize:    19000,
 			voucherAmts: []abi.TokenAmount{abi.NewTokenAmount(10136000), abi.NewTokenAmount(9784000)},
 			unsealing:   true},
-		{name: "multi-block file retrieval succeeds with V1 params and allSelector",
+		{name: "multi-block file retrieval succeeds with V1 params and AllSelector",
 			filename:    "lorem.txt",
 			filesize:    19000,
 			voucherAmts: []abi.TokenAmount{abi.NewTokenAmount(10136000), abi.NewTokenAmount(9784000)},
@@ -203,7 +204,10 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 
 			// Inject a unixFS file on the provider side to its blockstore
 			// obtained via `ls -laf` on this file
-			pieceLink := testData.LoadUnixFSFile(t, testCase.filename, true)
+
+			fpath := filepath.Join("retrievalmarket","impl","fixtures",testCase.filename)
+
+			pieceLink := testData.LoadUnixFSFile(t, fpath, true)
 			c, ok := pieceLink.(cidlink.Link)
 			require.True(t, ok)
 			payloadCID := c.Cid
@@ -415,7 +419,7 @@ func setupClient(
 		CreatePaychCID:         cids[0],
 		AddFundsCID:            cids[1],
 	})
-	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, clientNode, &testPeerResolver{}, testData.Ds1, testData.RetrievalStoredCounter1)
+	client, err := retrievalimpl.NewClient(nw1, testData.Bs1, clientNode, &tut.TestPeerResolver{}, testData.Ds1, testData.RetrievalStoredCounter1)
 	return &createdChan, &newLaneAddr, &createdVoucher, client, err
 }
 

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/blockunsealing"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/providerstates"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 // ProviderDsPrefix is the datastore for the provider key
@@ -247,7 +248,7 @@ func (p *provider) newProviderDeal(stream rmnet.RetrievalDealStream) error {
 			return xerrors.Errorf("selector is invalid: %w", err)
 		}
 	} else {
-		sel = AllSelector()
+		sel = shared.AllSelector()
 	}
 
 	br := blockio.NewSelectorBlockReader(cidlink.Link{Cid: dealProposal.PayloadCID}, sel, loaderWithUnsealing.Load)

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -247,7 +247,7 @@ func (p *provider) newProviderDeal(stream rmnet.RetrievalDealStream) error {
 			return xerrors.Errorf("selector is invalid: %w", err)
 		}
 	} else {
-		sel = allSelector()
+		sel = AllSelector()
 	}
 
 	br := blockio.NewSelectorBlockReader(cidlink.Link{Cid: dealProposal.PayloadCID}, sel, loaderWithUnsealing.Load)

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -1,0 +1,412 @@
+package retrievalmarket_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/impl/graphsync"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/discovery"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	testnodes2 "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
+	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
+	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	stormkt "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
+	stornet "github.com/filecoin-project/go-fil-markets/storagemarket/network"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
+)
+
+func TestStorageRetrieval(t *testing.T) {
+	bgCtx := context.Background()
+	sh := newStorageHarness(bgCtx, t)
+	sh.Client.Run(bgCtx)
+	require.NoError(t, sh.Provider.Start(bgCtx))
+
+	// set up a subscriber
+	providerDealChan := make(chan storagemarket.MinerDeal)
+	subscriber := func(event storagemarket.ProviderEvent, deal storagemarket.MinerDeal) {
+		providerDealChan <- deal
+	}
+	_ = sh.Provider.SubscribeToEvents(subscriber)
+
+	clientDealChan := make(chan storagemarket.ClientDeal)
+	clientSubscriber := func(event storagemarket.ClientEvent, deal storagemarket.ClientDeal) {
+		clientDealChan <- deal
+	}
+	_ = sh.Client.SubscribeToEvents(clientSubscriber)
+
+	// set ask price where we'll accept any price
+	err := sh.Provider.AddAsk(big.NewInt(0), 50_000)
+	assert.NoError(t, err)
+
+	result := sh.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: sh.PayloadCid})
+	require.False(t, result.ProposalCid.Equals(cid.Undef))
+
+	time.Sleep(time.Millisecond * 200)
+
+	ctxTimeout, canc := context.WithTimeout(bgCtx, 100*time.Millisecond)
+	defer canc()
+
+	var storageProviderSeenDeal storagemarket.MinerDeal
+	var storageClientSeenDeal storagemarket.ClientDeal
+	for storageProviderSeenDeal.State != storagemarket.StorageDealCompleted ||
+		storageClientSeenDeal.State != storagemarket.StorageDealActive {
+		select {
+		case storageProviderSeenDeal = <-providerDealChan:
+		case storageClientSeenDeal = <-clientDealChan:
+		case <-ctxTimeout.Done():
+			t.Fatalf("never saw completed: %d, %d", storageClientSeenDeal.State, storageProviderSeenDeal.State)
+		}
+	}
+
+	rh := newRetrievalHarness(ctxTimeout, t, sh, storageClientSeenDeal)
+
+	clientDealStateChan := make(chan retrievalmarket.ClientDealState)
+	rh.Client.SubscribeToEvents(func(event retrievalmarket.ClientEvent, state retrievalmarket.ClientDealState) {
+		switch event {
+		case retrievalmarket.ClientEventComplete:
+			clientDealStateChan <- state
+		}
+	})
+
+	providerDealStateChan := make(chan retrievalmarket.ProviderDealState)
+	rh.Provider.SubscribeToEvents(func(event retrievalmarket.ProviderEvent, state retrievalmarket.ProviderDealState) {
+		switch event {
+		case retrievalmarket.ProviderEventComplete:
+			providerDealStateChan <- state
+		}
+	})
+
+	// **** Send the query for the Piece
+	// set up retrieval params
+	retrievalPeer := &retrievalmarket.RetrievalPeer{Address: sh.ProviderAddr, ID: sh.TestData.Host2.ID()}
+
+	resp, err := rh.Client.Query(bgCtx, *retrievalPeer, sh.PayloadCid, retrievalmarket.QueryParams{})
+	require.NoError(t, err)
+	require.Equal(t, retrievalmarket.QueryResponseAvailable, resp.Status)
+
+	// testing V1 only
+	rmParams := retrievalmarket.NewParamsV1(rh.RetrievalParams.PricePerByte,
+		rh.RetrievalParams.PaymentInterval,
+		rh.RetrievalParams.PaymentIntervalIncrease, retrievalimpl.AllSelector(), nil)
+
+	voucherAmts := []abi.TokenAmount{abi.NewTokenAmount(10136000), abi.NewTokenAmount(9784000)}
+	proof := []byte("")
+	for _, voucherAmt := range voucherAmts {
+		require.NoError(t, rh.ProviderNode.ExpectVoucher(*rh.ExpPaych, rh.ExpVoucher, proof, voucherAmt, voucherAmt, nil))
+	}
+	// just make sure there is enough to cover the transfer
+	fsize := 19000 // this is the known file size of the test file lorem.txt
+	expectedTotal := big.Mul(rh.RetrievalParams.PricePerByte, abi.NewTokenAmount(int64(fsize*2)))
+
+	// *** Retrieve the piece
+
+	did, err := rh.Client.Retrieve(bgCtx, sh.PayloadCid, rmParams, expectedTotal, retrievalPeer.ID, *rh.ExpPaych, retrievalPeer.Address)
+	assert.Equal(t, did, retrievalmarket.DealID(0))
+	require.NoError(t, err)
+
+	ctxTimeout, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+	defer cancel()
+
+	// verify that client subscribers will be notified of state changes
+	var clientDealState retrievalmarket.ClientDealState
+	select {
+	case <-ctxTimeout.Done():
+		t.Error("deal never completed")
+		t.FailNow()
+	case clientDealState = <-clientDealStateChan:
+	}
+
+	ctxTimeout, cancel = context.WithTimeout(bgCtx, 5*time.Second)
+	defer cancel()
+	var providerDealState retrievalmarket.ProviderDealState
+	select {
+	case <-bgCtx.Done():
+		t.Error("provider never saw completed deal")
+		t.FailNow()
+	case providerDealState = <-providerDealStateChan:
+	}
+
+	require.Equal(t, retrievalmarket.DealStatusCompleted, providerDealState.Status)
+	require.Equal(t, retrievalmarket.DealStatusCompleted, clientDealState.Status)
+
+	sh.TestData.VerifyFileTransferred(t, sh.PieceLink, false, uint64(fsize))
+
+}
+
+type storageHarness struct {
+	Ctx          context.Context
+	Epoch        abi.ChainEpoch
+	PieceLink    ipld.Link
+	PayloadCid   cid.Cid
+	ProviderAddr address.Address
+	Client       storagemarket.StorageClient
+	ClientNode   *testnodes.FakeClientNode
+	Provider     storagemarket.StorageProvider
+	ProviderNode *testnodes.FakeProviderNode
+	ProviderInfo storagemarket.StorageProviderInfo
+	TestData     *shared_testutil.Libp2pTestData
+	PieceStore   piecestore.PieceStore
+}
+
+func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
+	epoch := abi.ChainEpoch(100)
+	td := shared_testutil.NewLibp2pTestData(ctx, t)
+	fpath := filepath.Join("retrievalmarket", "impl", "fixtures", "lorem.txt")
+	rootLink := td.LoadUnixFSFile(t, fpath, false)
+	payloadCid := rootLink.(cidlink.Link).Cid
+
+	smState := testnodes.NewStorageMarketState()
+	clientNode := testnodes.FakeClientNode{
+		FakeCommonNode: testnodes.FakeCommonNode{SMState: smState},
+		ClientAddr:     address.TestAddress,
+	}
+
+	expDealID := abi.DealID(rand.Uint64())
+	psdReturn := market.PublishStorageDealsReturn{IDs: []abi.DealID{expDealID}}
+	psdReturnBytes := bytes.NewBuffer([]byte{})
+	require.NoError(t, psdReturn.MarshalCBOR(psdReturnBytes))
+
+	providerAddr := address.TestAddress2
+	tempPath, err := ioutil.TempDir("", "storagemarket_test")
+	require.NoError(t, err)
+	ps := piecestore.NewPieceStore(td.Ds2)
+	providerNode := &testnodes.FakeProviderNode{
+		FakeCommonNode: testnodes.FakeCommonNode{
+			SMState:                smState,
+			WaitForMessageRetBytes: psdReturnBytes.Bytes(),
+		},
+		MinerAddr: providerAddr,
+	}
+	fs, err := filestore.NewLocalFileStore(filestore.OsPath(tempPath))
+	require.NoError(t, err)
+
+	// create provider and client
+	dt1 := graphsyncimpl.NewGraphSyncDataTransfer(td.Host1, td.GraphSync1, td.DTStoredCounter1)
+	require.NoError(t, dt1.RegisterVoucherType(reflect.TypeOf(&requestvalidation.StorageDataTransferVoucher{}), &fakeDTValidator{}))
+
+	client, err := stormkt.NewClient(
+		stornet.NewFromLibp2pHost(td.Host1),
+		td.Bs1,
+		dt1,
+		discovery.NewLocal(td.Ds1),
+		td.Ds1,
+		&clientNode,
+	)
+	require.NoError(t, err)
+	dt2 := graphsyncimpl.NewGraphSyncDataTransfer(td.Host2, td.GraphSync2, td.DTStoredCounter2)
+	provider, err := stormkt.NewProvider(
+		stornet.NewFromLibp2pHost(td.Host2),
+		td.Ds2,
+		td.Bs2,
+		fs,
+		ps,
+		dt2,
+		providerNode,
+		providerAddr,
+		abi.RegisteredProof_StackedDRG2KiBPoSt,
+	)
+	require.NoError(t, err)
+
+	// set ask price where we'll accept any price
+	require.NoError(t, provider.AddAsk(big.NewInt(0), 50_000))
+	require.NoError(t, provider.Start(ctx))
+
+	// Closely follows the MinerInfo struct in the spec
+	providerInfo := storagemarket.StorageProviderInfo{
+		Address:    providerAddr,
+		Owner:      providerAddr,
+		Worker:     providerAddr,
+		SectorSize: 1 << 20,
+		PeerID:     td.Host2.ID(),
+	}
+
+	return &storageHarness{
+		Ctx:          ctx,
+		Epoch:        epoch,
+		PayloadCid:   payloadCid,
+		ProviderAddr: providerAddr,
+		Client:       client,
+		ClientNode:   &clientNode,
+		PieceLink:    rootLink,
+		PieceStore:   ps,
+		Provider:     provider,
+		ProviderNode: providerNode,
+		ProviderInfo: providerInfo,
+		TestData:     td,
+	}
+}
+
+func (sh *storageHarness) ProposeStorageDeal(t *testing.T, dataRef *storagemarket.DataRef) *storagemarket.ProposeStorageDealResult {
+	result, err := sh.Client.ProposeStorageDeal(
+		sh.Ctx,
+		sh.ProviderAddr,
+		&sh.ProviderInfo,
+		dataRef,
+		sh.Epoch+100,
+		sh.Epoch+20100,
+		big.NewInt(1),
+		big.NewInt(0),
+		abi.RegisteredProof_StackedDRG2KiBPoSt,
+	)
+	assert.NoError(t, err)
+	return result
+}
+
+var _ datatransfer.RequestValidator = (*fakeDTValidator)(nil)
+
+type retrievalHarness struct {
+	Ctx                         context.Context
+	Epoch                       abi.ChainEpoch
+	Client                      retrievalmarket.RetrievalClient
+	ClientNode                  *testnodes2.TestRetrievalClientNode
+	Provider                    retrievalmarket.RetrievalProvider
+	ProviderNode                *testnodes2.TestRetrievalProviderNode
+	PieceStore                  piecestore.PieceStore
+	ExpPaych, NewLaneAddr       *address.Address
+	ExpPaychAmt, ActualPaychAmt *abi.TokenAmount
+	ExpVoucher, ActualVoucher   *paych.SignedVoucher
+	RetrievalParams             retrievalmarket.Params
+}
+
+func newRetrievalHarness(ctx context.Context, t *testing.T, sh *storageHarness, deal storagemarket.ClientDeal) *retrievalHarness {
+
+	var newPaychAmt abi.TokenAmount
+	paymentChannelRecorder := func(client, miner address.Address, amt abi.TokenAmount) {
+		newPaychAmt = amt
+	}
+
+	var newLaneAddr address.Address
+	laneRecorder := func(paymentChannel address.Address) {
+		newLaneAddr = paymentChannel
+	}
+
+	var newVoucher paych.SignedVoucher
+	paymentVoucherRecorder := func(v *paych.SignedVoucher) {
+		newVoucher = *v
+	}
+
+	cids := tut.GenerateCids(2)
+	clientPaymentChannel, err := address.NewActorAddress([]byte("a"))
+
+	expectedVoucher := tut.MakeTestSignedVoucher()
+	require.NoError(t, err)
+	clientNode := testnodes2.NewTestRetrievalClientNode(testnodes2.TestRetrievalClientNodeParams{
+		Lane:                   expectedVoucher.Lane,
+		PayCh:                  clientPaymentChannel,
+		Voucher:                expectedVoucher,
+		PaymentChannelRecorder: paymentChannelRecorder,
+		AllocateLaneRecorder:   laneRecorder,
+		PaymentVoucherRecorder: paymentVoucherRecorder,
+		CreatePaychCID:         cids[0],
+		AddFundsCID:            cids[1],
+	})
+
+	nw1 := rmnet.NewFromLibp2pHost(sh.TestData.Host1)
+	client, err := retrievalimpl.NewClient(nw1, sh.TestData.Bs1, clientNode, &tut.TestPeerResolver{}, sh.TestData.Ds1, sh.TestData.RetrievalStoredCounter1)
+
+	payloadCID := deal.DataRef.Root // TODO: is this right?
+	providerPaymentAddr := deal.MinerWorker
+	providerNode := testnodes2.NewTestRetrievalProviderNode()
+	cio := cario.NewCarIO()
+
+	var buf bytes.Buffer
+	require.NoError(t, cio.WriteCar(sh.Ctx, sh.TestData.Bs2, payloadCID, sh.TestData.AllSelector, &buf))
+	carData := buf.Bytes()
+	sectorID := uint64(100000)
+	offset := uint64(1000)
+	pieceInfo := piecestore.PieceInfo{
+		Deals: []piecestore.DealInfo{
+			{
+				SectorID: sectorID,
+				Offset:   offset,
+				Length:   uint64(len(carData)),
+			},
+		},
+	}
+	providerNode.ExpectUnseal(sectorID, offset, uint64(len(carData)), carData)
+	// clear out provider blockstore
+	allCids, err := sh.TestData.Bs2.AllKeysChan(sh.Ctx)
+	require.NoError(t, err)
+	for c := range allCids {
+		err = sh.TestData.Bs2.DeleteBlock(c)
+		require.NoError(t, err)
+	}
+
+	nw2 := rmnet.NewFromLibp2pHost(sh.TestData.Host2)
+	pieceStore := tut.NewTestPieceStore()
+	expectedPiece := tut.GenerateCids(1)[0]
+	cidInfo := piecestore.CIDInfo{
+		PieceBlockLocations: []piecestore.PieceBlockLocation{
+			{
+				PieceCID: expectedPiece,
+			},
+		},
+	}
+	pieceStore.ExpectCID(payloadCID, cidInfo)
+	pieceStore.ExpectPiece(expectedPiece, pieceInfo)
+	provider, err := retrievalimpl.NewProvider(providerPaymentAddr, providerNode, nw2, pieceStore, sh.TestData.Bs2, sh.TestData.Ds2)
+	require.NoError(t, err)
+
+	params := retrievalmarket.Params{
+		PricePerByte:            abi.NewTokenAmount(1000),
+		PaymentInterval:         uint64(10000),
+		PaymentIntervalIncrease: uint64(1000),
+	}
+
+	provider.SetPaymentInterval(params.PaymentInterval, params.PaymentIntervalIncrease)
+	provider.SetPricePerByte(params.PricePerByte)
+	require.NoError(t, provider.Start())
+
+	return &retrievalHarness{
+		Ctx:             ctx,
+		Client:          client,
+		ClientNode:      clientNode,
+		Epoch:           sh.Epoch,
+		ExpPaych:        &clientPaymentChannel,
+		NewLaneAddr:     &newLaneAddr,
+		ActualPaychAmt:  &newPaychAmt,
+		ExpVoucher:      expectedVoucher,
+		ActualVoucher:   &newVoucher,
+		Provider:        provider,
+		ProviderNode:    providerNode,
+		PieceStore:      sh.PieceStore,
+		RetrievalParams: params,
+	}
+}
+
+type fakeDTValidator struct{}
+
+func (v *fakeDTValidator) ValidatePush(sender peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) error {
+	return nil
+}
+
+func (v *fakeDTValidator) ValidatePull(receiver peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) error {
+	return nil
+}
+

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -31,6 +31,7 @@ import (
 	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
 	testnodes2 "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -112,7 +113,7 @@ func TestStorageRetrieval(t *testing.T) {
 	// testing V1 only
 	rmParams := retrievalmarket.NewParamsV1(rh.RetrievalParams.PricePerByte,
 		rh.RetrievalParams.PaymentInterval,
-		rh.RetrievalParams.PaymentIntervalIncrease, retrievalimpl.AllSelector(), nil)
+		rh.RetrievalParams.PaymentIntervalIncrease, shared.AllSelector(), nil)
 
 	voucherAmts := []abi.TokenAmount{abi.NewTokenAmount(10136000), abi.NewTokenAmount(9784000)}
 	proof := []byte("")
@@ -336,7 +337,7 @@ func newRetrievalHarness(ctx context.Context, t *testing.T, sh *storageHarness, 
 	cio := cario.NewCarIO()
 
 	var buf bytes.Buffer
-	require.NoError(t, cio.WriteCar(sh.Ctx, sh.TestData.Bs2, payloadCID, sh.TestData.AllSelector, &buf))
+	require.NoError(t, cio.WriteCar(sh.Ctx, sh.TestData.Bs2, payloadCID, shared.AllSelector(), &buf))
 	carData := buf.Bytes()
 	sectorID := uint64(100000)
 	offset := uint64(1000)

--- a/retrievalmarket/types_test.go
+++ b/retrievalmarket/types_test.go
@@ -7,20 +7,18 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
 func TestParamsMarshalUnmarshal(t *testing.T) {
 	pieceCid := tut.GenerateCids(1)[0]
 
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	node := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-	params := retrievalmarket.NewParamsV1(abi.NewTokenAmount(123), 456, 789, node, &pieceCid)
+	allSelector := shared.AllSelector()
+	params := retrievalmarket.NewParamsV1(abi.NewTokenAmount(123), 456, 789, allSelector, &pieceCid)
 
 	buf := new(bytes.Buffer)
 	err := params.MarshalCBOR(buf)
@@ -36,5 +34,5 @@ func TestParamsMarshalUnmarshal(t *testing.T) {
 	err = dagcbor.Decoder(nb, bytes.NewBuffer(unmarshalled.Selector.Raw))
 	assert.NoError(t, err)
 	sel := nb.Build()
-	assert.Equal(t, sel, node)
+	assert.Equal(t, sel, allSelector)
 }

--- a/shared/selectors.go
+++ b/shared/selectors.go
@@ -1,4 +1,4 @@
-package retrievalimpl
+package shared
 
 import (
 	"github.com/ipld/go-ipld-prime"
@@ -7,6 +7,7 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 )
 
+// entire DAG selector
 func AllSelector() ipld.Node {
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 	return ssb.ExploreRecursive(selector.RecursionLimitNone(),

--- a/shared_testutil/mocknet.go
+++ b/shared_testutil/mocknet.go
@@ -28,9 +28,6 @@ import (
 	"github.com/ipfs/go-unixfs/importer/helpers"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/libp2p/go-libp2p-core/host"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/stretchr/testify/require"
@@ -59,7 +56,6 @@ type Libp2pTestData struct {
 	Storer2                 ipld.Storer
 	Host1                   host.Host
 	Host2                   host.Host
-	AllSelector             ipld.Node
 	OrigBytes               []byte
 }
 
@@ -138,12 +134,6 @@ func NewLibp2pTestData(ctx context.Context, t *testing.T) *Libp2pTestData {
 	testData.GraphSync1 = graphsyncimpl.New(ctx, network.NewFromLibp2pHost(testData.Host1), testData.Loader1, testData.Storer1)
 	testData.GraphSync2 = graphsyncimpl.New(ctx, network.NewFromLibp2pHost(testData.Host2), testData.Loader2, testData.Storer2)
 
-	// create a selector for the whole UnixFS dag
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-
-	testData.AllSelector = ssb.ExploreRecursive(selector.RecursionLimitNone(),
-		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
 	return testData
 }
 
@@ -156,7 +146,7 @@ const unixfsLinksPerLevel = 1024
 func (ltd *Libp2pTestData) LoadUnixFSFile(t *testing.T, fixturesPath string, useSecondNode bool) ipld.Link {
 
 	// read in a fixture file
-	fpath, err := filepath.Abs(filepath.Join(thisDir(t), "..",fixturesPath))
+	fpath, err := filepath.Abs(filepath.Join(thisDir(t), "..", fixturesPath))
 	require.NoError(t, err)
 
 	f, err := os.Open(fpath)

--- a/shared_testutil/test_ipld_tree.go
+++ b/shared_testutil/test_ipld_tree.go
@@ -16,8 +16,8 @@ import (
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+
+	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 // TestIPLDTree is a set of IPLD Data that forms a tree spread across some blocks
@@ -135,13 +135,11 @@ func (tt TestIPLDTree) Get(c cid.Cid) (blocks.Block, error) {
 
 // DumpToCar puts the tree into a car file, with user configured functions
 func (tt TestIPLDTree) DumpToCar(out io.Writer, userOnNewCarBlocks ...car.OnNewCarBlockFunc) error {
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-	node := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
 	ctx := context.Background()
 	sc := car.NewSelectiveCar(ctx, tt, []car.Dag{
 		{
 			Root:     tt.RootNodeLnk.(cidlink.Link).Cid,
-			Selector: node,
+			Selector: shared.AllSelector(),
 		},
 	})
 

--- a/shared_testutil/test_network_types.go
+++ b/shared_testutil/test_network_types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
@@ -639,3 +640,14 @@ func FailStorageResponseWriter(smnet.SignedResponse) error {
 func FailStorageResponseReader() (smnet.SignedResponse, error) {
 	return smnet.SignedResponseUndefined, errors.New("read response failed")
 }
+
+// TestPeerResolver provides a fake retrievalmarket PeerResolver
+type TestPeerResolver struct {
+	Peers         []rm.RetrievalPeer
+	ResolverError error
+}
+
+func (tpr TestPeerResolver) GetPeers(cid.Cid) ([]rm.RetrievalPeer, error) {
+	return tpr.Peers, tpr.ResolverError
+}
+var _ rm.PeerResolver = &TestPeerResolver{}

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -8,9 +8,6 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-fil-markets/pieceio"
@@ -28,13 +25,8 @@ func CommP(ctx context.Context, pieceIO pieceio.PieceIO, rt abi.RegisteredProof,
 	if data.TransferType == storagemarket.TTManual {
 		return cid.Undef, 0, xerrors.New("Piece CID and size must be set for manual transfer")
 	}
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 
-	// entire DAG selector
-	allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
-		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
-
-	commp, paddedSize, err := pieceIO.GeneratePieceCommitment(rt, data.Root, allSelector)
+	commp, paddedSize, err := pieceIO.GeneratePieceCommitment(rt, data.Root, shared.AllSelector())
 	if err != nil {
 		return cid.Undef, 0, xerrors.Errorf("generating CommP: %w", err)
 	}

--- a/storagemarket/impl/clientutils/clientutils_test.go
+++ b/storagemarket/impl/clientutils/clientutils_test.go
@@ -12,10 +12,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/ipfs/go-cid"
-	ipld "github.com/ipld/go-ipld-prime"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	"github.com/ipld/go-ipld-prime"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-fil-markets/shared"
@@ -48,9 +45,7 @@ func TestCommP(t *testing.T) {
 			TransferType: storagemarket.TTGraphsync,
 			Root:         root,
 		}
-		ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
-		allSelector := ssb.ExploreRecursive(selector.RecursionLimitNone(),
-			ssb.ExploreAll(ssb.ExploreRecursiveEdge())).Node()
+		allSelector := shared.AllSelector()
 		t.Run("when pieceIO succeeds", func(t *testing.T) {
 			pieceCid := shared_testutil.GenerateCids(1)[0]
 			pieceSize := abi.UnpaddedPieceSize(rand.Uint64())

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"math/rand"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -238,7 +239,7 @@ type harness struct {
 func newHarness(t *testing.T, ctx context.Context) *harness {
 	epoch := abi.ChainEpoch(100)
 	td := shared_testutil.NewLibp2pTestData(ctx, t)
-	fpath := filepath.Join("storagemarket","fixtures","payload.txt")
+	fpath := filepath.Join("storagemarket", "fixtures", "payload.txt")
 	rootLink := td.LoadUnixFSFile(t, fpath, false)
 	payloadCid := rootLink.(cidlink.Link).Cid
 

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -238,7 +238,8 @@ type harness struct {
 func newHarness(t *testing.T, ctx context.Context) *harness {
 	epoch := abi.ChainEpoch(100)
 	td := shared_testutil.NewLibp2pTestData(ctx, t)
-	rootLink := td.LoadUnixFSFile(t, "payload.txt", false)
+	fpath := filepath.Join("storagemarket","fixtures","payload.txt")
+	rootLink := td.LoadUnixFSFile(t, fpath, false)
 	payloadCid := rootLink.(cidlink.Link).Cid
 
 	smState := testnodes.NewStorageMarketState()

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/discovery"
+	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
@@ -145,7 +146,7 @@ func TestMakeDealOffline(t *testing.T) {
 
 	carBuf := new(bytes.Buffer)
 
-	err := cario.NewCarIO().WriteCar(ctx, h.TestData.Bs1, h.PayloadCid, h.TestData.AllSelector, carBuf)
+	err := cario.NewCarIO().WriteCar(ctx, h.TestData.Bs1, h.PayloadCid, shared.AllSelector(), carBuf)
 	require.NoError(t, err)
 
 	commP, size, err := pieceio.GeneratePieceCommitment(abi.RegisteredProof_StackedDRG2KiBPoSt, carBuf, uint64(carBuf.Len()))
@@ -174,7 +175,7 @@ func TestMakeDealOffline(t *testing.T) {
 	assert.True(t, pd.ProposalCid.Equals(proposalCid))
 	assert.Equal(t, storagemarket.StorageDealWaitingForData, pd.State)
 
-	err = cario.NewCarIO().WriteCar(ctx, h.TestData.Bs1, h.PayloadCid, h.TestData.AllSelector, carBuf)
+	err = cario.NewCarIO().WriteCar(ctx, h.TestData.Bs1, h.PayloadCid, shared.AllSelector(), carBuf)
 	require.NoError(t, err)
 	err = h.Provider.ImportDataForDeal(ctx, pd.ProposalCid, carBuf)
 	require.NoError(t, err)


### PR DESCRIPTION
## Motivation
We need a storage-retrieval round trip integration test.  Closes #74 

## Change Summary:
* make a test that combines the storage and retrieval market integration tests
* move TestPeerResolver to shared testutils so it can be used more widely
* make everybody using `LoadUnixFSFile` have to specify the path to their fixture file, starting from package root, so it can be used more easily by different packages.
* export AllSelector
* please the linter with a bunch of nitpicky changes

More detail about the integration test:
This is essentially the combined storage and retrieval integration tests, with most assertions removed and the remaining ones converted to requires.  For retrieval code, the integration test code is converted to use the test harness method in storage integration test, in particular so the LibP2PTestData can be shared from the storage to the retrieval harness, as well as other things such as the Payload CID, so that the stored file can be retrieved.
