### PR TITLE
Support PieceCIDs in retrieval queries

### DIFF
--- a/retrievalmarket/network/libp2p_impl_test.go
+++ b/retrievalmarket/network/libp2p_impl_test.go
@@ -381,8 +381,8 @@ func assertQueryReceived(inCtx context.Context, t *testing.T, fromNetwork networ
 	require.NoError(t, err)
 
 	// send query to host2
-	cid := shared_testutil.GenerateCids(1)[0]
-	q := retrievalmarket.NewQueryV0(cid)
+	cids := shared_testutil.GenerateCids(2)
+	q := retrievalmarket.NewQueryV1(cids[0], &cids[1])
 	require.NoError(t, qs1.WriteQuery(q))
 
 	var inq retrievalmarket.Query
@@ -393,6 +393,7 @@ func assertQueryReceived(inCtx context.Context, t *testing.T, fromNetwork networ
 	}
 	require.NotNil(t, inq)
 	assert.Equal(t, q.PayloadCID, inq.PayloadCID)
+	assert.Equal(t, q.PieceCID, inq.PieceCID)
 }
 
 // assertQueryResponseReceived performs the verification that a DealStatusResponse is received

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -477,9 +477,19 @@ type Query struct {
 // QueryUndefined is a query with no values
 var QueryUndefined = Query{}
 
-// NewQueryV0 creates a V0 query (which only specifies a piece)
+// NewQueryV0 creates a V0 query (which only specifies a payload)
 func NewQueryV0(payloadCID cid.Cid) Query {
 	return Query{PayloadCID: payloadCID}
+}
+
+// NewQueryV1 creates a V1 query (which has an optional pieceCID)
+func NewQueryV1(payloadCID cid.Cid, pieceCID *cid.Cid) Query {
+	return Query{
+		PayloadCID: payloadCID,
+		QueryParams: QueryParams{
+			PieceCID: pieceCID,
+		},
+	}
 }
 
 // QueryResponse is a miners response to a given retrieval query


### PR DESCRIPTION
## Summary
Add a new retrievalmarket function, `NewQueryV1`, which takes an optional `PieceCID`.

Resolves #287 