### PR TITLE
Feat/restart deals client #65

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-data-transfer v0.3.0
 	github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6
-	github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9
+	github.com/filecoin-project/go-statemachine v0.0.0-20200608174332-9cf2bfb43ac0
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200508203401-a74812ba12f3
@@ -45,5 +45,3 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
-
-replace github.com/filecoin-project/go-statemachine => ../go-statemachine

--- a/go.mod
+++ b/go.mod
@@ -37,10 +37,12 @@ require (
 	github.com/libp2p/go-libp2p v0.6.0
 	github.com/libp2p/go-libp2p-core v0.5.0
 	github.com/multiformats/go-multihash v0.0.13
+	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.5.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200414195334-429a0b5e922e
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+	google.golang.org/appengine v1.4.0
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.mod
+++ b/go.mod
@@ -37,12 +37,10 @@ require (
 	github.com/libp2p/go-libp2p v0.6.0
 	github.com/libp2p/go-libp2p-core v0.5.0
 	github.com/multiformats/go-multihash v0.0.13
-	github.com/opentracing/opentracing-go v1.1.0
 	github.com/stretchr/testify v1.5.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200414195334-429a0b5e922e
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-	google.golang.org/appengine v1.4.0
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,5 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+
+replace github.com/filecoin-project/go-statemachine => ../go-statemachine

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,10 @@ github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:9
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.1 h1:gV7bs5YaqlgpGFMiLxInGK2L1FyCXUE0rimz4L7ghoE=
 github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
+github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
+github.com/filecoin-project/go-statemachine v0.0.0-20200608174332-9cf2bfb43ac0 h1:n/GZr0GvVOrz9SCD6lLyxK+qq1Ux0sWOaFsY957A0h4=
+github.com/filecoin-project/go-statemachine v0.0.0-20200608174332-9cf2bfb43ac0/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:9
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.1 h1:gV7bs5YaqlgpGFMiLxInGK2L1FyCXUE0rimz4L7ghoE=
 github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,6 @@ github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6 h1:9
 github.com/filecoin-project/go-padreader v0.0.0-20200210211231-548257017ca6/go.mod h1:0HgYnrkeSU4lu1p+LEOeDpFsNBssa0OGGriWdA4hvaE=
 github.com/filecoin-project/go-paramfetch v0.0.1 h1:gV7bs5YaqlgpGFMiLxInGK2L1FyCXUE0rimz4L7ghoE=
 github.com/filecoin-project/go-paramfetch v0.0.1/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9 h1:k9qVR9ItcziSB2rxtlkN/MDWNlbsI6yzec+zjUatLW0=
-github.com/filecoin-project/go-statemachine v0.0.0-20200226041606-2074af6d51d9/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statemachine v0.0.0-20200608174332-9cf2bfb43ac0 h1:n/GZr0GvVOrz9SCD6lLyxK+qq1Ux0sWOaFsY957A0h4=
 github.com/filecoin-project/go-statemachine v0.0.0-20200608174332-9cf2bfb43ac0/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
 github.com/filecoin-project/go-statestore v0.1.0 h1:t56reH59843TwXHkMcwyuayStBIiWBRilQjQ+5IiwdQ=

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -175,7 +175,9 @@ func (c *client) Stop() {
 			log.Error(err)
 		}
 	}
-	c.stateMachines.Stop(cont)
+	if err := c.stateMachines.Stop(context.Background()); err != nil {
+		log.Error(err)
+	}
 }
 
 func (c *client) Start() {

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -168,6 +168,19 @@ func (c *client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrie
 	return dealID, nil
 }
 
+// Stop stops processing by the client
+func (c *client) Stop() {
+	for _, ds := range c.dealStreams {
+		if err := ds.Close(); err != nil {
+			log.Error(err)
+		}
+	}
+	c.stateMachines.Stop(cont)
+}
+
+func (c *client) Start() {
+}
+
 // unsubscribeAt returns a function that removes an item from the subscribers list by comparing
 // their reflect.ValueOf before pulling the item out of the slice.  Does not preserve order.
 // Subsequent, repeated calls to the func with the same Subscriber are a no-op.

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -74,7 +74,8 @@ func NewClient(
 		return nil, err
 	}
 	c.stateMachines = stateMachines
-	return c, nil
+	err = c.Start()
+	return c, err
 }
 
 // V0
@@ -169,18 +170,17 @@ func (c *client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrie
 }
 
 // Stop stops processing by the client
