### PR TITLE
Include correction factor in DealProviderCollateralBounds

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -334,9 +334,12 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, params storagemarket.Pr
 		return nil, fmt.Errorf("cannot propose a deal whose piece size (%d) is greater than sector size (%d)", pieceSize.Padded(), params.Info.SectorSize)
 	}
 
-	pcMin, _, err := c.node.DealProviderCollateralBounds(ctx, pieceSize.Padded(), params.VerifiedDeal)
-	if err != nil {
-		return nil, xerrors.Errorf("computing deal provider collateral bound failed: %w", err)
+	pcMin := params.Collateral
+	if pcMin.Int == nil || pcMin.IsZero() {
+		pcMin, _, err = c.node.DealProviderCollateralBounds(ctx, pieceSize.Padded(), params.VerifiedDeal, 100)
+		if err != nil {
+			return nil, xerrors.Errorf("computing deal provider collateral bound failed: %w", err)
+		}
 	}
 
 	label, err := clientutils.LabelField(params.Data.Root)

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -69,7 +69,7 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("incorrect provider for deal"))
 	}
 
-	pcMin, pcMax, err := environment.Node().DealProviderCollateralBounds(ctx.Context(), proposal.PieceSize, proposal.VerifiedDeal)
+	pcMin, pcMax, err := environment.Node().DealProviderCollateralBounds(ctx.Context(), proposal.PieceSize, proposal.VerifiedDeal, 5)
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.Errorf("node error getting collateral bounds: %w", err))
 	}

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -51,8 +51,9 @@ type StorageCommon interface {
 	// SignsBytes signs the given data with the given address's private key
 	SignBytes(ctx context.Context, signer address.Address, b []byte) (*crypto.Signature, error)
 
-	// DealProviderCollateralBounds returns the min and max collateral a storage provider can issue.
-	DealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, isVerified bool) (abi.TokenAmount, abi.TokenAmount, error)
+	// DealProviderCollateralBounds returns the min and max collateral a storage provider must issue.
+	// The min collateral is increased by a factor of correctPercentage.
+	DealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, isVerified bool, correctPercentage uint) (abi.TokenAmount, abi.TokenAmount, error)
 
 	// OnDealSectorCommitted waits for a deal's sector to be sealed and proved, indicating the deal is active
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, cb DealSectorCommittedCallback) error

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -182,7 +182,7 @@ func (n *FakeCommonNode) SignBytes(ctx context.Context, signer address.Address, 
 	return nil, n.SignBytesError
 }
 
-func (n *FakeCommonNode) DealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, isVerified bool) (abi.TokenAmount, abi.TokenAmount, error) {
+func (n *FakeCommonNode) DealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, isVerified bool, pct uint) (abi.TokenAmount, abi.TokenAmount, error) {
 	return abi.NewTokenAmount(5000), abi.TotalFilecoin, nil
 }
 


### PR DESCRIPTION
This will help, but I think the question of "how to estimate DealProviderCollateralBounds in the future" needs to be answered.

We also might wanna make the `correctPercentage` easily configurable (I can see miners needing to quickly increase that % under certain network conditions).