### PR TITLE
Remove storedask from provider

### DIFF
--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-data-transfer/impl/graphsync"
+	graphsyncimpl "github.com/filecoin-project/go-data-transfer/impl/graphsync"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -37,6 +38,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	stormkt "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
 	stornet "github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
 )
@@ -220,6 +222,8 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	)
 	require.NoError(t, err)
 	dt2 := graphsyncimpl.NewGraphSyncDataTransfer(td.Host2, td.GraphSync2, td.DTStoredCounter2)
+	storedAsk, err := storedask.NewStoredAsk(td.Ds2, datastore.NewKey("latest-ask"), providerNode, providerAddr)
+	require.NoError(t, err)
 	provider, err := stormkt.NewProvider(
 		stornet.NewFromLibp2pHost(td.Host2),
 		td.Ds2,
@@ -230,6 +234,7 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 		providerNode,
 		providerAddr,
 		abi.RegisteredProof_StackedDRG2KiBPoSt,
+		storedAsk,
 	)
 	require.NoError(t, err)
 

--- a/storagemarket/impl/storedask/storedask_test.go
+++ b/storagemarket/impl/storedask/storedask_test.go
@@ -23,7 +23,7 @@ func TestStoredAsk(t *testing.T) {
 		},
 	}
 	actor := address.TestAddress2
-	storedAsk, err := storedask.NewStoredAsk(ds, spn, actor)
+	storedAsk, err := storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spn, actor)
 	require.NoError(t, err)
 
 	testPrice := abi.NewTokenAmount(1000000000)
@@ -48,7 +48,7 @@ func TestStoredAsk(t *testing.T) {
 		require.Nil(t, ask)
 	})
 	t.Run("reloading stored ask from disk", func(t *testing.T) {
-		storedAsk2, err := storedask.NewStoredAsk(ds, spn, actor)
+		storedAsk2, err := storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spn, actor)
 		require.NoError(t, err)
 		ask := storedAsk2.GetAsk(actor)
 		require.Equal(t, ask.Ask.Price, testPrice)
@@ -62,7 +62,7 @@ func TestStoredAsk(t *testing.T) {
 			},
 		}
 		// should load cause ask is is still in data store
-		storedAskError, err := storedask.NewStoredAsk(ds, spnStateIDErr, actor)
+		storedAskError, err := storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnStateIDErr, actor)
 		require.NoError(t, err)
 		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)
@@ -74,7 +74,7 @@ func TestStoredAsk(t *testing.T) {
 			MinerWorkerError: errors.New("something went wrong"),
 		}
 		// should load cause ask is is still in data store
-		storedAskError, err = storedask.NewStoredAsk(ds, spnMinerWorkerErr, actor)
+		storedAskError, err = storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnMinerWorkerErr, actor)
 		require.NoError(t, err)
 		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)
@@ -86,7 +86,7 @@ func TestStoredAsk(t *testing.T) {
 			SignBytesError: errors.New("something went wrong"),
 		}
 		// should load cause ask is is still in data store
-		storedAskError, err = storedask.NewStoredAsk(ds, spnSignBytesErr, actor)
+		storedAskError, err = storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnSignBytesErr, actor)
 		require.NoError(t, err)
 		err = storedAskError.AddAsk(testPrice, testDuration)
 		require.Error(t, err)

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -33,6 +34,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
 )
@@ -284,7 +286,10 @@ func newHarness(t *testing.T, ctx context.Context) *harness {
 		&clientNode,
 	)
 	require.NoError(t, err)
+
 	dt2 := graphsync.NewGraphSyncDataTransfer(td.Host2, td.GraphSync2, td.DTStoredCounter2)
+	storedAsk, err := storedask.NewStoredAsk(td.Ds2, datastore.NewKey("latest-ask"), providerNode, providerAddr)
+	assert.NoError(t, err)
 	provider, err := storageimpl.NewProvider(
 		network.NewFromLibp2pHost(td.Host2),
 		td.Ds2,
@@ -295,6 +300,7 @@ func newHarness(t *testing.T, ctx context.Context) *harness {
 		providerNode,
 		providerAddr,
 		abi.RegisteredProof_StackedDRG2KiBPoSt,
+		storedAsk,
 	)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
# Goals

Add one more element of datastore customization

# Implementation

- Move stored ask out of provider so its setup and configured seperately. 
- Also allow customizing the DS key for stored ask
- Remove prefix for provider in DS store
- Modify integration tests