-func (c *client) Stop() {
+func (c *client) Stop() error {
 	for _, ds := range c.dealStreams {
 		if err := ds.Close(); err != nil {
-			log.Error(err)
+			return err
 		}
 	}
-	if err := c.stateMachines.Stop(context.Background()); err != nil {
-		log.Error(err)
-	}
+	return c.stateMachines.Stop(context.Background())
 }
 
-func (c *client) Start() {
+func (c *client) Start() error {
+	return nil
 }
 
 // unsubscribeAt returns a function that removes an item from the subscribers list by comparing

--- a/retrievalmarket/impl/clientstates/client_fsm.go
+++ b/retrievalmarket/impl/clientstates/client_fsm.go
@@ -180,7 +180,7 @@ var ClientEvents = fsm.Events{
 		From(rm.DealStatusPaymentChannelReady).To(rm.DealStatusOngoing).
 		From(rm.DealStatusOngoing).ToNoChange().
 		Action(recordProcessed),
-	fsm.Event(rm.ClientEventDealResume).
+	fsm.Event(rm.ClientEventDealRestart).
 		FromAny().ToNoChange(),
 }
 

--- a/retrievalmarket/impl/clientstates/client_fsm.go
+++ b/retrievalmarket/impl/clientstates/client_fsm.go
@@ -197,3 +197,9 @@ var ClientStateEntryFuncs = fsm.StateEntryFuncs{
 	rm.DealStatusFundsNeededLastPayment:    ProcessPaymentRequested,
 	rm.DealStatusFinalizing:                Finalize,
 }
+
+var ClientFinalityStates = []fsm.StateKey{
+	rm.DealStatusCompleted,
+	rm.DealStatusErrored,
+	rm.DealStatusFailed,
+}

--- a/retrievalmarket/impl/clientstates/client_fsm.go
+++ b/retrievalmarket/impl/clientstates/client_fsm.go
@@ -180,6 +180,8 @@ var ClientEvents = fsm.Events{
 		From(rm.DealStatusPaymentChannelReady).To(rm.DealStatusOngoing).
 		From(rm.DealStatusOngoing).ToNoChange().
 		Action(recordProcessed),
+	fsm.Event(rm.ClientEventDealResume).
+		FromAny().ToNoChange(),
 }
 
 // ClientStateEntryFuncs are the handlers for different states in a retrieval client

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -7,7 +7,6 @@ import (
 	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
-	"github.com/opentracing/opentracing-go/log"
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -196,6 +196,5 @@ func Finalize(ctx fsm.Context, environment ClientDealEnvironment, deal rm.Client
 	if response.Status != rm.DealStatusCompleted {
 		return ctx.Trigger(rm.ClientEventUnknownResponseReceived)
 	}
-
 	return ctx.Trigger(rm.ClientEventComplete, uint64(0))
 }

--- a/retrievalmarket/impl/clientstates/client_states.go
+++ b/retrievalmarket/impl/clientstates/client_states.go
@@ -7,6 +7,7 @@ import (
 	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
+	"github.com/opentracing/opentracing-go/log"
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -305,7 +305,6 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 
 /// =======================
 func TestRestartProvider(t *testing.T) {
-	log.SetDebugLogging()
 	bgCtx := context.Background()
 
 	ch := new(test_harnesses.ClientHarness).Bootstrap(bgCtx, t, false)
@@ -343,11 +342,13 @@ func TestRestartProvider(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	ctx, cancel := context.WithTimeout(bgCtx, 15*time.Second)
+	ctx, cancel := context.WithTimeout(bgCtx, 5*time.Second)
 	defer cancel()
 	var seenState rm.ProviderDealState
 	seen := 0
-	// wait for client to process past the restart
+	// wait for client to process events past the restart.
+	// it will not complete the transfer due to connection issues between
+	// client and provider.
 	for seen < 5 {
 		select {
 		case <-ctx.Done():
@@ -358,6 +359,7 @@ func TestRestartProvider(t *testing.T) {
 		}
 	}
 	// checking only that provider continues processing
+	// TODO: this isn't the correct ending status.
 	assert.Equal(t, rm.DealStatusFundsNeeded, seenState.Status)
 }
 

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -109,10 +109,6 @@ func (p *Provider) Stop() error {
 	if err != nil {
 		return err
 	}
-	err = p.stateMachines.Stop(context.Background())
-	if err != nil {
-		return err
-	}
 	return p.network.StopHandlingRequests()
 }
 

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -109,6 +109,10 @@ func (p *Provider) Stop() error {
 	if err != nil {
 		return err
 	}
+	err = p.stateMachines.Stop(context.Background())
+	if err != nil {
+		return err
+	}
 	return p.network.StopHandlingRequests()
 }
 

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -2,7 +2,6 @@ package retrievalimpl_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -249,80 +248,6 @@ func TestProviderConfigOpts(t *testing.T) {
 		bs, ds, ddOpt)
 	require.NoError(t, err)
 	require.NotNil(t, p)
-}
-
-func TestProviderRestart(t *testing.T) {
-	payloadCID := tut.GenerateCids(1)[0]
-	expectedPeer := peer.ID("somepeer")
-	expectedSize := uint64(1234)
-
-	expectedPieceCID := tut.GenerateCids(1)[0]
-	expectedCIDInfo := piecestore.CIDInfo{
-		PieceBlockLocations: []piecestore.PieceBlockLocation{
-			{
-				PieceCID: expectedPieceCID,
-			},
-		},
-	}
-	expectedPiece := piecestore.PieceInfo{
-		Deals: []piecestore.DealInfo{
-			{
-				Length: expectedSize,
-			},
-		},
-	}
-	expectedAddress := address.TestAddress2
-	expectedPricePerByte := abi.NewTokenAmount(4321)
-	expectedPaymentInterval := uint64(4567)
-	expectedPaymentIntervalIncrease := uint64(100)
-
-	rwDealStream := func() network.RetrievalDealStream {
-		pRead, pWrite := ProposalReadWriter()
-		rRead, rWrite := ResponseReadWriter()
-		qs := tut.NewTestRetrievalDealStream(tut.TestDealStreamParams{
-			PeerID:         expectedPeer,
-			ProposalReader: pRead,
-			ProposalWriter: pWrite,
-			ResponseReader: rRead,
-			ResponseWriter: rWrite,
-		})
-		return qs
-	}
-}
-
-func ProposalReadWriter() (tut.DealProposalReader, tut.DealProposalWriter) {
-	var p retrievalmarket.DealProposal
-	var written bool
-	propRead := func() (retrievalmarket.DealProposal, error) {
-		if written {
-			return p, nil
-		}
-		return retrievalmarket.DealProposalUndefined, errors.New("unable to read proposal")
-	}
-
-	propWrite := func(wp retrievalmarket.DealProposal) error {
-		p = wp
-		written = true
-		return nil
-	}
-	return propRead, propWrite
-}
-
-func ResponseReadWriter() (tut.DealResponseReader, tut.DealResponseWriter) {
-	var dr retrievalmarket.DealResponse
-	var written bool
-	responseRead := func() (retrievalmarket.DealResponse, error) {
-		if written {
-			return dr, nil
-		}
-		return retrievalmarket.DealResponseUndefined, errors.New("unabled to read deal response")
-	}
-	responseWrite := func(wdr retrievalmarket.DealResponse) error {
-		dr = wdr
-		written = true
-		return nil
-	}
-	return responseRead, responseWrite
 }
 
 // loadPieceCIDS sets expectations to receive expectedPieceCID and 3 other random PieceCIDs to

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -2,6 +2,7 @@ package retrievalimpl_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/filecoin-project/go-address"
@@ -248,6 +249,80 @@ func TestProviderConfigOpts(t *testing.T) {
 		bs, ds, ddOpt)
 	require.NoError(t, err)
 	require.NotNil(t, p)
+}
+
+func TestProviderRestart(t *testing.T) {
+	payloadCID := tut.GenerateCids(1)[0]
+	expectedPeer := peer.ID("somepeer")
+	expectedSize := uint64(1234)
+
+	expectedPieceCID := tut.GenerateCids(1)[0]
+	expectedCIDInfo := piecestore.CIDInfo{
+		PieceBlockLocations: []piecestore.PieceBlockLocation{
+			{
+				PieceCID: expectedPieceCID,
+			},
+		},
+	}
+	expectedPiece := piecestore.PieceInfo{
+		Deals: []piecestore.DealInfo{
+			{
+				Length: expectedSize,
+			},
+		},
+	}
+	expectedAddress := address.TestAddress2
+	expectedPricePerByte := abi.NewTokenAmount(4321)
+	expectedPaymentInterval := uint64(4567)
+	expectedPaymentIntervalIncrease := uint64(100)
+
+	rwDealStream := func() network.RetrievalDealStream {
+		pRead, pWrite := ProposalReadWriter()
+		rRead, rWrite := ResponseReadWriter()
+		qs := tut.NewTestRetrievalDealStream(tut.TestDealStreamParams{
+			PeerID:         expectedPeer,
+			ProposalReader: pRead,
+			ProposalWriter: pWrite,
+			ResponseReader: rRead,
+			ResponseWriter: rWrite,
+		})
+		return qs
+	}
+}
+
+func ProposalReadWriter() (tut.DealProposalReader, tut.DealProposalWriter) {
+	var p retrievalmarket.DealProposal
+	var written bool
+	propRead := func() (retrievalmarket.DealProposal, error) {
+		if written {
+			return p, nil
+		}
+		return retrievalmarket.DealProposalUndefined, errors.New("unable to read proposal")
+	}
+
+	propWrite := func(wp retrievalmarket.DealProposal) error {
+		p = wp
+		written = true
+		return nil
+	}
+	return propRead, propWrite
+}
+
+func ResponseReadWriter() (tut.DealResponseReader, tut.DealResponseWriter) {
+	var dr retrievalmarket.DealResponse
+	var written bool
+	responseRead := func() (retrievalmarket.DealResponse, error) {
+		if written {
+			return dr, nil
+		}
+		return retrievalmarket.DealResponseUndefined, errors.New("unabled to read deal response")
+	}
+	responseWrite := func(wdr retrievalmarket.DealResponse) error {
+		dr = wdr
+		written = true
+		return nil
+	}
+	return responseRead, responseWrite
 }
 
 // loadPieceCIDS sets expectations to receive expectedPieceCID and 3 other random PieceCIDs to

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -92,6 +92,8 @@ var ProviderEvents = fsm.Events{
 		}),
 	fsm.Event(rm.ProviderEventComplete).
 		From(rm.DealStatusFinalizing).To(rm.DealStatusCompleted),
+	fsm.Event(rm.ProviderEventDealResume).
+		FromAny().ToNoChange(),
 }
 
 // ProviderStateEntryFuncs are the handlers for different states in a retrieval provider

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -92,9 +92,7 @@ var ProviderEvents = fsm.Events{
 		}),
 	fsm.Event(rm.ProviderEventComplete).
 		From(rm.DealStatusFinalizing).To(rm.DealStatusCompleted),
-	fsm.Event(rm.ProviderEventDealSuspended).
-		FromAny().ToNoChange(),
-	fsm.Event(rm.ProviderEventDealResumed).
+	fsm.Event(rm.ProviderEventDealRestart).
 		FromAny().ToNoChange(),
 }
 

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -92,7 +92,9 @@ var ProviderEvents = fsm.Events{
 		}),
 	fsm.Event(rm.ProviderEventComplete).
 		From(rm.DealStatusFinalizing).To(rm.DealStatusCompleted),
