### PR TITLE
Store more detailed information in ClientDealState when a deal is rejected

### DIFF
--- a/storagemarket/impl/clientstates/client_fsm.go
+++ b/storagemarket/impl/clientstates/client_fsm.go
@@ -50,8 +50,8 @@ var ClientEvents = fsm.Events{
 		}),
 	fsm.Event(storagemarket.ClientEventUnexpectedDealState).
 		From(storagemarket.StorageDealWaitingForDataRequest).To(storagemarket.StorageDealFailing).
-		Action(func(deal *storagemarket.ClientDeal, status storagemarket.StorageDealStatus) error {
-			deal.Message = xerrors.Errorf("unexpected deal status while waiting for data request: %d", status).Error()
+		Action(func(deal *storagemarket.ClientDeal, status storagemarket.StorageDealStatus, providerMessage string) error {
+			deal.Message = xerrors.Errorf("unexpected deal status while waiting for data request: %d (%s). Provider message: %s", status, storagemarket.DealStates[status], providerMessage).Error()
 			return nil
 		}),
 	fsm.Event(storagemarket.ClientEventDataTransferFailed).

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -106,7 +106,7 @@ func WaitingForDataRequest(ctx fsm.Context, environment ClientDealEnvironment, d
 	}
 
 	if resp.Response.State != storagemarket.StorageDealWaitingForData {
-		return ctx.Trigger(storagemarket.ClientEventUnexpectedDealState, resp.Response.State)
+		return ctx.Trigger(storagemarket.ClientEventUnexpectedDealState, resp.Response.State, resp.Response.Message)
 	}
 
 	if deal.DataRef.TransferType == storagemarket.TTManual {

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -133,11 +133,12 @@ func TestWaitingForDataRequest(t *testing.T) {
 				dealStream: testResponseStream(t, responseParams{
 					proposal: clientDealProposal,
 					state:    storagemarket.StorageDealProposalNotFound,
+					message:  "couldn't find deal in store",
 				}),
 			},
 			inspector: func(deal storagemarket.ClientDeal, env *fakeEnvironment) {
 				tut.AssertDealState(t, storagemarket.StorageDealFailing, deal.State)
-				assert.Equal(t, "unexpected deal status while waiting for data request: 1", deal.Message)
+				assert.Equal(t, "unexpected deal status while waiting for data request: 1 (StorageDealProposalNotFound). Provider message: couldn't find deal in store", deal.Message)
 			},
 		})
 	})


### PR DESCRIPTION
## Summary
Store more detailed information in the client's local state when a deal is rejected.  Specifically, store the message given by the StorageProvider, if any.