### PR TITLE
Fast retrieval support

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -346,6 +346,7 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, addr address.Address, i
 		Miner:              info.PeerID,
 		MinerWorker:        info.Worker,
 		DataRef:            data,
+		FastRetrieval:      fastRetrieval,
 	}
 
 	err = c.statemachines.Begin(proposalNd.Cid(), deal)

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -77,7 +77,11 @@ func WaitForFunding(ctx fsm.Context, environment ClientDealEnvironment, deal sto
 
 // ProposeDeal sends the deal proposal to the provider
 func ProposeDeal(ctx fsm.Context, environment ClientDealEnvironment, deal storagemarket.ClientDeal) error {
-	proposal := network.Proposal{DealProposal: &deal.ClientDealProposal, Piece: deal.DataRef}
+	proposal := network.Proposal{
+		DealProposal:  &deal.ClientDealProposal,
+		Piece:         deal.DataRef,
+		FastRetrieval: deal.FastRetrieval,
+	}
 
 	s, err := environment.NewDealStream(deal.Miner)
 	if err != nil {

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -450,13 +450,14 @@ func (p *Provider) HandleDealStatusStream(s network.DealStatusStream) {
 	}
 
 	dealState := storagemarket.ProviderDealState{
-		State:       md.State,
-		Message:     md.Message,
-		Proposal:    &md.Proposal,
-		ProposalCid: &md.ProposalCid,
-		AddFundsCid: md.AddFundsCid,
-		PublishCid:  md.PublishCid,
-		DealID:      md.DealID,
+		State:         md.State,
+		Message:       md.Message,
+		Proposal:      &md.Proposal,
+		ProposalCid:   &md.ProposalCid,
+		AddFundsCid:   md.AddFundsCid,
+		PublishCid:    md.PublishCid,
+		DealID:        md.DealID,
+		FastRetrieval: md.FastRetrieval,
 	}
 
 	signature, err := p.sign(ctx, &dealState)

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -220,6 +220,7 @@ func (p *Provider) receiveDeal(s network.StorageDealStream) error {
 		ProposalCid:        proposalNd.Cid(),
 		State:              storagemarket.StorageDealUnknown,
 		Ref:                proposal.Piece,
+		FastRetrieval:      proposal.FastRetrieval,
 	}
 
 	err = p.deals.Begin(proposalNd.Cid(), deal)

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -239,6 +239,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 			State:              deal.State,
 			Ref:                deal.Ref,
 			DealID:             deal.DealID,
+			FastRetrieval:      deal.FastRetrieval,
 		},
 		paddedSize,
 		paddedReader,

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -152,6 +152,7 @@ func TestMakeDeal(t *testing.T) {
 	status, err := h.Client.GetProviderDealState(ctx, proposalCid)
 	assert.NoError(t, err)
 	shared_testutil.AssertDealState(t, storagemarket.StorageDealCompleted, status.State)
+	assert.True(t, status.FastRetrieval)
 }
 
 func TestMakeDealOffline(t *testing.T) {

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -149,10 +149,15 @@ func TestMakeDeal(t *testing.T) {
 	assert.True(t, pd.FastRetrieval)
 	shared_testutil.AssertDealState(t, storagemarket.StorageDealCompleted, pd.State)
 
+	// test out query protocol
 	status, err := h.Client.GetProviderDealState(ctx, proposalCid)
 	assert.NoError(t, err)
 	shared_testutil.AssertDealState(t, storagemarket.StorageDealCompleted, status.State)
 	assert.True(t, status.FastRetrieval)
+
+	// ensure that the handoff has fast retrieval info
+	assert.Len(t, h.ProviderNode.OnDealCompleteCalls, 1)
+	assert.True(t, h.ProviderNode.OnDealCompleteCalls[0].FastRetrieval)
 }
 
 func TestMakeDealOffline(t *testing.T) {

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -71,7 +71,7 @@ func TestMakeDeal(t *testing.T) {
 	err := h.Provider.SetAsk(big.NewInt(0), 50_000)
 	assert.NoError(t, err)
 
-	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid})
+	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid}, true, false)
 	proposalCid := result.ProposalCid
 
 	dealStatesToStrings := func(states []storagemarket.StorageDealStatus) []string {
@@ -139,12 +139,14 @@ func TestMakeDeal(t *testing.T) {
 	cd, err := h.Client.GetLocalDeal(ctx, proposalCid)
 	assert.NoError(t, err)
 	shared_testutil.AssertDealState(t, storagemarket.StorageDealExpired, cd.State)
+	assert.True(t, cd.FastRetrieval)
 
 	providerDeals, err := h.Provider.ListLocalDeals()
 	assert.NoError(t, err)
 
 	pd := providerDeals[0]
 	assert.Equal(t, proposalCid, pd.ProposalCid)
+	assert.True(t, pd.FastRetrieval)
 	shared_testutil.AssertDealState(t, storagemarket.StorageDealCompleted, pd.State)
 
 	status, err := h.Client.GetProviderDealState(ctx, proposalCid)
@@ -172,7 +174,7 @@ func TestMakeDealOffline(t *testing.T) {
 		PieceSize:    size,
 	}
 
-	result := h.ProposeStorageDeal(t, dataRef)
+	result := h.ProposeStorageDeal(t, dataRef, false, false)
 	proposalCid := result.ProposalCid
 
 	wg := sync.WaitGroup{}
@@ -225,7 +227,7 @@ func TestMakeDealNonBlocking(t *testing.T) {
 	h.ClientNode.AddFundsCid = testCids[0]
 	require.NoError(t, h.Client.Start(ctx))
 
-	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid})
+	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid}, false, false)
 
 	wg := sync.WaitGroup{}
 	h.WaitForClientEvent(&wg, storagemarket.ClientEventDataTransferComplete)
