### PR TITLE
Validate client's DataCap for verified deals

### DIFF
--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-address"
@@ -74,6 +75,9 @@ type StorageProviderNode interface {
 
 	// LocatePieceForDealWithinSector looks up a given dealID in the miners sectors, and returns its sectorID and location
 	LocatePieceForDealWithinSector(ctx context.Context, dealID abi.DealID, tok shared.TipSetToken) (sectorID uint64, offset uint64, length uint64, err error)
+
+	// GetDataCap gets the current data cap for addr
+	GetDataCap(ctx context.Context, addr address.Address, tok shared.TipSetToken) (verifreg.DataCap, error)
 }
 
 // StorageClientNode are node dependencies for a StorageClient

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
+	"github.com/filecoin-project/specs-actors/actors/builtin/verifreg"
 	"github.com/filecoin-project/specs-actors/actors/crypto"
 	"github.com/filecoin-project/specs-actors/actors/runtime/exitcode"
 	"github.com/ipfs/go-cid"
@@ -280,6 +281,8 @@ type FakeProviderNode struct {
 	OnDealCompleteError                 error
 	OnDealCompleteCalls                 []storagemarket.MinerDeal
 	LocatePieceForDealWithinSectorError error
+	DataCap                             verifreg.DataCap
+	GetDataCapErr                       error
 }
 
 // PublishDeals simulates publishing a deal by adding it to the storage market state
@@ -322,6 +325,11 @@ func (n *FakeProviderNode) LocatePieceForDealWithinSector(ctx context.Context, d
 		return n.PieceSectorID, 0, n.PieceLength, nil
 	}
 	return 0, 0, 0, n.LocatePieceForDealWithinSectorError
+}
+
+// GetDataCap gets the current data cap for addr
+func (n *FakeProviderNode) GetDataCap(ctx context.Context, addr address.Address, tok shared.TipSetToken) (verifreg.DataCap, error) {
+	return n.DataCap, n.GetDataCapErr
 }
 
 var _ storagemarket.StorageProviderNode = (*FakeProviderNode)(nil)


### PR DESCRIPTION
## Summary
For verified deal proposals, reject the deal if the `verifreg.DataCap` for the client isn't large enough.

Resolves #286 