### PR TITLE
Use GetSync in Request Validation

### DIFF
--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -22,7 +22,6 @@ import (
 	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
 	dtgstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
 	"github.com/filecoin-project/go-multistore"
-	"github.com/filecoin-project/go-statestore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -41,7 +40,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	stormkt "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/funds"
-	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
 	stornet "github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
@@ -261,8 +259,6 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	require.NoError(t, err)
 	err = dt1.Start(ctx)
 	require.NoError(t, err)
-	rv1 := requestvalidation.NewUnifiedRequestValidator(nil, statestore.New(td.Ds1))
-	require.NoError(t, dt1.RegisterVoucherType(&requestvalidation.StorageDataTransferVoucher{}, rv1))
 
 	peerResolver := discovery.NewLocal(td.Ds1)
 
@@ -287,8 +283,6 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	require.NoError(t, err)
 	err = dt2.Start(ctx)
 	require.NoError(t, err)
-	rv2 := requestvalidation.NewUnifiedRequestValidator(statestore.New(td.Ds2), nil)
-	require.NoError(t, dt2.RegisterVoucherType(&requestvalidation.StorageDataTransferVoucher{}, rv2))
 	storedAsk, err := storedask.NewStoredAsk(td.Ds2, datastore.NewKey("latest-ask"), providerNode, providerAddr)
 	require.NoError(t, err)
 	providerDealFunds, err := funds.NewDealFunds(td.Ds1, datastore.NewKey("storage/provider/dealfunds"))

--- a/storagemarket/impl/client_environments.go
+++ b/storagemarket/impl/client_environments.go
@@ -1,0 +1,84 @@
+package storageimpl
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-multistore"
+
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/funds"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
+)
+
+// -------
+// clientDealEnvironment
+// -------
+
+type clientDealEnvironment struct {
+	c *Client
+}
+
+func (c *clientDealEnvironment) NewDealStream(ctx context.Context, p peer.ID) (network.StorageDealStream, error) {
+	return c.c.net.NewDealStream(ctx, p)
+}
+
+func (c *clientDealEnvironment) Node() storagemarket.StorageClientNode {
+	return c.c.node
+}
+
+func (c *clientDealEnvironment) StartDataTransfer(ctx context.Context, to peer.ID, voucher datatransfer.Voucher, baseCid cid.Cid, selector ipld.Node) error {
+	_, err := c.c.dataTransfer.OpenPushDataChannel(ctx, to, voucher, baseCid, selector)
+	return err
+}
+
+func (c *clientDealEnvironment) GetProviderDealState(ctx context.Context, proposalCid cid.Cid) (*storagemarket.ProviderDealState, error) {
+	return c.c.GetProviderDealState(ctx, proposalCid)
+}
+
+func (c *clientDealEnvironment) PollingInterval() time.Duration {
+	return c.c.pollingInterval
+}
+
+func (c *clientDealEnvironment) DealFunds() funds.DealFunds {
+	return c.c.dealFunds
+}
+
+type clientStoreGetter struct {
+	c *Client
+}
+
+func (csg *clientStoreGetter) Get(proposalCid cid.Cid) (*multistore.Store, error) {
+	var deal storagemarket.ClientDeal
+	err := csg.c.statemachines.Get(proposalCid).Get(&deal)
+	if err != nil {
+		return nil, err
+	}
+	if deal.StoreID == nil {
+		return nil, nil
+	}
+	return csg.c.multiStore.Get(*deal.StoreID)
+}
+
+func (c *clientDealEnvironment) TagPeer(peer peer.ID, tag string) {
+	c.c.net.TagPeer(peer, tag)
+}
+
+func (c *clientDealEnvironment) UntagPeer(peer peer.ID, tag string) {
+	c.c.net.UntagPeer(peer, tag)
+}
+
+type clientPullDeals struct {
+	c *Client
+}
+
+func (cpd *clientPullDeals) Get(proposalCid cid.Cid) (storagemarket.ClientDeal, error) {
+	var deal storagemarket.ClientDeal
+	err := cpd.c.statemachines.GetSync(context.TODO(), proposalCid, &deal)
+	return deal, err
+}