@@ -267,7 +269,7 @@ func TestRestartClient(t *testing.T) {
 		}
 	})
 
-	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid})
+	result := h.ProposeStorageDeal(t, &storagemarket.DataRef{TransferType: storagemarket.TTGraphsync, Root: h.PayloadCid}, false, false)
 	proposalCid := result.ProposalCid
 
 	wg.Wait()
@@ -427,8 +429,8 @@ func newHarnessWithTestData(t *testing.T, ctx context.Context, td *shared_testut
 	}
 }
 
-func (h *harness) ProposeStorageDeal(t *testing.T, dataRef *storagemarket.DataRef) *storagemarket.ProposeStorageDealResult {
-	result, err := h.Client.ProposeStorageDeal(h.Ctx, h.ProviderAddr, &h.ProviderInfo, dataRef, h.Epoch+100, h.Epoch+20100, big.NewInt(1), big.NewInt(0), abi.RegisteredSealProof_StackedDrg2KiBV1, false, false)
+func (h *harness) ProposeStorageDeal(t *testing.T, dataRef *storagemarket.DataRef, fastRetrieval, verifiedDeal bool) *storagemarket.ProposeStorageDealResult {
+	result, err := h.Client.ProposeStorageDeal(h.Ctx, h.ProviderAddr, &h.ProviderInfo, dataRef, h.Epoch+100, h.Epoch+20100, big.NewInt(1), big.NewInt(0), abi.RegisteredSealProof_StackedDrg2KiBV1, fastRetrieval, verifiedDeal)
 	assert.NoError(t, err)
 	return result
 }

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -49,7 +49,7 @@ func (impl *libp2pStorageMarketNetwork) NewDealStream(id peer.ID) (StorageDealSt
 }
 
 func (impl *libp2pStorageMarketNetwork) NewDealStatusStream(id peer.ID) (DealStatusStream, error) {
-	s, err := impl.host.NewStream(context.Background(), id, storagemarket.DealStatusProtcolID)
+	s, err := impl.host.NewStream(context.Background(), id, storagemarket.DealStatusProtocolID)
 	if err != nil {
 		log.Warn(err)
 		return nil, err
@@ -62,7 +62,7 @@ func (impl *libp2pStorageMarketNetwork) SetDelegate(r StorageReceiver) error {
 	impl.receiver = r
 	impl.host.SetStreamHandler(storagemarket.DealProtocolID, impl.handleNewDealStream)
 	impl.host.SetStreamHandler(storagemarket.AskProtocolID, impl.handleNewAskStream)
-	impl.host.SetStreamHandler(storagemarket.DealStatusProtcolID, impl.handleNewDealStatusStream)
+	impl.host.SetStreamHandler(storagemarket.DealStatusProtocolID, impl.handleNewDealStatusStream)
 	return nil
 }
 
@@ -70,7 +70,7 @@ func (impl *libp2pStorageMarketNetwork) StopHandlingRequests() error {
 	impl.receiver = nil
 	impl.host.RemoveStreamHandler(storagemarket.DealProtocolID)
 	impl.host.RemoveStreamHandler(storagemarket.AskProtocolID)
-	impl.host.RemoveStreamHandler(storagemarket.DealStatusProtcolID)
+	impl.host.RemoveStreamHandler(storagemarket.DealStatusProtocolID)
 	return nil
 }
 

--- a/storagemarket/network/types.go
+++ b/storagemarket/network/types.go
@@ -14,9 +14,9 @@ import (
 // Proposal is the data sent over the network from client to provider when proposing
 // a deal
 type Proposal struct {
-	DealProposal *market.ClientDealProposal
-
-	Piece *storagemarket.DataRef
+	DealProposal  *market.ClientDealProposal
+	Piece         *storagemarket.DataRef
+	FastRetrieval bool
 }
 
 // ProposalUndefined is an empty Proposal message

--- a/storagemarket/network/types_cbor_gen.go
+++ b/storagemarket/network/types_cbor_gen.go
@@ -118,7 +118,7 @@ func (t *Proposal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{130}); err != nil {
+	if _, err := w.Write([]byte{131}); err != nil {
 		return err
 	}
 
@@ -129,6 +129,11 @@ func (t *Proposal) MarshalCBOR(w io.Writer) error {
 
 	// t.Piece (storagemarket.DataRef) (struct)
 	if err := t.Piece.MarshalCBOR(w); err != nil {
+		return err
+	}
+
+	// t.FastRetrieval (bool) (bool)
+	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
 		return err
 	}
 	return nil
@@ -145,7 +150,7 @@ func (t *Proposal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 2 {
+	if extra != 3 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -190,6 +195,23 @@ func (t *Proposal) UnmarshalCBOR(r io.Reader) error {
 			}
 		}
 
+	}
+	// t.FastRetrieval (bool) (bool)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.FastRetrieval = false
+	case 21:
+		t.FastRetrieval = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -278,6 +278,7 @@ type FakeProviderNode struct {
 	PublishDealID                       abi.DealID
 	PublishDealsError                   error
 	OnDealCompleteError                 error
+	OnDealCompleteCalls                 []storagemarket.MinerDeal
 	LocatePieceForDealWithinSectorError error
 }
 
@@ -303,6 +304,7 @@ func (n *FakeProviderNode) ListProviderDeals(ctx context.Context, addr address.A
 
 // OnDealComplete simulates passing of the deal to the storage miner, and does nothing
 func (n *FakeProviderNode) OnDealComplete(ctx context.Context, deal storagemarket.MinerDeal, pieceSize abi.UnpaddedPieceSize, pieceReader io.Reader) error {
+	n.OnDealCompleteCalls = append(n.OnDealCompleteCalls, deal)
 	return n.OnDealCompleteError
 }
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -153,11 +153,12 @@ type DataRef struct {
 
 // ProviderDealState represents a Provider's current state of a deal
 type ProviderDealState struct {
-	State       StorageDealStatus
-	Message     string
-	Proposal    *market.DealProposal
-	ProposalCid *cid.Cid
-	AddFundsCid *cid.Cid
-	PublishCid  *cid.Cid
-	DealID      abi.DealID
+	State         StorageDealStatus
+	Message       string
+	Proposal      *market.DealProposal
+	ProposalCid   *cid.Cid
+	AddFundsCid   *cid.Cid
+	PublishCid    *cid.Cid
+	DealID        abi.DealID
+	FastRetrieval bool
 }

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -20,8 +20,8 @@ const DealProtocolID = "/fil/storage/mk/1.0.1"
 // AskProtocolID is the ID for the libp2p protocol for querying miners for their current StorageAsk.
 const AskProtocolID = "/fil/storage/ask/1.0.1"
 
-// DealStatusProtcolID is the ID for the libp2p protocol for querying miners for the current status of a deal.
-const DealStatusProtcolID = "/fil/storage/status/1.0.1"
+// DealStatusProtocolID is the ID for the libp2p protocol for querying miners for the current status of a deal.
+const DealStatusProtocolID = "/fil/storage/status/1.0.1"
 
 // Balance represents a current balance of funds in the StorageMarketActor.
 type Balance struct {

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -77,15 +77,16 @@ var StorageAskUndefined = StorageAsk{}
 // MinerDeal is the local state tracked for a deal by a StorageProvider
 type MinerDeal struct {
 	market.ClientDealProposal
-	ProposalCid  cid.Cid
-	AddFundsCid  *cid.Cid
-	PublishCid   *cid.Cid
-	Miner        peer.ID
-	Client       peer.ID
-	State        StorageDealStatus
-	PiecePath    filestore.Path
-	MetadataPath filestore.Path
-	Message      string
+	ProposalCid   cid.Cid
+	AddFundsCid   *cid.Cid
+	PublishCid    *cid.Cid
+	Miner         peer.ID
+	Client        peer.ID
+	State         StorageDealStatus
+	PiecePath     filestore.Path
+	MetadataPath  filestore.Path
+	Message       string
+	FastRetrieval bool
 
 	Ref *DataRef
 
@@ -107,6 +108,7 @@ type ClientDeal struct {
 	SlashEpoch     abi.ChainEpoch
 	PollRetryCount uint64
 	PollErrorCount uint64
+	FastRetrieval  bool
 }
 
 // StorageDeal is a local combination of a proposal and a current deal state

--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -22,7 +22,7 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{141}); err != nil {
+	if _, err := w.Write([]byte{142}); err != nil {
 		return err
 	}
 
@@ -130,6 +130,10 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.FastRetrieval (bool) (bool)
+	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -144,7 +148,7 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 13 {
+	if extra != 14 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -348,6 +352,23 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 		t.PollErrorCount = uint64(extra)
 
 	}
+	// t.FastRetrieval (bool) (bool)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.FastRetrieval = false
+	case 21:
+		t.FastRetrieval = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+	}
 	return nil
 }
 
@@ -356,7 +377,7 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{140}); err != nil {
+	if _, err := w.Write([]byte{141}); err != nil {
 		return err
 	}
 
@@ -461,6 +482,11 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.FastRetrieval (bool) (bool)
+	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
+		return err
+	}
+
 	// t.Ref (storagemarket.DataRef) (struct)
 	if err := t.Ref.MarshalCBOR(w); err != nil {
 		return err
@@ -486,7 +512,7 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 12 {
+	if extra != 13 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -622,6 +648,23 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 		}
 
 		t.Message = string(sval)
+	}
+	// t.FastRetrieval (bool) (bool)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.FastRetrieval = false
+	case 21:
+		t.FastRetrieval = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	// t.Ref (storagemarket.DataRef) (struct)
 

--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -1220,7 +1220,7 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write([]byte{135}); err != nil {
+	if _, err := w.Write([]byte{136}); err != nil {
 		return err
 	}
 
@@ -1289,6 +1289,10 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
+	// t.FastRetrieval (bool) (bool)
+	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1303,7 +1307,7 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 		return fmt.Errorf("cbor input should be of type array")
 	}
 
-	if extra != 7 {
+	if extra != 8 {
 		return fmt.Errorf("cbor input had wrong number of fields")
 	}
 
@@ -1437,6 +1441,23 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 		}
 		t.DealID = abi.DealID(extra)
 
+	}
+	// t.FastRetrieval (bool) (bool)
+
+	maj, extra, err = cbg.CborReadHeader(br)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajOther {
+		return fmt.Errorf("booleans must be major type 7")
+	}
+	switch extra {
+	case 20:
+		t.FastRetrieval = false
+	case 21:
+		t.FastRetrieval = true
+	default:
+		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
Send the fast retrieval flag along with the proposal and track it in the `ClientDeal` and `MinerDeal`.  Also return this flag in the deal status query.

Resolves #285