-	fsm.Event(rm.ProviderEventDealResume).
+	fsm.Event(rm.ProviderEventDealSuspended).
+		FromAny().ToNoChange(),
+	fsm.Event(rm.ProviderEventDealResumed).
 		FromAny().ToNoChange(),
 }
 

--- a/retrievalmarket/impl/providerstates/provider_fsm.go
+++ b/retrievalmarket/impl/providerstates/provider_fsm.go
@@ -1,8 +1,6 @@
 package providerstates
 
 import (
-	"fmt"
-
 	"github.com/filecoin-project/go-statemachine/fsm"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
@@ -69,7 +67,6 @@ var ProviderEvents = fsm.Events{
 		FromMany(rm.DealStatusAccepted, rm.DealStatusOngoing).To(rm.DealStatusFundsNeeded).
 		From(rm.DealStatusBlocksComplete).To(rm.DealStatusFundsNeededLastPayment).
 		Action(func(deal *rm.ProviderDealState, totalSent uint64) error {
-			fmt.Println("Requesting payment")
 			deal.TotalSent = totalSent
 			return nil
 		}),
@@ -108,4 +105,10 @@ var ProviderStateEntryFuncs = fsm.StateEntryFuncs{
 	rm.DealStatusFundsNeeded:            ProcessPayment,
 	rm.DealStatusFundsNeededLastPayment: ProcessPayment,
 	rm.DealStatusFinalizing:             Finalize,
+}
+
+var FinalityStates = []fsm.StateKey{
+	rm.DealStatusCompleted,
+	rm.DealStatusErrored,
+	rm.DealStatusFailed,
 }

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -74,6 +74,7 @@ func DecideOnDeal(ctx fsm.Context, env ProviderDealEnvironment, state rm.Provide
 
 // SendBlocks sends blocks to the client until funds are needed
 func SendBlocks(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.ProviderDealState) error {
+	log.Info("HERE")
 	totalSent := deal.TotalSent
 	totalPaidFor := big.Div(deal.FundsReceived, deal.PricePerByte).Uint64()
 	var blocks []rm.Block
@@ -110,7 +111,6 @@ func SendBlocks(ctx fsm.Context, environment ProviderDealEnvironment, deal rm.Pr
 	if err != nil {
 		return ctx.Trigger(rm.ProviderEventWriteResponseFailed, err)
 	}
-
 	return ctx.Trigger(rm.ProviderEventPaymentRequested, totalSent)
 }
 

--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -8,11 +8,14 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
 	"golang.org/x/xerrors"
 
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 )
+
+var log = logging.Logger("providerstates")
 
 // ProviderDealEnvironment is a bridge to the environment a provider deal is executing in
 type ProviderDealEnvironment interface {

--- a/retrievalmarket/impl/test_harnesses/client_harness.go
+++ b/retrievalmarket/impl/test_harnesses/client_harness.go
@@ -1,0 +1,94 @@
+package test_harnesses
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
+)
+
+type ClientHarness struct {
+	ctx context.Context
+	t   *testing.T
+	retrievalmarket.RetrievalClient
+	ClientNode                  *testnodes.TestRetrievalClientNode
+	CreatedPayChInfo            PayChInfo
+	CreatedVoucher              *paych.SignedVoucher
+	ExpectedVoucher             *paych.SignedVoucher
+	Network                     network.RetrievalMarketNetwork
+	NewLaneAddr                 address.Address
+	PaychAddr                   address.Address
+	CreatePaychCID, AddFundsCID cid.Cid
+	TestData                    *shared_testutil.Libp2pTestData
+}
+
+type PayChInfo struct {
+	Client, Miner address.Address
+	Amt           abi.TokenAmount
+}
+
+func (ch *ClientHarness) Bootstrap(ctx context.Context, t *testing.T, addFunds bool) *ClientHarness {
+	var err error
+	ch.t = t
+	ch.ctx = ctx
+	if ch.TestData == nil {
+		ch.TestData = shared_testutil.NewLibp2pTestData(ctx, t)
+	}
+	paymentChannelRecorder := func(client, miner address.Address, amt abi.TokenAmount) {
+		ch.CreatedPayChInfo = PayChInfo{Client: client, Miner: miner, Amt: amt}
+	}
+
+	laneRecorder := func(paymentChannel address.Address) {
+		ch.NewLaneAddr = paymentChannel
+	}
+
+	paymentVoucherRecorder := func(v *paych.SignedVoucher) {
+		ch.CreatedVoucher = v
+	}
+	cids := shared_testutil.GenerateCids(2)
+	ch.AddFundsCID = cids[0]
+	ch.CreatePaychCID = cids[1]
+
+	if ch.PaychAddr == address.Undef {
+		ch.PaychAddr, err = address.NewIDAddress(rand.Uint64())
+		require.NoError(ch.t, err)
+	}
+
+	if ch.ExpectedVoucher == nil {
+		ch.ExpectedVoucher = shared_testutil.MakeTestSignedVoucher()
+	}
+
+	if ch.ClientNode == nil {
+		ch.ClientNode = testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{
+			AddFundsOnly:           addFunds,
+			PayCh:                  ch.PaychAddr,
+			Lane:                   ch.ExpectedVoucher.Lane,
+			Voucher:                ch.ExpectedVoucher,
+			PaymentChannelRecorder: paymentChannelRecorder,
+			AllocateLaneRecorder:   laneRecorder,
+			PaymentVoucherRecorder: paymentVoucherRecorder,
+			CreatePaychCID:         cids[0],
+			AddFundsCID:            cids[1],
+		})
+	}
+
+	if ch.Network == nil {
+		ch.Network = network.NewFromLibp2pHost(ch.TestData.Host1)
+
+	}
+	ch.RetrievalClient, err = retrievalimpl.NewClient(ch.Network, ch.TestData.Bs1, ch.ClientNode,
+		&shared_testutil.TestPeerResolver{}, ch.TestData.Ds1, ch.TestData.RetrievalStoredCounter1)
+	require.NoError(ch.t, err)
+	return ch
+}

--- a/retrievalmarket/impl/test_harnesses/provider_harness.go
+++ b/retrievalmarket/impl/test_harnesses/provider_harness.go
@@ -26,6 +26,7 @@ import (
 type ProviderHarness struct {
 	ctx          context.Context
 	t            *testing.T
+	ProviderOpts []retrievalimpl.RetrievalProviderOption
 	Filename     string
 	Filesize     uint64
 	ExpectedQR   *retrievalmarket.QueryResponse
@@ -40,6 +41,9 @@ type ProviderHarness struct {
 	TestData *shared_testutil.Libp2pTestData
 }
 
+// Bootstrap uses the provided file information and unsealing flag to
+// use the test harness settings, to set up requisite test dependencies,
+// initialize and start a new RetrievalProvider.
 func (ph *ProviderHarness) Bootstrap(ctx context.Context, t *testing.T, filename string,
 	filesize uint64, unsealing bool) *ProviderHarness {
 	ph.ctx = ctx
@@ -98,7 +102,7 @@ func (ph *ProviderHarness) Bootstrap(ctx context.Context, t *testing.T, filename
 	ps.ExpectPiece(expectedPiece, pieceInfo)
 
 	provider, err := retrievalimpl.NewProvider(providerPaymentAddr, ph.ProviderNode, ph.Network,
-		ps, ph.TestData.Bs2, ph.TestData.Ds2)
+		ps, ph.TestData.Bs2, ph.TestData.Ds2, ph.ProviderOpts...)
 	require.NoError(t, err)
 
 	provider.SetPaymentInterval(ph.ExpectedQR.MaxPaymentInterval,
@@ -109,6 +113,7 @@ func (ph *ProviderHarness) Bootstrap(ctx context.Context, t *testing.T, filename
 	ph.PieceStore = ps
 	return ph
 }
+
 func (ph *ProviderHarness) setupUnseal(unsealing bool) (pi piecestore.PieceInfo) {
 	if !unsealing {
 		pi = piecestore.PieceInfo{

--- a/retrievalmarket/impl/test_harnesses/provider_harness.go
+++ b/retrievalmarket/impl/test_harnesses/provider_harness.go
@@ -1,0 +1,150 @@
+package test_harnesses
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-fil-markets/pieceio/cario"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
+	"github.com/filecoin-project/go-fil-markets/shared_testutil"
+)
+
+type ProviderHarness struct {
+	ctx          context.Context
+	t            *testing.T
+	Filename     string
+	Filesize     uint64
+	ExpectedQR   *retrievalmarket.QueryResponse
+	Network      network.RetrievalMarketNetwork
+	PayloadCID   cid.Cid
+	PaychAddr    address.Address
+	PieceInfo    *piecestore.PieceInfo
+	PieceLink    ipld.Link
+	PieceStore   piecestore.PieceStore
+	ProviderNode *testnodes.TestRetrievalProviderNode
+	retrievalmarket.RetrievalProvider
+	TestData *shared_testutil.Libp2pTestData
+}
+
+func (ph *ProviderHarness) Bootstrap(ctx context.Context, t *testing.T, filename string,
+	filesize uint64, unsealing bool) *ProviderHarness {
+	ph.ctx = ctx
+	ph.t = t
+	ph.Filename = filename
+	ph.Filesize = filesize
+	var err error
+	if ph.TestData == nil {
+		ph.TestData = shared_testutil.NewLibp2pTestData(ph.ctx, t)
+	}
+	if ph.Network == nil {
+		ph.Network = network.NewFromLibp2pHost(ph.TestData.Host2)
+	}
+	if ph.PaychAddr == address.Undef {
+		ph.PaychAddr, err = address.NewIDAddress(999)
+		require.NoError(ph.t, err)
+	}
+
+	// Inject a unixFS file on the provider side to its blockstore
+	// obtained via `ls -laf` on this file
+	fpath := filepath.Join("retrievalmarket", "impl", "fixtures", filename)
+
+	ph.PieceLink = ph.TestData.LoadUnixFSFile(t, fpath, true)
+	c, ok := ph.PieceLink.(cidlink.Link)
+	require.True(t, ok)
+	ph.PayloadCID = c.Cid
+	providerPaymentAddr, err := address.NewIDAddress(575)
+	require.NoError(t, err)
+	paymentInterval := uint64(10000)
+	paymentIntervalIncrease := uint64(1000)
+	pricePerByte := abi.NewTokenAmount(1000)
+
+	ph.ExpectedQR = &retrievalmarket.QueryResponse{
+		Size:                       1024,
+		PaymentAddress:             providerPaymentAddr,
+		MinPricePerByte:            pricePerByte,
+		MaxPaymentInterval:         paymentInterval,
+		MaxPaymentIntervalIncrease: paymentIntervalIncrease,
+	}
+
+	if ph.ProviderNode == nil {
+		ph.ProviderNode = testnodes.NewTestRetrievalProviderNode()
+	}
+
+	pieceInfo := ph.setupUnseal(unsealing)
+	ps := shared_testutil.NewTestPieceStore()
+	expectedPiece := shared_testutil.GenerateCids(1)[0]
+	cidInfo := piecestore.CIDInfo{
+		PieceBlockLocations: []piecestore.PieceBlockLocation{
+			{
+				PieceCID: expectedPiece,
+			},
+		},
+	}
+	ps.ExpectCID(ph.PayloadCID, cidInfo)
+	ps.ExpectPiece(expectedPiece, pieceInfo)
+
+	provider, err := retrievalimpl.NewProvider(providerPaymentAddr, ph.ProviderNode, ph.Network,
+		ps, ph.TestData.Bs2, ph.TestData.Ds2)
+	require.NoError(t, err)
+
+	provider.SetPaymentInterval(ph.ExpectedQR.MaxPaymentInterval,
+		ph.ExpectedQR.MaxPaymentIntervalIncrease)
+	provider.SetPricePerByte(ph.ExpectedQR.MinPricePerByte)
+	require.NoError(t, provider.Start())
+	ph.RetrievalProvider = provider
+	ph.PieceStore = ps
+	return ph
+}
+func (ph *ProviderHarness) setupUnseal(unsealing bool) (pi piecestore.PieceInfo) {
+	if !unsealing {
+		pi = piecestore.PieceInfo{
+			Deals: []piecestore.DealInfo{
+				{
+					Length: ph.ExpectedQR.Size,
+				},
+			},
+		}
+		return pi
+	}
+
+	cio := cario.NewCarIO()
+	var buf bytes.Buffer
+	err := cio.WriteCar(ph.ctx, ph.TestData.Bs2, ph.PayloadCID, shared.AllSelector(), &buf)
+	require.NoError(ph.t, err)
+	carData := buf.Bytes()
+	sectorID := uint64(100000)
+	offset := uint64(1000)
+	pi = piecestore.PieceInfo{
+		Deals: []piecestore.DealInfo{
+			{
+				SectorID: sectorID,
+				Offset:   offset,
+				Length:   uint64(len(carData)),
+			},
+		},
+	}
+	ph.ProviderNode.ExpectUnseal(sectorID, offset, uint64(len(carData)), carData)
+	// clear out provider blockstore
+	allCids, err := ph.TestData.Bs2.AllKeysChan(ph.ctx)
+	require.NoError(ph.t, err)
+	for c := range allCids {
+		err = ph.TestData.Bs2.DeleteBlock(c)
+		require.NoError(ph.t, err)
+	}
+
+	return pi
+}

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -193,6 +193,8 @@ type RetrievalClient interface {
 	CancelDeal(id DealID) error
 	RetrievalStatus(id DealID)
 	ListDeals() map[DealID]ClientDealState
+	Start() error
+	Stop() error
 }
 
 // RetrievalClientNode are the node dependencies for a RetrievalClient

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -150,6 +150,10 @@ const (
 
 	// ClientEventComplete indicates a deal has completed
 	ClientEventComplete
+
+	// ClientEvenDealResume kickstarts the statemachine to load the deal state and continue
+	// where it left off.
+	ClientEventDealResume
 )
 
 // ClientSubscriber is a callback that is registered to listen for retrieval events
@@ -309,6 +313,10 @@ const (
 
 	// ProviderEventComplete indicates a retrieval deal was completed for a client
 	ProviderEventComplete
+
+	// ProviderDealRestart kickstarts the statemachine to load the deal state and continue
+	// where it left off.
+	ProviderEventDealResume
 )
 
 // ProviderDealID is a unique identifier for a deal on a provider -- it is

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -193,6 +193,7 @@ type RetrievalClient interface {
 	CancelDeal(id DealID) error
 	RetrievalStatus(id DealID)
 	ListDeals() map[DealID]ClientDealState
+	Run() error
 }
 
 // RetrievalClientNode are the node dependencies for a RetrievalClient
@@ -291,7 +292,7 @@ const (
 	// trying to read the next block from the piece
 	ProviderEventBlockErrored
 
-	// ProviderEventBlocksCompleted happeds when the provider reads the last block
+	// ProviderEventBlocksCompleted happens when the provider reads the last block
 	// in the piece
 	ProviderEventBlocksCompleted
 
@@ -539,22 +540,23 @@ const (
 
 // DealStatuses maps deal status to a human readable representation
 var DealStatuses = map[DealStatus]string{
-	DealStatusNew:                       "DealStatusNew",
-	DealStatusPaymentChannelCreating:    "DealStatusPaymentChannelCreating",
-	DealStatusPaymentChannelAddingFunds: "DealStatusPaymentChannelAddingFunds",
-	DealStatusPaymentChannelReady:       "DealStatusPaymentChannelReady",
-	DealStatusAccepted:                  "DealStatusAccepted",
-	DealStatusFailed:                    "DealStatusFailed",
-	DealStatusRejected:                  "DealStatusRejected",
-	DealStatusFundsNeeded:               "DealStatusFundsNeeded",
-	DealStatusOngoing:                   "DealStatusOngoing",
-	DealStatusFundsNeededLastPayment:    "DealStatusFundsNeededLastPayment",
-	DealStatusCompleted:                 "DealStatusCompleted",
-	DealStatusDealNotFound:              "DealStatusDealNotFound",
-	DealStatusVerified:                  "DealStatusVerified",
-	DealStatusErrored:                   "DealStatusErrored",
-	DealStatusBlocksComplete:            "DealStatusBlocksComplete",
-	DealStatusFinalizing:                "DealStatusFinalizing",
+	DealStatusNew:                          "DealStatusNew",
+	DealStatusPaymentChannelCreating:       "DealStatusPaymentChannelCreating",
+	DealStatusPaymentChannelAddingFunds:    "DealStatusPaymentChannelAddingFunds",
+	DealStatusPaymentChannelAllocatingLane: "DealStatusPaymentChannelAllocatingLane",
+	DealStatusPaymentChannelReady:          "DealStatusPaymentChannelReady",
+	DealStatusAccepted:                     "DealStatusAccepted",
+	DealStatusFailed:                       "DealStatusFailed",
+	DealStatusRejected:                     "DealStatusRejected",
+	DealStatusFundsNeeded:                  "DealStatusFundsNeeded",
+	DealStatusOngoing:                      "DealStatusOngoing",
+	DealStatusFundsNeededLastPayment:       "DealStatusFundsNeededLastPayment",
+	DealStatusCompleted:                    "DealStatusCompleted",
+	DealStatusDealNotFound:                 "DealStatusDealNotFound",
+	DealStatusVerified:                     "DealStatusVerified",
+	DealStatusErrored:                      "DealStatusErrored",
+	DealStatusBlocksComplete:               "DealStatusBlocksComplete",
+	DealStatusFinalizing:                   "DealStatusFinalizing",
 }
 
 // IsTerminalError returns true if this status indicates processing of this deal

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -151,9 +151,9 @@ const (
 	// ClientEventComplete indicates a deal has completed
 	ClientEventComplete
 
-	// ClientEvenDealResume kickstarts the statemachine to load the deal state and continue
+	// ClientEventDealRestart kickstarts the statemachine to load the deal state and continue
 	// where it left off.
-	ClientEventDealResume
+	ClientEventDealRestart
 )
 
 // ClientSubscriber is a callback that is registered to listen for retrieval events
@@ -193,8 +193,6 @@ type RetrievalClient interface {
 	CancelDeal(id DealID) error
 	RetrievalStatus(id DealID)
 	ListDeals() map[DealID]ClientDealState
-	Start() error
-	Stop() error
 }
 
 // RetrievalClientNode are the node dependencies for a RetrievalClient
@@ -316,13 +314,9 @@ const (
 	// ProviderEventComplete indicates a retrieval deal was completed for a client
 	ProviderEventComplete
 
-	// ProviderEventDealSuspended is  simply for triggering an event so client can
-	// respond
-	ProviderEventDealSuspended
-
 	// ProviderDealRestart kickstarts the statemachine to load the deal state and continue
 	// where it left off.
-	ProviderEventDealResumed
+	ProviderEventDealRestart
 )
 
 // ProviderDealID is a unique identifier for a deal on a provider -- it is

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -314,9 +314,13 @@ const (
 	// ProviderEventComplete indicates a retrieval deal was completed for a client
 	ProviderEventComplete
 
+	// ProviderEventDealSuspended is  simply for triggering an event so client can
+	// respond
+	ProviderEventDealSuspended
+
 	// ProviderDealRestart kickstarts the statemachine to load the deal state and continue
 	// where it left off.
-	ProviderEventDealResume
+	ProviderEventDealResumed
 )
 
 // ProviderDealID is a unique identifier for a deal on a provider -- it is


### PR DESCRIPTION
Preliminary code + (failing) tests for restarting provider and client statemachines.  Testing retrieval provider restart is flaky because it sometimes is restarted in the midst of sending blocks.