### PR TITLE
(WIP - don't review yet) Store PayloadCID in flexible DealProposal.Label field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/filecoin-project/go-statestore v0.1.0
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200615154852-728a47ab99d6
-	github.com/filecoin-project/specs-actors v0.7.0
+	github.com/filecoin-project/specs-actors v0.7.2
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
 	github.com/ipfs/go-block-format v0.0.2

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -327,7 +327,7 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, addr address.Address, i
 		PieceSize:            pieceSize.Padded(),
 		Client:               addr,
 		Provider:             info.Address,
-		Label:                data.Root,
+		Label:                data.Root.String(),
 		StartEpoch:           startEpoch,
 		EndEpoch:             endEpoch,
 		StoragePricePerEpoch: price,

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -327,6 +327,7 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, addr address.Address, i
 		PieceSize:            pieceSize.Padded(),
 		Client:               addr,
 		Provider:             info.Address,
+		Label:                data.Root,
 		StartEpoch:           startEpoch,
 		EndEpoch:             endEpoch,
 		StoragePricePerEpoch: price,


### PR DESCRIPTION
This PR adds the Payload CID, a hash computed over the client's data in its original form, into the flexible `Label` field of each storage deal's `DealProposal` struct.  This ensures that each storage deal's Payload CID will be published on the blockchain together with that deal's corresponding Piece CID.

By publishing messages containing both CIDs, the blockchain will become a record of {PayloadCID, PieceCID} tuples that have existed on the Filecoin network.  This will enable a variety of indexing and retrieval-related use cases, such as: 
- retrieval by 3rd parties, such as retrieval market participants, even when they have only partial information about the original storage deal, 
- retrieval by clients who no longer possess all of their storage deal's original metadata,
- the generation of blockchain indices that keep track of alternate names that a piece of data on the Filecoin network might be known as (e.g., to support Filecoin network light clients),
- other proxy retrieval scenarios.