--- a/storagemarket/impl/provider_environments.go
+++ b/storagemarket/impl/provider_environments.go
@@ -1,0 +1,141 @@
+package storageimpl
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"golang.org/x/xerrors"
+
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/go-multistore"
+
+	"github.com/filecoin-project/go-fil-markets/filestore"
+	"github.com/filecoin-project/go-fil-markets/piecestore"
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/funds"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/providerstates"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/providerutils"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
+)
+
+// -------
+// providerDealEnvironment
+// -------
+
+type providerDealEnvironment struct {
+	p *Provider
+}
+
+func (p *providerDealEnvironment) Address() address.Address {
+	return p.p.actor
+}
+
+func (p *providerDealEnvironment) Node() storagemarket.StorageProviderNode {
+	return p.p.spn
+}
+
+func (p *providerDealEnvironment) Ask() storagemarket.StorageAsk {
+	sask := p.p.storedAsk.GetAsk()
+	if sask == nil {
+		return storagemarket.StorageAskUndefined
+	}
+	return *sask.Ask
+}
+
+func (p *providerDealEnvironment) DeleteStore(storeID multistore.StoreID) error {
+	return p.p.multiStore.Delete(storeID)
+}
+
+func (p *providerDealEnvironment) GeneratePieceCommitmentToFile(storeID *multistore.StoreID, payloadCid cid.Cid, selector ipld.Node) (cid.Cid, filestore.Path, filestore.Path, error) {
+	if p.p.universalRetrievalEnabled {
+		return providerutils.GeneratePieceCommitmentWithMetadata(p.p.fs, p.p.pio.GeneratePieceCommitmentToFile, p.p.proofType, payloadCid, selector, storeID)
+	}
+	pieceCid, piecePath, _, err := p.p.pio.GeneratePieceCommitmentToFile(p.p.proofType, payloadCid, selector, storeID)
+	return pieceCid, piecePath, filestore.Path(""), err
+}
+
+func (p *providerDealEnvironment) FileStore() filestore.FileStore {
+	return p.p.fs
+}
+
+func (p *providerDealEnvironment) PieceStore() piecestore.PieceStore {
+	return p.p.pieceStore
+}
+
+func (p *providerDealEnvironment) SendSignedResponse(ctx context.Context, resp *network.Response) error {
+	s, err := p.p.conns.DealStream(resp.Proposal)
+	if err != nil {
+		return xerrors.Errorf("couldn't send response: %w", err)
+	}
+
+	sig, err := p.p.sign(ctx, resp)
+	if err != nil {
+		return xerrors.Errorf("failed to sign response message: %w", err)
+	}
+
+	signedResponse := network.SignedResponse{
+		Response:  *resp,
+		Signature: sig,
+	}
+
+	err = s.WriteDealResponse(signedResponse)
+	if err != nil {
+		// Assume client disconnected
+		_ = p.p.conns.Disconnect(resp.Proposal)
+	}
+	return err
+}
+
+func (p *providerDealEnvironment) Disconnect(proposalCid cid.Cid) error {
+	return p.p.conns.Disconnect(proposalCid)
+}
+
+func (p *providerDealEnvironment) RunCustomDecisionLogic(ctx context.Context, deal storagemarket.MinerDeal) (bool, string, error) {
+	if p.p.customDealDeciderFunc == nil {
+		return true, "", nil
+	}
+	return p.p.customDealDeciderFunc(ctx, deal)
+}
+
+func (p *providerDealEnvironment) DealFunds() funds.DealFunds {
+	return p.p.dealFunds
+}
+
+func (p *providerDealEnvironment) TagPeer(id peer.ID, s string) {
+	p.p.net.TagPeer(id, s)
+}
+
+func (p *providerDealEnvironment) UntagPeer(id peer.ID, s string) {
+	p.p.net.UntagPeer(id, s)
+}
+
+var _ providerstates.ProviderDealEnvironment = &providerDealEnvironment{}
+
+type providerStoreGetter struct {
+	p *Provider
+}
+
+func (psg *providerStoreGetter) Get(proposalCid cid.Cid) (*multistore.Store, error) {
+	var deal storagemarket.MinerDeal
+	err := psg.p.deals.Get(proposalCid).Get(&deal)
+	if err != nil {
+		return nil, err
+	}
+	if deal.StoreID == nil {
+		return nil, errors.New("No store for this deal")
+	}
+	return psg.p.multiStore.Get(*deal.StoreID)
+}
+
+type providerPushDeals struct {
+	p *Provider
+}
+
+func (ppd *providerPushDeals) Get(proposalCid cid.Cid) (storagemarket.MinerDeal, error) {
+	var deal storagemarket.MinerDeal
+	err := ppd.p.deals.GetSync(context.TODO(), proposalCid, &deal)
+	return deal, err
+}

