### PR TITLE
Protect/tag libp2p connections during data transfer

### DIFF
--- a/shared_testutil/test_network_types.go
+++ b/shared_testutil/test_network_types.go
@@ -524,7 +524,6 @@ type TestStorageDealStream struct {
 	proposalWriter StorageDealProposalWriter
 	responseReader StorageDealResponseReader
 	responseWriter StorageDealResponseWriter
-	tags           map[string]struct{}
 
 	CloseCount int
 	CloseError error
@@ -549,7 +548,6 @@ func NewTestStorageDealStream(params TestStorageDealStreamParams) *TestStorageDe
 		proposalWriter: TrivialStorageDealProposalWriter,
 		responseReader: TrivialStorageDealResponseReader,
 		responseWriter: TrivialStorageDealResponseWriter,
-		tags:           make(map[string]struct{}),
 	}
 	if params.ProposalReader != nil {
 		stream.proposalReader = params.ProposalReader
@@ -593,23 +591,6 @@ func (tsds TestStorageDealStream) RemotePeer() peer.ID { return tsds.p }
 func (tsds *TestStorageDealStream) Close() error {
 	tsds.CloseCount += 1
 	return tsds.CloseError
-}
-
-// TagProtectedConnection preserves this connection as higher priority than others
-func (tsds TestStorageDealStream) TagProtectedConnection(identifier string) {
-	tsds.tags[identifier] = struct{}{}
-}
-
-// UntagProtectedConnection removes the given tag on this connection, increasing
-// the likelyhood it will be cleaned up
-func (tsds TestStorageDealStream) UntagProtectedConnection(identifier string) {
-	delete(tsds.tags, identifier)
-}
-
-// AssertConnectionTagged verifies a connection was tagged with the given identifier
-func (tsds TestStorageDealStream) AssertConnectionTagged(t *testing.T, identifier string) {
-	_, ok := tsds.tags[identifier]
-	require.True(t, ok)
 }
 
 // TrivialStorageDealProposalReader succeeds trivially, returning an empty proposal.
@@ -677,3 +658,22 @@ func (tpr TestPeerResolver) GetPeers(cid.Cid) ([]rm.RetrievalPeer, error) {
 }
 
 var _ rm.PeerResolver = &TestPeerResolver{}
+
+type TestPeerTagger struct {
+	TagCalls   []peer.ID
+	UntagCalls []peer.ID
+}
+
+func NewTestPeerTagger() *TestPeerTagger {
+	return &TestPeerTagger{}
+}
+
+func (pt *TestPeerTagger) TagPeer(id peer.ID, _ string) {
+	pt.TagCalls = append(pt.TagCalls, id)
+}
+
+func (pt *TestPeerTagger) UntagPeer(id peer.ID, _ string) {
+	pt.UntagCalls = append(pt.UntagCalls, id)
+}
+
+var _ smnet.PeerTagger = &TestPeerTagger{}

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -539,6 +539,14 @@ func (c *clientDealEnvironment) PollingInterval() time.Duration {
 	return c.c.pollingInterval
 }
 
+func (c *clientDealEnvironment) TagPeer(peer peer.ID, tag string) {
+	c.c.net.TagPeer(peer, tag)
+}
+
+func (c *clientDealEnvironment) UntagPeer(peer peer.ID, tag string) {
+	c.c.net.UntagPeer(peer, tag)
+}
+
 // ClientFSMParameterSpec is a valid set of parameters for a client deal FSM - used in doc generation
 var ClientFSMParameterSpec = fsm.Parameters{
 	Environment:     &clientDealEnvironment{},

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -31,8 +31,8 @@ type ClientDealEnvironment interface {
 	StartDataTransfer(ctx context.Context, to peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) error
 	GetProviderDealState(ctx context.Context, proposalCid cid.Cid) (*storagemarket.ProviderDealState, error)
 	PollingInterval() time.Duration
-	TagPeer(id peer.ID, ident string)
-	UntagPeer(id peer.ID, ident string)
+
+	network.PeerTagger
 }
 
 // ClientStateEntryFunc is the type for all state entry functions on a storage client

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-fil-markets/filestore"
@@ -657,6 +658,14 @@ func (p *providerDealEnvironment) RunCustomDecisionLogic(ctx context.Context, de
 		return true, "", nil
 	}
 	return p.p.customDealDeciderFunc(ctx, deal)
+}
+
+func (p *providerDealEnvironment) TagPeer(id peer.ID, s string) {
+	p.p.net.TagPeer(id, s)
+}
+
+func (p *providerDealEnvironment) UntagPeer(id peer.ID, s string) {
+	p.p.net.UntagPeer(id, s)
 }
 
 var _ providerstates.ProviderDealEnvironment = &providerDealEnvironment{}

--- a/storagemarket/network/deal_stream.go
+++ b/storagemarket/network/deal_stream.go
@@ -55,11 +55,3 @@ func (d *dealStream) Close() error {
 func (d *dealStream) RemotePeer() peer.ID {
 	return d.p
 }
-
-func (d *dealStream) TagProtectedConnection(identifier string) {
-	d.host.ConnManager().TagPeer(d.p, identifier, TagPriority)
-}
-
-func (d *dealStream) UntagProtectedConnection(identifier string) {
-	d.host.ConnManager().UntagPeer(d.p, identifier)
-}

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -114,3 +114,11 @@ func (impl *libp2pStorageMarketNetwork) ID() peer.ID {
 func (impl *libp2pStorageMarketNetwork) AddAddrs(p peer.ID, addrs []ma.Multiaddr) {
 	impl.host.Peerstore().AddAddrs(p, addrs, time.Minute*10)
 }
+
+func (impl *libp2pStorageMarketNetwork) TagPeer(p peer.ID, id string) {
+	impl.host.ConnManager().TagPeer(p, id, TagPriority)
+}
+
+func (impl *libp2pStorageMarketNetwork) UntagPeer(p peer.ID, id string) {
+	impl.host.ConnManager().UntagPeer(p, id)
+}

--- a/storagemarket/network/network.go
+++ b/storagemarket/network/network.go
@@ -29,8 +29,6 @@ type StorageDealStream interface {
 	ReadDealResponse() (SignedResponse, error)
 	WriteDealResponse(SignedResponse) error
 	RemotePeer() peer.ID
-	TagProtectedConnection(identifier string)
-	UntagProtectedConnection(identifier string)
 	Close() error
 }
 
@@ -61,4 +59,12 @@ type StorageMarketNetwork interface {
 	StopHandlingRequests() error
 	ID() peer.ID
 	AddAddrs(peer.ID, []ma.Multiaddr)
+
+	PeerTagger
+}
+
+// PeerTagger implements arbitrary tagging of peers
+type PeerTagger interface {
+	TagPeer(peer.ID, string)
+	UntagPeer(peer.ID, string)
 }


### PR DESCRIPTION
## Problem
Connection/peer tagging was removed in a previous commit, but it is needed to prevent connections from being recycled.

## Summary
Add peer tagging during data transfer in both the client and provider FSMs.

