### PR TITLE
replace AddAsk with SetAsk, to convey intent

### DIFF
--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -63,7 +63,7 @@ func TestStorageRetrieval(t *testing.T) {
 	_ = sh.Client.SubscribeToEvents(clientSubscriber)
 
 	// set ask price where we'll accept any price
-	err := sh.Provider.AddAsk(big.NewInt(0), 50_000)
+	err := sh.Provider.SetAsk(big.NewInt(0), 50_000)
 	assert.NoError(t, err)
 
 	result := sh.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: sh.PayloadCid})
@@ -247,7 +247,7 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	require.NoError(t, err)
 
 	// set ask price where we'll accept any price
-	require.NoError(t, provider.AddAsk(big.NewInt(0), 50_000))
+	require.NoError(t, provider.SetAsk(big.NewInt(0), 50_000))
 	require.NoError(t, provider.Start(ctx))
 
 	// Closely follows the MinerInfo struct in the spec

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -36,7 +36,7 @@ var _ storagemarket.StorageProvider = &Provider{}
 
 type StoredAsk interface {
 	GetAsk(address.Address) *storagemarket.SignedStorageAsk
-	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error
+	SetAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error
 }
 
 // Provider is a storage provider implementation
@@ -256,12 +256,8 @@ func (p *Provider) ImportDataForDeal(ctx context.Context, propCid cid.Cid, data 
 
 }
 
-func (p *Provider) ListAsks(addr address.Address) []*storagemarket.SignedStorageAsk {
-	ask := p.storedAsk.GetAsk(addr)
-	if ask != nil {
-		return []*storagemarket.SignedStorageAsk{ask}
-	}
-	return nil
+func (p *Provider) GetAsk(addr address.Address) *storagemarket.SignedStorageAsk {
+	return p.storedAsk.GetAsk(addr)
 }
 
 func (p *Provider) ListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error) {
@@ -316,8 +312,8 @@ func (p *Provider) ListLocalDeals() ([]storagemarket.MinerDeal, error) {
 	return out, nil
 }
 
-func (p *Provider) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
-	return p.storedAsk.AddAsk(price, duration, options...)
+func (p *Provider) SetAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
+	return p.storedAsk.SetAsk(price, duration, options...)
 }
 
 func (p *Provider) HandleAskStream(s network.StorageAskStream) {

--- a/storagemarket/impl/storedask/storedask.go
+++ b/storagemarket/impl/storedask/storedask.go
@@ -49,14 +49,14 @@ func NewStoredAsk(ds datastore.Batching, dsKey datastore.Key, spn storagemarket.
 	if s.ask == nil {
 		// TODO: we should be fine with this state, and just say it means 'not actively accepting deals'
 		// for now... lets just set a price
-		if err := s.AddAsk(defaultPrice, defaultDuration); err != nil {
+		if err := s.SetAsk(defaultPrice, defaultDuration); err != nil {
 			return nil, xerrors.Errorf("failed setting a default price: %w", err)
 		}
 	}
 	return s, nil
 }
 
-func (s *StoredAsk) AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
+func (s *StoredAsk) SetAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {
 	s.askLk.Lock()
 	defer s.askLk.Unlock()
 	var seqno uint64

--- a/storagemarket/impl/storedask/storedask_test.go
+++ b/storagemarket/impl/storedask/storedask_test.go
@@ -34,7 +34,7 @@ func TestStoredAsk(t *testing.T) {
 	})
 	t.Run("setting ask price", func(t *testing.T) {
 		minPieceSize := abi.PaddedPieceSize(1024)
-		err := storedAsk.AddAsk(testPrice, testDuration, storagemarket.MinPieceSize(minPieceSize))
+		err := storedAsk.SetAsk(testPrice, testDuration, storagemarket.MinPieceSize(minPieceSize))
 		require.NoError(t, err)
 		ask := storedAsk.GetAsk(actor)
 		require.Equal(t, ask.Ask.Price, testPrice)
@@ -64,7 +64,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err := storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnStateIDErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.SetAsk(testPrice, testDuration)
 		require.Error(t, err)
 
 		spnMinerWorkerErr := &testnodes.FakeProviderNode{
@@ -76,7 +76,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnMinerWorkerErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.SetAsk(testPrice, testDuration)
 		require.Error(t, err)
 
 		spnSignBytesErr := &testnodes.FakeProviderNode{
@@ -88,7 +88,7 @@ func TestStoredAsk(t *testing.T) {
 		// should load cause ask is is still in data store
 		storedAskError, err = storedask.NewStoredAsk(ds, datastore.NewKey("latest-ask"), spnSignBytesErr, actor)
 		require.NoError(t, err)
-		err = storedAskError.AddAsk(testPrice, testDuration)
+		err = storedAskError.SetAsk(testPrice, testDuration)
 		require.Error(t, err)
 	})
 }

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -71,7 +71,7 @@ func TestMakeDeal(t *testing.T) {
 	_ = h.Client.SubscribeToEvents(clientSubscriber)
 
 	// set ask price where we'll accept any price
-	err = h.Provider.AddAsk(big.NewInt(0), 50_000)
+	err = h.Provider.SetAsk(big.NewInt(0), 50_000)
 	assert.NoError(t, err)
 
 	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid})
@@ -314,7 +314,7 @@ func newHarness(t *testing.T, ctx context.Context) *harness {
 	assert.NoError(t, err)
 
 	// set ask price where we'll accept any price
-	err = provider.AddAsk(big.NewInt(0), 50_000)
+	err = provider.SetAsk(big.NewInt(0), 50_000)
 	assert.NoError(t, err)
 
 	err = provider.Start(ctx)

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -392,16 +392,19 @@ type MessagePublishedCallback func(mcid cid.Cid, err error)
 type ProviderSubscriber func(event ProviderEvent, deal MinerDeal)
 type ClientSubscriber func(event ClientEvent, deal ClientDeal)
 
-// StorageProvider is the interface provided for storage providers
+// StorageProvider provides an interface to the storage market for a single
+// storage miner.
 type StorageProvider interface {
 	Start(ctx context.Context) error
 
 	Stop() error
 
-	AddAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...StorageAskOption) error
+	// SetAsk configures the storage miner's ask with the provided price,
+	// duration, and options. Any previously-existing ask is replaced.
+	SetAsk(price abi.TokenAmount, duration abi.ChainEpoch, options ...StorageAskOption) error
 
-	// ListAsks lists current asks
-	ListAsks(addr address.Address) []*SignedStorageAsk
+	// GetAsk returns the storage miner's ask, or nil if one does not exist.
+	GetAsk(addr address.Address) *SignedStorageAsk
 
 	// ListDeals lists on-chain deals associated with this storage provider
 	ListDeals(ctx context.Context) ([]StorageDeal, error)


### PR DESCRIPTION
## Why does this PR exist?

Searching for a `DeleteAsk` operation caused me to go down the rabbit hole of trying to figure out how asks added with the `AddAsk` method could be replaced with a new ask (when the miner changed their minimum piece size, for instance). 

As it turns out, the current implementation of go-fil-markets allows a storage miner to have exactly one ask, manipulated through the misleadingly-named `AddAsk` method.

## What's in this PR?

This PR replaces the `AddAsk` method with a `SetAsk` method, and replaces `ListAsks` with `GetAsk`.

## Alternative approaches

If a `SignedStorageAsk` had an identity (I don't see that it does right now), we could preserve the `AddAsk` and `ListAsks` signatures. We'd need to add a `DeleteAsk` method, though.