### PR TITLE
Add label field to deals

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -334,11 +334,17 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, params storagemarket.Pr
 		return nil, xerrors.Errorf("computing deal provider collateral bound failed: %w", err)
 	}
 
+	label, err := clientutils.LabelField(params.Data.Root)
+	if err != nil {
+		return nil, xerrors.Errorf("creating label field in proposal: %w", err)
+	}
+
 	dealProposal := market.DealProposal{
 		PieceCID:             commP,
 		PieceSize:            pieceSize.Padded(),
 		Client:               params.Addr,
 		Provider:             params.Info.Address,
+		Label:                string(label),
 		StartEpoch:           params.StartEpoch,
 		EndEpoch:             params.EndEpoch,
 		StoragePricePerEpoch: params.Price,


### PR DESCRIPTION
# Goals

Per https://docs.google.com/document/d/1cyO_Ah0R9XbfgpR_isJUtEREspbco_A6EDYJZWouR-8/edit# -- we are encoding the payload CID in the Label field on deals to enable discoverability.

# Implementation

Encode a JSON structure into the label field (tried CBOR, but issue arise from the fact that label is a string). Matches label described in doc but with proper IPLD DAG JSON CID structure.