### PR TITLE
Tag deal connections to preserve them

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -368,7 +368,21 @@ func (c *clientDealEnvironment) ReadDealResponse(proposalCid cid.Cid) (network.S
 	return s.ReadDealResponse()
 }
 
+func (c *clientDealEnvironment) TagConnection(proposalCid cid.Cid) error {
+	s, err := c.c.conns.DealStream(proposalCid)
+	if err != nil {
+		return err
+	}
+	s.TagProtectedConnection(proposalCid.String())
+	return nil
+}
+
 func (c *clientDealEnvironment) CloseStream(proposalCid cid.Cid) error {
+	s, err := c.c.conns.DealStream(proposalCid)
+	if err != nil {
+		return err
+	}
+	s.UntagProtectedConnection(proposalCid.String())
 	return c.c.conns.Disconnect(proposalCid)
 }
 

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -442,7 +442,21 @@ func (p *providerDealEnvironment) SendSignedResponse(ctx context.Context, resp *
 	return err
 }
 
+func (p *providerDealEnvironment) TagConnection(proposalCid cid.Cid) error {
+	s, err := p.p.conns.DealStream(proposalCid)
+	if err != nil {
+		return err
+	}
+	s.TagProtectedConnection(proposalCid.String())
+	return nil
+}
+
 func (p *providerDealEnvironment) Disconnect(proposalCid cid.Cid) error {
+	s, err := p.p.conns.DealStream(proposalCid)
+	if err != nil {
+		return err
+	}
+	s.UntagProtectedConnection(proposalCid.String())
 	return p.p.conns.Disconnect(proposalCid)
 }
 

--- a/storagemarket/network/deal_stream.go
+++ b/storagemarket/network/deal_stream.go
@@ -4,12 +4,17 @@ import (
 	"bufio"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
+	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+// TagPriority is the priority for deal streams -- they should generally be preserved above all else
+const TagPriority = 100
+
 type dealStream struct {
 	p        peer.ID
+	host     host.Host
 	rw       mux.MuxedStream
 	buffered *bufio.Reader
 }
@@ -49,4 +54,12 @@ func (d *dealStream) Close() error {
 
 func (d *dealStream) RemotePeer() peer.ID {
 	return d.p
+}
+
+func (d *dealStream) TagProtectedConnection(identifier string) {
+	d.host.ConnManager().TagPeer(d.p, identifier, TagPriority)
+}
+
+func (d *dealStream) UntagProtectedConnection(identifier string) {
+	d.host.ConnManager().UntagPeer(d.p, identifier)
 }

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -43,7 +43,7 @@ func (impl *libp2pStorageMarketNetwork) NewDealStream(id peer.ID) (StorageDealSt
 		return nil, err
 	}
 	buffered := bufio.NewReaderSize(s, 16)
-	return &dealStream{p: id, rw: s, buffered: buffered}, nil
+	return &dealStream{p: id, rw: s, buffered: buffered, host: impl.host}, nil
 }
 
 func (impl *libp2pStorageMarketNetwork) SetDelegate(r StorageReceiver) error {
@@ -80,7 +80,7 @@ func (impl *libp2pStorageMarketNetwork) handleNewDealStream(s network.Stream) {
 	}
 	remotePID := s.Conn().RemotePeer()
 	buffered := bufio.NewReaderSize(s, 16)
-	ds := &dealStream{remotePID, s, buffered}
+	ds := &dealStream{remotePID, impl.host, s, buffered}
 	impl.receiver.HandleDealStream(ds)
 }
 

--- a/storagemarket/network/network.go
+++ b/storagemarket/network/network.go
@@ -22,6 +22,8 @@ type StorageDealStream interface {
 	ReadDealResponse() (SignedResponse, error)
 	WriteDealResponse(SignedResponse) error
 	RemotePeer() peer.ID
+	TagProtectedConnection(identifier string)
+	UntagProtectedConnection(identifier string)
 	Close() error
 }
 


### PR DESCRIPTION
# Goals

Don't drop open storage deal connections

# Implementation

Libp2p's connection manager supports a tagging functionality which helps prevent connections from getting cleaned up when there are lots of them active.

This PR adds a method to do this to the storage deal stream, then pipes it through to the storage deal process so connections get tagged at the moment they become likely to stay open a long time and then untagged at close.

Unfortunately, libp2p's mock network has a connection manager that does nothing, so it's hard to test this at an actual integration level :(