### PR TITLE
Run deal restarts in go routine

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -111,7 +111,13 @@ func NewClient(
 // Start initializes deal processing on a StorageClient and restarts
 // in progress deals
 func (c *Client) Start(ctx context.Context) error {
-	return c.restartDeals()
+	go func() {
+		err := c.restartDeals()
+		if err != nil {
+			log.Errorf("Failed to restart deals: %s", err.Error())
+		}
+	}()
+	return nil
 }
 
 // Stop ends deal processing on a StorageClient

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -160,12 +160,12 @@ func (p *Provider) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	err = p.restartDeals()
-	if err != nil {
-		return err
-	}
-
+	go func() {
+		err := p.restartDeals()
+		if err != nil {
+			log.Errorf("Failed to restart deals: %s", err.Error())
+		}
+	}()
 	return nil
 }
 


### PR DESCRIPTION
# Goals

Deal restarts make take a while particularly if there are connection timeouts. There's no reason to
run them synchronously in node initialization, and we definitely should not fail node startup if there are errors.

# Implementation

Run restart deals in a go routine, simply log any errors