--- a/storagemarket/impl/requestvalidation/common.go
+++ b/storagemarket/impl/requestvalidation/common.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/xerrors"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-statestore"
 
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 )
@@ -20,7 +19,7 @@ import (
 // - referenced deal matches the given base CID
 // - referenced deal is in an acceptable state
 func ValidatePush(
-	deals *statestore.StateStore,
+	deals PushDeals,
 	sender peer.ID,
 	voucher datatransfer.Voucher,
 	baseCid cid.Cid,
@@ -31,7 +30,7 @@ func ValidatePush(
 	}
 
 	var deal storagemarket.MinerDeal
-	err := deals.Get(dealVoucher.Proposal).Get(&deal)
+	deal, err := deals.Get(dealVoucher.Proposal)
 	if err != nil {
 		return xerrors.Errorf("Proposal CID %s: %w", dealVoucher.Proposal.String(), ErrNoDeal)
 	}
@@ -58,7 +57,7 @@ func ValidatePush(
 // - referenced deal matches the given base CID
 // - referenced deal is in an acceptable state
 func ValidatePull(
-	deals *statestore.StateStore,
+	deals PullDeals,
 	receiver peer.ID,
 	voucher datatransfer.Voucher,
 	baseCid cid.Cid,
@@ -67,9 +66,7 @@ func ValidatePull(
 	if !ok {
 		return xerrors.Errorf("voucher type %s: %w", voucher.Type(), ErrWrongVoucherType)
 	}
-
-	var deal storagemarket.ClientDeal
-	err := deals.Get(dealVoucher.Proposal).Get(&deal)
+	deal, err := deals.Get(dealVoucher.Proposal)
 	if err != nil {
 		return xerrors.Errorf("Proposal CID %s: %w", dealVoucher.Proposal.String(), ErrNoDeal)
 	}

--- a/storagemarket/impl/requestvalidation/unified_request_validator.go
+++ b/storagemarket/impl/requestvalidation/unified_request_validator.go
@@ -6,20 +6,31 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-statestore"
+
+	"github.com/filecoin-project/go-fil-markets/storagemarket"
 )
+
+// PushDeals gets deal states for Push validations
+type PushDeals interface {
+	Get(cid.Cid) (storagemarket.MinerDeal, error)
+}
+
+// PullDeals gets deal states for Pull validations
+type PullDeals interface {
+	Get(cid.Cid) (storagemarket.ClientDeal, error)
+}
 
 // UnifiedRequestValidator is a data transfer request validator that validates
 // StorageDataTransferVoucher from the given state store
 // It can be made to only accept push requests (Provider) or pull requests (Client)
 // by passing nil for the statestore value for pushes or pulls
 type UnifiedRequestValidator struct {
-	pushDeals *statestore.StateStore
-	pullDeals *statestore.StateStore
+	pushDeals PushDeals
+	pullDeals PullDeals
 }
 
 // NewUnifiedRequestValidator returns a new instance of UnifiedRequestValidator
-func NewUnifiedRequestValidator(pushDeals *statestore.StateStore, pullDeals *statestore.StateStore) *UnifiedRequestValidator {
+func NewUnifiedRequestValidator(pushDeals PushDeals, pullDeals PullDeals) *UnifiedRequestValidator {
 	return &UnifiedRequestValidator{
 		pushDeals: pushDeals,
 		pullDeals: pullDeals,
@@ -27,12 +38,12 @@ func NewUnifiedRequestValidator(pushDeals *statestore.StateStore, pullDeals *sta
 }
 
 // SetPushDeals sets the store to look up push deals with
-func (v *UnifiedRequestValidator) SetPushDeals(pushDeals *statestore.StateStore) {
+func (v *UnifiedRequestValidator) SetPushDeals(pushDeals PushDeals) {
 	v.pushDeals = pushDeals
 }
 
 // SetPullDeals sets the store to look up pull deals with
-func (v *UnifiedRequestValidator) SetPullDeals(pullDeals *statestore.StateStore) {
+func (v *UnifiedRequestValidator) SetPullDeals(pullDeals PullDeals) {
 	v.pullDeals = pullDeals
 }
 

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -22,7 +22,6 @@ import (
 	dtimpl "github.com/filecoin-project/go-data-transfer/impl"
 	dtgstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
 	"github.com/filecoin-project/go-multistore"
-	"github.com/filecoin-project/go-statestore"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/filecoin-project/specs-actors/actors/abi/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -37,7 +36,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	storageimpl "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/funds"
-	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
@@ -415,8 +413,6 @@ func newHarnessWithTestData(t *testing.T, ctx context.Context, td *shared_testut
 	require.NoError(t, err)
 	err = dt1.Start(ctx)
 	require.NoError(t, err)
-	rv1 := requestvalidation.NewUnifiedRequestValidator(nil, statestore.New(td.Ds1))
-	require.NoError(t, dt1.RegisterVoucherType(&requestvalidation.StorageDataTransferVoucher{}, rv1))
 	clientDealFunds, err := funds.NewDealFunds(td.Ds1, datastore.NewKey("storage/client/dealfunds"))
 	require.NoError(t, err)
 
@@ -438,9 +434,6 @@ func newHarnessWithTestData(t *testing.T, ctx context.Context, td *shared_testut
 	require.NoError(t, err)
 	err = dt2.Start(ctx)
 	require.NoError(t, err)
-
-	rv2 := requestvalidation.NewUnifiedRequestValidator(statestore.New(td.Ds2), nil)
-	require.NoError(t, dt2.RegisterVoucherType(&requestvalidation.StorageDataTransferVoucher{}, rv2))
 
 	storedAsk, err := storedask.NewStoredAsk(td.Ds2, datastore.NewKey("latest-ask"), providerNode, providerAddr)
 	assert.NoError(t, err)


### PR DESCRIPTION
# Goals

Fix a race condition where deal status in request validation could fall behind actual events dispatched (resulting in state = StorageDealAcceptWait when Get was called, which then caused a deal rejection)

# Implementation

- Move registering of voucher types for storage market into storage market constructor (long holdover of original way markets was extracted from lotus)
- Use an interface to abstract how deals are "gotten" from the store in Request Validator
- Provide implementation of said interface for client and provider (still assumes multi-process model with seperate data transfer -- we'll need to think about what we want to do if this ever goes back in go-filecoin)
- Register storage voucher types in constructors for client and provider
- Move all of these little "environment wrappers" -- implementations of bridge interfaces between the client/provider and various utility modules -- into seperate environments file -- mirroring retrieval
