### PR TITLE
Add a hook to plug in custom deal acceptance logic

### DIFF
--- a/storagemarket/impl/providerstates/provider_fsm.go
+++ b/storagemarket/impl/providerstates/provider_fsm.go
@@ -24,8 +24,10 @@ var ProviderEvents = fsm.Events{
 			deal.Message = xerrors.Errorf("deal rejected: %w", err).Error()
 			return nil
 		}),
+	fsm.Event(storagemarket.ProviderEventDealDeciding).
+		From(storagemarket.StorageDealValidating).To(storagemarket.StorageDealAcceptWait),
 	fsm.Event(storagemarket.ProviderEventDealAccepted).
-		From(storagemarket.StorageDealValidating).To(storagemarket.StorageDealProposalAccepted),
+		From(storagemarket.StorageDealAcceptWait).To(storagemarket.StorageDealProposalAccepted),
 	fsm.Event(storagemarket.ProviderEventWaitingForManualData).
 		From(storagemarket.StorageDealProposalAccepted).To(storagemarket.StorageDealWaitingForData),
 	fsm.Event(storagemarket.ProviderEventDataTransferFailed).
@@ -125,6 +127,7 @@ var ProviderEvents = fsm.Events{
 // ProviderStateEntryFuncs are the handlers for different states in a storage client
 var ProviderStateEntryFuncs = fsm.StateEntryFuncs{
 	storagemarket.StorageDealValidating:          ValidateDealProposal,
+	storagemarket.StorageDealAcceptWait:          DecideOnProposal,
 	storagemarket.StorageDealProposalAccepted:    TransferData,
 	storagemarket.StorageDealVerifyData:          VerifyData,
 	storagemarket.StorageDealEnsureProviderFunds: EnsureProviderFunds,

--- a/storagemarket/impl/providerstates/provider_fsm.go
+++ b/storagemarket/impl/providerstates/provider_fsm.go
@@ -19,7 +19,7 @@ var ProviderEvents = fsm.Events{
 			return nil
 		}),
 	fsm.Event(storagemarket.ProviderEventDealRejected).
-		FromMany(storagemarket.StorageDealValidating, storagemarket.StorageDealVerifyData).To(storagemarket.StorageDealFailing).
+		FromMany(storagemarket.StorageDealValidating, storagemarket.StorageDealVerifyData, storagemarket.StorageDealAcceptWait).To(storagemarket.StorageDealFailing).
 		Action(func(deal *storagemarket.MinerDeal, err error) error {
 			deal.Message = xerrors.Errorf("deal rejected: %w", err).Error()
 			return nil

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -108,6 +108,19 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 	}
 
 	// TODO: Send intent to accept
+	return ctx.Trigger(storagemarket.ProviderEventDealDeciding)
+}
+
+func DecideOnProposal(ctx fsm.Context, environment ProviderDealEnvironment, deal storagemarket.MinerDeal) error {
+	accept, reason, err := environment.Node().DecideOnProposal(ctx.Context(), deal)
+	if err != nil {
+		return xerrors.Errorf("failed to decide on proposal: %w", err)
+	}
+
+	if !accept {
+		return ctx.Trigger(storagemarket.ProviderEventDealRejected, reason)
+	}
+
 	return ctx.Trigger(storagemarket.ProviderEventDealAccepted)
 }
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -3,6 +3,7 @@ package providerstates
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -118,7 +119,7 @@ func DecideOnProposal(ctx fsm.Context, environment ProviderDealEnvironment, deal
 	}
 
 	if !accept {
-		return ctx.Trigger(storagemarket.ProviderEventDealRejected, reason)
+		return ctx.Trigger(storagemarket.ProviderEventDealRejected, fmt.Errorf(reason))
 	}
 
 	return ctx.Trigger(storagemarket.ProviderEventDealAccepted)

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -52,7 +52,7 @@ func TestValidateDealProposal(t *testing.T) {
 				TagsProposal: true,
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, storagemarket.StorageDealProposalAccepted, deal.State)
+				require.Equal(t, storagemarket.StorageDealAcceptWait, deal.State)
 			},
 		},
 		"verify signature fails": {
@@ -87,7 +87,7 @@ func TestValidateDealProposal(t *testing.T) {
 			dealParams:        dealParams{StartEpoch: 200},
 			nodeParams:        nodeParams{Height: 190},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal) {
-				require.Equal(t, storagemarket.StorageDealProposalAccepted, deal.State)
+				require.Equal(t, storagemarket.StorageDealAcceptWait, deal.State)
 			},
 		},
 		"CurrentHeight > StartEpoch - DealAcceptanceBuffer() fails": {

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -96,6 +96,7 @@ func TestMakeDeal(t *testing.T) {
 
 	expProviderStates := []storagemarket.StorageDealStatus{
 		storagemarket.StorageDealValidating,
+		storagemarket.StorageDealAcceptWait,
 		storagemarket.StorageDealProposalAccepted,
 		storagemarket.StorageDealTransferring,
 		storagemarket.StorageDealVerifyData,

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -282,4 +282,8 @@ func (n *FakeProviderNode) LocatePieceForDealWithinSector(ctx context.Context, d
 	return 0, 0, 0, n.LocatePieceForDealWithinSectorError
 }
 
+func (n *FakeProviderNode) DecideOnProposal(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error) {
+	return true, "", nil
+}
+
 var _ storagemarket.StorageProviderNode = (*FakeProviderNode)(nil)

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -44,6 +44,7 @@ const (
 
 	StorageDealFundsEnsured        // Deposited funds as neccesary to create a deal, ready to move forward
 	StorageDealValidating          // Verifying that deal parameters are good
+	StorageDealAcceptWait          // Deciding whether or not to accept the deal
 	StorageDealTransferring        // Moving data
 	StorageDealWaitingForData      // Manual transfer
 	StorageDealVerifyData          // Verify transferred data - generate CAR / piece data
@@ -63,6 +64,7 @@ var DealStates = map[StorageDealStatus]string{
 	StorageDealProposalNotFound:    "StorageDealProposalNotFound",
 	StorageDealProposalRejected:    "StorageDealProposalRejected",
 	StorageDealProposalAccepted:    "StorageDealProposalAccepted",
+	StorageDealAcceptWait:          "StorageDealAcceptWait",
 	StorageDealStaged:              "StorageDealStaged",
 	StorageDealSealing:             "StorageDealSealing",
 	StorageDealActive:              "StorageDealActive",
@@ -151,6 +153,9 @@ const (
 	// ProviderEventNodeErrored indicates an error happened talking to the node implementation
 	ProviderEventNodeErrored
 
+	// ProviderEventDealDeciding happens when a deal is being decided on by the miner
+	ProviderEventDealDeciding
+
 	// ProviderEventDealRejected happens when a deal proposal is rejected for not meeting criteria
 	ProviderEventDealRejected
 
@@ -238,6 +243,7 @@ var ProviderEvents = map[ProviderEvent]string{
 	ProviderEventNodeErrored:            "ProviderEventNodeErrored",
 	ProviderEventDealRejected:           "ProviderEventDealRejected",
 	ProviderEventDealAccepted:           "ProviderEventDealAccepted",
+	ProviderEventDealDeciding:           "ProviderEventDealDeciding",
 	ProviderEventWaitingForManualData:   "ProviderEventWaitingForManualData",
 	ProviderEventInsufficientFunds:      "ProviderEventInsufficientFunds",
 	ProviderEventFundingInitiated:       "ProviderEventFundingInitiated",
@@ -443,6 +449,8 @@ type StorageProviderNode interface {
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, cb DealSectorCommittedCallback) error
 
 	LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID, tok shared.TipSetToken) (sectorID uint64, offset uint64, length uint64, err error)
+
+	DecideOnProposal(ctx context.Context, deal MinerDeal) (bool, string, error)
 }
 
 // Node dependencies for a StorageClient


### PR DESCRIPTION
Working on getting a hook integrated so that the logic for deciding whether or not to accept a deal lives in the node implementation. This will give us a lot more freedom, and effectively resolves #255 for free

This is still a bit WIP, need to make tests pass and all, but it seems like we might be able to move information about asks out of this module.