### PR TITLE
Buffer the done channel when adding storage collateral

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -271,7 +271,7 @@ func (c *Client) GetPaymentEscrow(ctx context.Context, addr address.Address) (st
 }
 
 func (c *Client) AddPaymentEscrow(ctx context.Context, addr address.Address, amount abi.TokenAmount) error {
-	done := make(chan error)
+	done := make(chan error, 1)
 
 	mcid, err := c.node.AddFunds(ctx, addr, amount)
 	if err != nil {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -249,7 +249,7 @@ func (p *Provider) ListDeals(ctx context.Context) ([]storagemarket.StorageDeal, 
 }
 
 func (p *Provider) AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error {
-	done := make(chan error)
+	done := make(chan error, 1)
 
 	mcid, err := p.spn.AddFunds(ctx, p.actor, amount)
 	if err != nil {


### PR DESCRIPTION
## Problem
Unbuffered channels in the top-level functions `AddPaymentEscrow` and `AddStorageCollateral` can deadlock if the implementation of `WaitForMessage` is synchronous.

## Solution
Make channels have a buffer.