### PR TITLE
switch over to map encodings for all markets structs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/sector-storage v0.0.0-20200730050024-3ee28c3b6d9a
 	github.com/filecoin-project/specs-actors v0.8.7-0.20200811203034-272d022c1923
-	github.com/hannahhoward/cbor-gen-for v0.0.0-20200723175505-5892b522820a
+	github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1
 	github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.4-0.20200624145336-a978cec6e834

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfm
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099 h1:vQqOW42RRM5LoM/1K5dK940VipLqpH8lEVGrMz+mNjU=
 github.com/hannahhoward/cbor-gen-for v0.0.0-20191218204337-9ab7b1bcc099/go.mod h1:WVPCl0HO/0RAL5+vBH2GMxBomlxBF70MAS78+Lu1//k=
-github.com/hannahhoward/cbor-gen-for v0.0.0-20200723175505-5892b522820a h1:wfqh5oiHXvn3Rk54xy8Cwqh+HnYihGnjMNzdNb3/ld0=
-github.com/hannahhoward/cbor-gen-for v0.0.0-20200723175505-5892b522820a/go.mod h1:jvfsLIxk0fY/2BKSQ1xf2406AKA5dwMmKKv0ADcOfN8=
+github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1 h1:F9k+7wv5OIk1zcq23QpdiL0hfDuXPjuOmMNaC6fgQ0Q=
+github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1/go.mod h1:jvfsLIxk0fY/2BKSQ1xf2406AKA5dwMmKKv0ADcOfN8=
 github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e h1:3YKHER4nmd7b5qy5t0GWDTwSn4OyRgfAXSmo6VnryBY=
 github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e/go.mod h1:I8h3MITA53gN9OnWGCgaMa0JWVRdXthWw4M3CPM54OY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/piecestore/types.go
+++ b/piecestore/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/filecoin-project/specs-actors/actors/abi"
 )
 
-//go:generate cbor-gen-for PieceInfo DealInfo BlockLocation PieceBlockLocation CIDInfo
+//go:generate cbor-gen-for --map-encoding PieceInfo DealInfo BlockLocation PieceBlockLocation CIDInfo
 
 // DealInfo is information about a single deal for a given piece
 type DealInfo struct {

--- a/piecestore/types_cbor_gen.go
+++ b/piecestore/types_cbor_gen.go
@@ -13,26 +13,45 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufPieceInfo = []byte{130}
-
 func (t *PieceInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufPieceInfo); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PieceCID (cid.Cid) (struct)
+	if len("PieceCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.PieceCID); err != nil {
 		return xerrors.Errorf("failed to write cid field t.PieceCID: %w", err)
 	}
 
 	// t.Deals ([]piecestore.DealInfo) (slice)
+	if len("Deals") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Deals\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Deals"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Deals")); err != nil {
+		return err
+	}
+
 	if len(t.Deals) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.Deals was too long")
 	}
@@ -58,90 +77,149 @@ func (t *PieceInfo) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.PieceCID (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
-		}
-
-		t.PieceCID = c
-
-	}
-	// t.Deals ([]piecestore.DealInfo) (slice)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.Deals: array too large (%d)", extra)
+		return fmt.Errorf("PieceInfo: map struct too large (%d)", extra)
 	}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+	var name string
+	n := extra
 
-	if extra > 0 {
-		t.Deals = make([]DealInfo, extra)
-	}
+	for i := uint64(0); i < n; i++ {
 
-	for i := 0; i < int(extra); i++ {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
 
-		var v DealInfo
-		if err := v.UnmarshalCBOR(br); err != nil {
-			return err
+			name = string(sval)
 		}
 
-		t.Deals[i] = v
+		switch name {
+		// t.PieceCID (cid.Cid) (struct)
+		case "PieceCID":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+				}
+
+				t.PieceCID = c
+
+			}
+			// t.Deals ([]piecestore.DealInfo) (slice)
+		case "Deals":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.Deals: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.Deals = make([]DealInfo, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				var v DealInfo
+				if err := v.UnmarshalCBOR(br); err != nil {
+					return err
+				}
+
+				t.Deals[i] = v
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
 
 	return nil
 }
-
-var lengthBufDealInfo = []byte{132}
-
 func (t *DealInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealInfo); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.DealID (abi.DealID) (uint64)
+	if len("DealID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealID)); err != nil {
 		return err
 	}
 
 	// t.SectorID (abi.SectorNumber) (uint64)
+	if len("SectorID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SectorID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SectorID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SectorID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SectorID)); err != nil {
 		return err
 	}
 
 	// t.Offset (abi.PaddedPieceSize) (uint64)
+	if len("Offset") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Offset\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Offset"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Offset")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Offset)); err != nil {
 		return err
 	}
 
 	// t.Length (abi.PaddedPieceSize) (uint64)
+	if len("Length") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Length\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Length"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Length")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Length)); err != nil {
 		return err
@@ -160,93 +238,135 @@ func (t *DealInfo) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealInfo: map struct too large (%d)", extra)
 	}
 
-	// t.DealID (abi.DealID) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.DealID = abi.DealID(extra)
 
+		switch name {
+		// t.DealID (abi.DealID) (uint64)
+		case "DealID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.DealID = abi.DealID(extra)
+
+			}
+			// t.SectorID (abi.SectorNumber) (uint64)
+		case "SectorID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.SectorID = abi.SectorNumber(extra)
+
+			}
+			// t.Offset (abi.PaddedPieceSize) (uint64)
+		case "Offset":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Offset = abi.PaddedPieceSize(extra)
+
+			}
+			// t.Length (abi.PaddedPieceSize) (uint64)
+		case "Length":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Length = abi.PaddedPieceSize(extra)
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.SectorID (abi.SectorNumber) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.SectorID = abi.SectorNumber(extra)
-
-	}
-	// t.Offset (abi.PaddedPieceSize) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Offset = abi.PaddedPieceSize(extra)
-
-	}
-	// t.Length (abi.PaddedPieceSize) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Length = abi.PaddedPieceSize(extra)
-
-	}
 	return nil
 }
-
-var lengthBufBlockLocation = []byte{130}
-
 func (t *BlockLocation) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufBlockLocation); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.RelOffset (uint64) (uint64)
+	if len("RelOffset") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"RelOffset\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("RelOffset"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("RelOffset")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.RelOffset)); err != nil {
 		return err
 	}
 
 	// t.BlockSize (uint64) (uint64)
+	if len("BlockSize") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"BlockSize\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("BlockSize"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("BlockSize")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.BlockSize)); err != nil {
 		return err
@@ -265,64 +385,105 @@ func (t *BlockLocation) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("BlockLocation: map struct too large (%d)", extra)
 	}
 
-	// t.RelOffset (uint64) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.RelOffset = uint64(extra)
 
+		switch name {
+		// t.RelOffset (uint64) (uint64)
+		case "RelOffset":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.RelOffset = uint64(extra)
+
+			}
+			// t.BlockSize (uint64) (uint64)
+		case "BlockSize":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.BlockSize = uint64(extra)
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.BlockSize (uint64) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.BlockSize = uint64(extra)
-
-	}
 	return nil
 }
-
-var lengthBufPieceBlockLocation = []byte{130}
-
 func (t *PieceBlockLocation) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufPieceBlockLocation); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.BlockLocation (piecestore.BlockLocation) (struct)
+	if len("BlockLocation") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"BlockLocation\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("BlockLocation"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("BlockLocation")); err != nil {
+		return err
+	}
+
 	if err := t.BlockLocation.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PieceCID (cid.Cid) (struct)
+	if len("PieceCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.PieceCID); err != nil {
 		return xerrors.Errorf("failed to write cid field t.PieceCID: %w", err)
@@ -341,58 +502,99 @@ func (t *PieceBlockLocation) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("PieceBlockLocation: map struct too large (%d)", extra)
 	}
 
-	// t.BlockLocation (piecestore.BlockLocation) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.BlockLocation.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.BlockLocation: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-	}
-	// t.PieceCID (cid.Cid) (struct)
+		switch name {
+		// t.BlockLocation (piecestore.BlockLocation) (struct)
+		case "BlockLocation":
 
-	{
+			{
 
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+				if err := t.BlockLocation.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.BlockLocation: %w", err)
+				}
+
+			}
+			// t.PieceCID (cid.Cid) (struct)
+		case "PieceCID":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+				}
+
+				t.PieceCID = c
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
-		t.PieceCID = c
-
 	}
+
 	return nil
 }
-
-var lengthBufCIDInfo = []byte{130}
-
 func (t *CIDInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufCIDInfo); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.CID (cid.Cid) (struct)
+	if len("CID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.CID); err != nil {
 		return xerrors.Errorf("failed to write cid field t.CID: %w", err)
 	}
 
 	// t.PieceBlockLocations ([]piecestore.PieceBlockLocation) (slice)
+	if len("PieceBlockLocations") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceBlockLocations\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceBlockLocations"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceBlockLocations")); err != nil {
+		return err
+	}
+
 	if len(t.PieceBlockLocations) > cbg.MaxLength {
 		return xerrors.Errorf("Slice value in field t.PieceBlockLocations was too long")
 	}
@@ -418,53 +620,75 @@ func (t *CIDInfo) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.CID (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.CID: %w", err)
-		}
-
-		t.CID = c
-
-	}
-	// t.PieceBlockLocations ([]piecestore.PieceBlockLocation) (slice)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
 	if extra > cbg.MaxLength {
-		return fmt.Errorf("t.PieceBlockLocations: array too large (%d)", extra)
+		return fmt.Errorf("CIDInfo: map struct too large (%d)", extra)
 	}
 
-	if maj != cbg.MajArray {
-		return fmt.Errorf("expected cbor array")
-	}
+	var name string
+	n := extra
 
-	if extra > 0 {
-		t.PieceBlockLocations = make([]PieceBlockLocation, extra)
-	}
+	for i := uint64(0); i < n; i++ {
 
-	for i := 0; i < int(extra); i++ {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
 
-		var v PieceBlockLocation
-		if err := v.UnmarshalCBOR(br); err != nil {
-			return err
+			name = string(sval)
 		}
 
-		t.PieceBlockLocations[i] = v
+		switch name {
+		// t.CID (cid.Cid) (struct)
+		case "CID":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.CID: %w", err)
+				}
+
+				t.CID = c
+
+			}
+			// t.PieceBlockLocations ([]piecestore.PieceBlockLocation) (slice)
+		case "PieceBlockLocations":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			if extra > cbg.MaxLength {
+				return fmt.Errorf("t.PieceBlockLocations: array too large (%d)", extra)
+			}
+
+			if maj != cbg.MajArray {
+				return fmt.Errorf("expected cbor array")
+			}
+
+			if extra > 0 {
+				t.PieceBlockLocations = make([]PieceBlockLocation, extra)
+			}
+
+			for i := 0; i < int(extra); i++ {
+
+				var v PieceBlockLocation
+				if err := v.UnmarshalCBOR(br); err != nil {
+					return err
+				}
+
+				t.PieceBlockLocations[i] = v
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
 
 	return nil

--- a/retrievalmarket/discovery/local.go
+++ b/retrievalmarket/discovery/local.go
@@ -1,6 +1,6 @@
 package discovery
 
-//go:generate cbor-gen-for retrievalPeers
+//go:generate cbor-gen-for --map-encoding retrievalPeers
 
 import (
 	"bytes"

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -22,7 +22,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 )
 
-//go:generate cbor-gen-for Query QueryResponse DealProposal DealResponse Params QueryParams DealPayment ClientDealState ProviderDealState PaymentInfo RetrievalPeer Ask
+//go:generate cbor-gen-for --map-encoding Query QueryResponse DealProposal DealResponse Params QueryParams DealPayment ClientDealState ProviderDealState PaymentInfo RetrievalPeer Ask
 
 // ProtocolID is the protocol for proposing / responding to retrieval deals
 const ProtocolID = "/fil/retrieval/0.0.1"

--- a/retrievalmarket/types_cbor_gen.go
+++ b/retrievalmarket/types_cbor_gen.go
@@ -16,26 +16,45 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufQuery = []byte{130}
-
 func (t *Query) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufQuery); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PayloadCID (cid.Cid) (struct)
+	if len("PayloadCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PayloadCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PayloadCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PayloadCID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.PayloadCID); err != nil {
 		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
 	}
 
 	// t.QueryParams (retrievalmarket.QueryParams) (struct)
+	if len("QueryParams") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"QueryParams\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("QueryParams"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("QueryParams")); err != nil {
+		return err
+	}
+
 	if err := t.QueryParams.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -52,92 +71,195 @@ func (t *Query) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Query: map struct too large (%d)", extra)
 	}
 
-	// t.PayloadCID (cid.Cid) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-		t.PayloadCID = c
+		switch name {
+		// t.PayloadCID (cid.Cid) (struct)
+		case "PayloadCID":
 
-	}
-	// t.QueryParams (retrievalmarket.QueryParams) (struct)
+			{
 
-	{
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+				}
 
-		if err := t.QueryParams.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.QueryParams: %w", err)
+				t.PayloadCID = c
+
+			}
+			// t.QueryParams (retrievalmarket.QueryParams) (struct)
+		case "QueryParams":
+
+			{
+
+				if err := t.QueryParams.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.QueryParams: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }
-
-var lengthBufQueryResponse = []byte{137}
-
 func (t *QueryResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufQueryResponse); err != nil {
+	if _, err := w.Write([]byte{169}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Status (retrievalmarket.QueryResponseStatus) (uint64)
+	if len("Status") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Status\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Status"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Status")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
 		return err
 	}
 
 	// t.PieceCIDFound (retrievalmarket.QueryItemStatus) (uint64)
+	if len("PieceCIDFound") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCIDFound\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCIDFound"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCIDFound")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PieceCIDFound)); err != nil {
 		return err
 	}
 
 	// t.Size (uint64) (uint64)
+	if len("Size") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Size\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Size"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Size")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Size)); err != nil {
 		return err
 	}
 
 	// t.PaymentAddress (address.Address) (struct)
+	if len("PaymentAddress") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentAddress\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentAddress"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentAddress")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentAddress.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.MinPricePerByte (big.Int) (struct)
+	if len("MinPricePerByte") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MinPricePerByte\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MinPricePerByte"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MinPricePerByte")); err != nil {
+		return err
+	}
+
 	if err := t.MinPricePerByte.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.MaxPaymentInterval (uint64) (uint64)
+	if len("MaxPaymentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MaxPaymentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MaxPaymentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MaxPaymentInterval")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MaxPaymentInterval)); err != nil {
 		return err
 	}
 
 	// t.MaxPaymentIntervalIncrease (uint64) (uint64)
+	if len("MaxPaymentIntervalIncrease") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MaxPaymentIntervalIncrease\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MaxPaymentIntervalIncrease"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MaxPaymentIntervalIncrease")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MaxPaymentIntervalIncrease)); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -150,6 +272,17 @@ func (t *QueryResponse) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.UnsealPrice (big.Int) (struct)
+	if len("UnsealPrice") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"UnsealPrice\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("UnsealPrice"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("UnsealPrice")); err != nil {
+		return err
+	}
+
 	if err := t.UnsealPrice.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -166,150 +299,208 @@ func (t *QueryResponse) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 9 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("QueryResponse: map struct too large (%d)", extra)
 	}
 
-	// t.Status (retrievalmarket.QueryResponseStatus) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Status = QueryResponseStatus(extra)
 
+		switch name {
+		// t.Status (retrievalmarket.QueryResponseStatus) (uint64)
+		case "Status":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Status = QueryResponseStatus(extra)
+
+			}
+			// t.PieceCIDFound (retrievalmarket.QueryItemStatus) (uint64)
+		case "PieceCIDFound":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PieceCIDFound = QueryItemStatus(extra)
+
+			}
+			// t.Size (uint64) (uint64)
+		case "Size":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Size = uint64(extra)
+
+			}
+			// t.PaymentAddress (address.Address) (struct)
+		case "PaymentAddress":
+
+			{
+
+				if err := t.PaymentAddress.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PaymentAddress: %w", err)
+				}
+
+			}
+			// t.MinPricePerByte (big.Int) (struct)
+		case "MinPricePerByte":
+
+			{
+
+				if err := t.MinPricePerByte.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.MinPricePerByte: %w", err)
+				}
+
+			}
+			// t.MaxPaymentInterval (uint64) (uint64)
+		case "MaxPaymentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MaxPaymentInterval = uint64(extra)
+
+			}
+			// t.MaxPaymentIntervalIncrease (uint64) (uint64)
+		case "MaxPaymentIntervalIncrease":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MaxPaymentIntervalIncrease = uint64(extra)
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+			// t.UnsealPrice (big.Int) (struct)
+		case "UnsealPrice":
+
+			{
+
+				if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.PieceCIDFound (retrievalmarket.QueryItemStatus) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PieceCIDFound = QueryItemStatus(extra)
-
-	}
-	// t.Size (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Size = uint64(extra)
-
-	}
-	// t.PaymentAddress (address.Address) (struct)
-
-	{
-
-		if err := t.PaymentAddress.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PaymentAddress: %w", err)
-		}
-
-	}
-	// t.MinPricePerByte (big.Int) (struct)
-
-	{
-
-		if err := t.MinPricePerByte.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.MinPricePerByte: %w", err)
-		}
-
-	}
-	// t.MaxPaymentInterval (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.MaxPaymentInterval = uint64(extra)
-
-	}
-	// t.MaxPaymentIntervalIncrease (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.MaxPaymentIntervalIncrease = uint64(extra)
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.UnsealPrice (big.Int) (struct)
-
-	{
-
-		if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
-		}
-
-	}
 	return nil
 }
-
-var lengthBufDealProposal = []byte{131}
-
 func (t *DealProposal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealProposal); err != nil {
+	if _, err := w.Write([]byte{163}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PayloadCID (cid.Cid) (struct)
+	if len("PayloadCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PayloadCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PayloadCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PayloadCID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.PayloadCID); err != nil {
 		return xerrors.Errorf("failed to write cid field t.PayloadCID: %w", err)
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+	if len("ID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ID)); err != nil {
 		return err
 	}
 
 	// t.Params (retrievalmarket.Params) (struct)
+	if len("Params") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Params\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Params"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Params")); err != nil {
+		return err
+	}
+
 	if err := t.Params.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -326,83 +517,146 @@ func (t *DealProposal) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 3 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealProposal: map struct too large (%d)", extra)
 	}
 
-	// t.PayloadCID (cid.Cid) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-		t.PayloadCID = c
+		switch name {
+		// t.PayloadCID (cid.Cid) (struct)
+		case "PayloadCID":
 
-	}
-	// t.ID (retrievalmarket.DealID) (uint64)
+			{
 
-	{
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.PayloadCID: %w", err)
+				}
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+				t.PayloadCID = c
+
+			}
+			// t.ID (retrievalmarket.DealID) (uint64)
+		case "ID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.ID = DealID(extra)
+
+			}
+			// t.Params (retrievalmarket.Params) (struct)
+		case "Params":
+
+			{
+
+				if err := t.Params.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Params: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ID = DealID(extra)
-
 	}
-	// t.Params (retrievalmarket.Params) (struct)
 
-	{
-
-		if err := t.Params.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Params: %w", err)
-		}
-
-	}
 	return nil
 }
-
-var lengthBufDealResponse = []byte{132}
-
 func (t *DealResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealResponse); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+	if len("Status") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Status\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Status"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Status")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
 		return err
 	}
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+	if len("ID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ID)); err != nil {
 		return err
 	}
 
 	// t.PaymentOwed (big.Int) (struct)
+	if len("PaymentOwed") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentOwed\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentOwed"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentOwed")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentOwed.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -426,83 +680,126 @@ func (t *DealResponse) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealResponse: map struct too large (%d)", extra)
 	}
 
-	// t.Status (retrievalmarket.DealStatus) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Status = DealStatus(extra)
 
+		switch name {
+		// t.Status (retrievalmarket.DealStatus) (uint64)
+		case "Status":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Status = DealStatus(extra)
+
+			}
+			// t.ID (retrievalmarket.DealID) (uint64)
+		case "ID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.ID = DealID(extra)
+
+			}
+			// t.PaymentOwed (big.Int) (struct)
+		case "PaymentOwed":
+
+			{
+
+				if err := t.PaymentOwed.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PaymentOwed: %w", err)
+				}
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.ID (retrievalmarket.DealID) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ID = DealID(extra)
-
-	}
-	// t.PaymentOwed (big.Int) (struct)
-
-	{
-
-		if err := t.PaymentOwed.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PaymentOwed: %w", err)
-		}
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
 	return nil
 }
-
-var lengthBufParams = []byte{134}
-
 func (t *Params) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufParams); err != nil {
+	if _, err := w.Write([]byte{166}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Selector (typegen.Deferred) (struct)
+	if len("Selector") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Selector\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Selector"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Selector")); err != nil {
+		return err
+	}
+
 	if err := t.Selector.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PieceCID (cid.Cid) (struct)
+	if len("PieceCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCID")); err != nil {
+		return err
+	}
 
 	if t.PieceCID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -515,23 +812,65 @@ func (t *Params) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PricePerByte (big.Int) (struct)
+	if len("PricePerByte") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PricePerByte\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PricePerByte"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PricePerByte")); err != nil {
+		return err
+	}
+
 	if err := t.PricePerByte.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PaymentInterval (uint64) (uint64)
+	if len("PaymentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentInterval")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PaymentInterval)); err != nil {
 		return err
 	}
 
 	// t.PaymentIntervalIncrease (uint64) (uint64)
+	if len("PaymentIntervalIncrease") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentIntervalIncrease\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentIntervalIncrease"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentIntervalIncrease")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PaymentIntervalIncrease)); err != nil {
 		return err
 	}
 
 	// t.UnsealPrice (big.Int) (struct)
+	if len("UnsealPrice") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"UnsealPrice\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("UnsealPrice"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("UnsealPrice")); err != nil {
+		return err
+	}
+
 	if err := t.UnsealPrice.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -548,109 +887,143 @@ func (t *Params) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 6 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Params: map struct too large (%d)", extra)
 	}
 
-	// t.Selector (typegen.Deferred) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		t.Selector = new(cbg.Deferred)
-
-		if err := t.Selector.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("failed to read deferred field: %w", err)
-		}
-	}
-	// t.PieceCID (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Selector (typegen.Deferred) (struct)
+		case "Selector":
+
+			{
+
+				t.Selector = new(cbg.Deferred)
+
+				if err := t.Selector.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("failed to read deferred field: %w", err)
+				}
+			}
+			// t.PieceCID (cid.Cid) (struct)
+		case "PieceCID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+					}
+
+					t.PieceCID = &c
+				}
+
+			}
+			// t.PricePerByte (big.Int) (struct)
+		case "PricePerByte":
+
+			{
+
+				if err := t.PricePerByte.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PricePerByte: %w", err)
+				}
+
+			}
+			// t.PaymentInterval (uint64) (uint64)
+		case "PaymentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PaymentInterval = uint64(extra)
+
+			}
+			// t.PaymentIntervalIncrease (uint64) (uint64)
+		case "PaymentIntervalIncrease":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PaymentIntervalIncrease = uint64(extra)
+
+			}
+			// t.UnsealPrice (big.Int) (struct)
+		case "UnsealPrice":
+
+			{
+
+				if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
+				}
+
 			}
 
-			t.PieceCID = &c
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
-	// t.PricePerByte (big.Int) (struct)
 
-	{
-
-		if err := t.PricePerByte.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PricePerByte: %w", err)
-		}
-
-	}
-	// t.PaymentInterval (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PaymentInterval = uint64(extra)
-
-	}
-	// t.PaymentIntervalIncrease (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PaymentIntervalIncrease = uint64(extra)
-
-	}
-	// t.UnsealPrice (big.Int) (struct)
-
-	{
-
-		if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
-		}
-
-	}
 	return nil
 }
-
-var lengthBufQueryParams = []byte{129}
-
 func (t *QueryParams) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufQueryParams); err != nil {
+	if _, err := w.Write([]byte{161}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PieceCID (cid.Cid) (struct)
+	if len("PieceCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCID")); err != nil {
+		return err
+	}
 
 	if t.PieceCID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -675,64 +1048,115 @@ func (t *QueryParams) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("QueryParams: map struct too large (%d)", extra)
 	}
 
-	// t.PieceCID (cid.Cid) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
-			}
-
-			t.PieceCID = &c
+			name = string(sval)
 		}
 
+		switch name {
+		// t.PieceCID (cid.Cid) (struct)
+		case "PieceCID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+					}
+
+					t.PieceCID = &c
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufDealPayment = []byte{131}
-
 func (t *DealPayment) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealPayment); err != nil {
+	if _, err := w.Write([]byte{163}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.ID (retrievalmarket.DealID) (uint64)
+	if len("ID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.ID)); err != nil {
 		return err
 	}
 
 	// t.PaymentChannel (address.Address) (struct)
+	if len("PaymentChannel") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentChannel\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentChannel"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentChannel")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentChannel.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PaymentVoucher (paych.SignedVoucher) (struct)
+	if len("PaymentVoucher") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentVoucher\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentVoucher"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentVoucher")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentVoucher.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -749,78 +1173,120 @@ func (t *DealPayment) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 3 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealPayment: map struct too large (%d)", extra)
 	}
 
-	// t.ID (retrievalmarket.DealID) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.ID = DealID(extra)
-
-	}
-	// t.PaymentChannel (address.Address) (struct)
-
-	{
-
-		if err := t.PaymentChannel.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PaymentChannel: %w", err)
-		}
-
-	}
-	// t.PaymentVoucher (paych.SignedVoucher) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.PaymentVoucher = new(paych.SignedVoucher)
-			if err := t.PaymentVoucher.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.PaymentVoucher pointer: %w", err)
-			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.ID (retrievalmarket.DealID) (uint64)
+		case "ID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.ID = DealID(extra)
+
+			}
+			// t.PaymentChannel (address.Address) (struct)
+		case "PaymentChannel":
+
+			{
+
+				if err := t.PaymentChannel.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PaymentChannel: %w", err)
+				}
+
+			}
+			// t.PaymentVoucher (paych.SignedVoucher) (struct)
+		case "PaymentVoucher":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.PaymentVoucher = new(paych.SignedVoucher)
+					if err := t.PaymentVoucher.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.PaymentVoucher pointer: %w", err)
+					}
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufClientDealState = []byte{147}
-
 func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufClientDealState); err != nil {
+	if _, err := w.Write([]byte{179}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.DealProposal (retrievalmarket.DealProposal) (struct)
+	if len("DealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.DealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.StoreID (multistore.StoreID) (uint64)
+	if len("StoreID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"StoreID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StoreID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("StoreID")); err != nil {
+		return err
+	}
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -833,47 +1299,145 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.ChannelID (datatransfer.ChannelID) (struct)
+	if len("ChannelID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ChannelID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ChannelID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ChannelID")); err != nil {
+		return err
+	}
+
 	if err := t.ChannelID.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.LastPaymentRequested (bool) (bool)
+	if len("LastPaymentRequested") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"LastPaymentRequested\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("LastPaymentRequested"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("LastPaymentRequested")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.LastPaymentRequested); err != nil {
 		return err
 	}
 
 	// t.AllBlocksReceived (bool) (bool)
+	if len("AllBlocksReceived") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AllBlocksReceived\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AllBlocksReceived"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AllBlocksReceived")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.AllBlocksReceived); err != nil {
 		return err
 	}
 
 	// t.TotalFunds (big.Int) (struct)
+	if len("TotalFunds") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"TotalFunds\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("TotalFunds"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("TotalFunds")); err != nil {
+		return err
+	}
+
 	if err := t.TotalFunds.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.ClientWallet (address.Address) (struct)
+	if len("ClientWallet") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ClientWallet\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ClientWallet"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ClientWallet")); err != nil {
+		return err
+	}
+
 	if err := t.ClientWallet.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.MinerWallet (address.Address) (struct)
+	if len("MinerWallet") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MinerWallet\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MinerWallet"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MinerWallet")); err != nil {
+		return err
+	}
+
 	if err := t.MinerWallet.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PaymentInfo (retrievalmarket.PaymentInfo) (struct)
+	if len("PaymentInfo") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentInfo\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentInfo"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentInfo")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentInfo.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+	if len("Status") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Status\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Status"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Status")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
 		return err
 	}
 
 	// t.Sender (peer.ID) (string)
+	if len("Sender") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Sender\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Sender"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Sender")); err != nil {
+		return err
+	}
+
 	if len(t.Sender) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Sender was too long")
 	}
@@ -886,12 +1450,33 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.TotalReceived (uint64) (uint64)
+	if len("TotalReceived") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"TotalReceived\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("TotalReceived"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("TotalReceived")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.TotalReceived)); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -904,33 +1489,96 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.BytesPaidFor (uint64) (uint64)
+	if len("BytesPaidFor") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"BytesPaidFor\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("BytesPaidFor"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("BytesPaidFor")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.BytesPaidFor)); err != nil {
 		return err
 	}
 
 	// t.CurrentInterval (uint64) (uint64)
+	if len("CurrentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CurrentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CurrentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CurrentInterval")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.CurrentInterval)); err != nil {
 		return err
 	}
 
 	// t.PaymentRequested (big.Int) (struct)
+	if len("PaymentRequested") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentRequested\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentRequested"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentRequested")); err != nil {
+		return err
+	}
+
 	if err := t.PaymentRequested.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.FundsSpent (big.Int) (struct)
+	if len("FundsSpent") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FundsSpent\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FundsSpent"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FundsSpent")); err != nil {
+		return err
+	}
+
 	if err := t.FundsSpent.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.UnsealFundsPaid (big.Int) (struct)
+	if len("UnsealFundsPaid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"UnsealFundsPaid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("UnsealFundsPaid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("UnsealFundsPaid")); err != nil {
+		return err
+	}
+
 	if err := t.UnsealFundsPaid.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.WaitMsgCID (cid.Cid) (struct)
+	if len("WaitMsgCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"WaitMsgCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("WaitMsgCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("WaitMsgCID")); err != nil {
+		return err
+	}
 
 	if t.WaitMsgCID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -955,305 +1603,406 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 19 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("ClientDealState: map struct too large (%d)", extra)
 	}
 
-	// t.DealProposal (retrievalmarket.DealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
-		}
-
-	}
-	// t.StoreID (multistore.StoreID) (uint64)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.DealProposal (retrievalmarket.DealProposal) (struct)
+		case "DealProposal":
+
+			{
+
+				if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
+				}
+
+			}
+			// t.StoreID (multistore.StoreID) (uint64)
+		case "StoreID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					typed := multistore.StoreID(extra)
+					t.StoreID = &typed
+				}
+
+			}
+			// t.ChannelID (datatransfer.ChannelID) (struct)
+		case "ChannelID":
+
+			{
+
+				if err := t.ChannelID.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.ChannelID: %w", err)
+				}
+
+			}
+			// t.LastPaymentRequested (bool) (bool)
+		case "LastPaymentRequested":
+
 			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 			if err != nil {
 				return err
 			}
-			if maj != cbg.MajUnsignedInt {
-				return fmt.Errorf("wrong type for uint64 field")
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
 			}
-			typed := multistore.StoreID(extra)
-			t.StoreID = &typed
-		}
-
-	}
-	// t.ChannelID (datatransfer.ChannelID) (struct)
-
-	{
-
-		if err := t.ChannelID.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ChannelID: %w", err)
-		}
-
-	}
-	// t.LastPaymentRequested (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.LastPaymentRequested = false
-	case 21:
-		t.LastPaymentRequested = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.AllBlocksReceived (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.AllBlocksReceived = false
-	case 21:
-		t.AllBlocksReceived = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.TotalFunds (big.Int) (struct)
-
-	{
-
-		if err := t.TotalFunds.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.TotalFunds: %w", err)
-		}
-
-	}
-	// t.ClientWallet (address.Address) (struct)
-
-	{
-
-		if err := t.ClientWallet.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ClientWallet: %w", err)
-		}
-
-	}
-	// t.MinerWallet (address.Address) (struct)
-
-	{
-
-		if err := t.MinerWallet.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.MinerWallet: %w", err)
-		}
-
-	}
-	// t.PaymentInfo (retrievalmarket.PaymentInfo) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
+			switch extra {
+			case 20:
+				t.LastPaymentRequested = false
+			case 21:
+				t.LastPaymentRequested = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 			}
-			t.PaymentInfo = new(PaymentInfo)
-			if err := t.PaymentInfo.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.PaymentInfo pointer: %w", err)
-			}
-		}
+			// t.AllBlocksReceived (bool) (bool)
+		case "AllBlocksReceived":
 
-	}
-	// t.Status (retrievalmarket.DealStatus) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Status = DealStatus(extra)
-
-	}
-	// t.Sender (peer.ID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Sender = peer.ID(sval)
-	}
-	// t.TotalReceived (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.TotalReceived = uint64(extra)
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.BytesPaidFor (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.BytesPaidFor = uint64(extra)
-
-	}
-	// t.CurrentInterval (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.CurrentInterval = uint64(extra)
-
-	}
-	// t.PaymentRequested (big.Int) (struct)
-
-	{
-
-		if err := t.PaymentRequested.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PaymentRequested: %w", err)
-		}
-
-	}
-	// t.FundsSpent (big.Int) (struct)
-
-	{
-
-		if err := t.FundsSpent.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FundsSpent: %w", err)
-		}
-
-	}
-	// t.UnsealFundsPaid (big.Int) (struct)
-
-	{
-
-		if err := t.UnsealFundsPaid.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.UnsealFundsPaid: %w", err)
-		}
-
-	}
-	// t.WaitMsgCID (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-
-			c, err := cbg.ReadCid(br)
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.WaitMsgCID: %w", err)
+				return err
+			}
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.AllBlocksReceived = false
+			case 21:
+				t.AllBlocksReceived = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.TotalFunds (big.Int) (struct)
+		case "TotalFunds":
+
+			{
+
+				if err := t.TotalFunds.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.TotalFunds: %w", err)
+				}
+
+			}
+			// t.ClientWallet (address.Address) (struct)
+		case "ClientWallet":
+
+			{
+
+				if err := t.ClientWallet.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.ClientWallet: %w", err)
+				}
+
+			}
+			// t.MinerWallet (address.Address) (struct)
+		case "MinerWallet":
+
+			{
+
+				if err := t.MinerWallet.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.MinerWallet: %w", err)
+				}
+
+			}
+			// t.PaymentInfo (retrievalmarket.PaymentInfo) (struct)
+		case "PaymentInfo":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.PaymentInfo = new(PaymentInfo)
+					if err := t.PaymentInfo.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.PaymentInfo pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Status (retrievalmarket.DealStatus) (uint64)
+		case "Status":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Status = DealStatus(extra)
+
+			}
+			// t.Sender (peer.ID) (string)
+		case "Sender":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Sender = peer.ID(sval)
+			}
+			// t.TotalReceived (uint64) (uint64)
+		case "TotalReceived":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.TotalReceived = uint64(extra)
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+			// t.BytesPaidFor (uint64) (uint64)
+		case "BytesPaidFor":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.BytesPaidFor = uint64(extra)
+
+			}
+			// t.CurrentInterval (uint64) (uint64)
+		case "CurrentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.CurrentInterval = uint64(extra)
+
+			}
+			// t.PaymentRequested (big.Int) (struct)
+		case "PaymentRequested":
+
+			{
+
+				if err := t.PaymentRequested.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PaymentRequested: %w", err)
+				}
+
+			}
+			// t.FundsSpent (big.Int) (struct)
+		case "FundsSpent":
+
+			{
+
+				if err := t.FundsSpent.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.FundsSpent: %w", err)
+				}
+
+			}
+			// t.UnsealFundsPaid (big.Int) (struct)
+		case "UnsealFundsPaid":
+
+			{
+
+				if err := t.UnsealFundsPaid.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.UnsealFundsPaid: %w", err)
+				}
+
+			}
+			// t.WaitMsgCID (cid.Cid) (struct)
+		case "WaitMsgCID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.WaitMsgCID: %w", err)
+					}
+
+					t.WaitMsgCID = &c
+				}
+
 			}
 
-			t.WaitMsgCID = &c
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }
-
-var lengthBufProviderDealState = []byte{138}
-
 func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufProviderDealState); err != nil {
+	if _, err := w.Write([]byte{170}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.DealProposal (retrievalmarket.DealProposal) (struct)
+	if len("DealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.DealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.StoreID (multistore.StoreID) (uint64)
+	if len("StoreID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"StoreID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StoreID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("StoreID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.StoreID)); err != nil {
 		return err
 	}
 
 	// t.ChannelID (datatransfer.ChannelID) (struct)
+	if len("ChannelID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ChannelID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ChannelID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ChannelID")); err != nil {
+		return err
+	}
+
 	if err := t.ChannelID.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PieceInfo (piecestore.PieceInfo) (struct)
+	if len("PieceInfo") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceInfo\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceInfo"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceInfo")); err != nil {
+		return err
+	}
+
 	if err := t.PieceInfo.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Status (retrievalmarket.DealStatus) (uint64)
+	if len("Status") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Status\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Status"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Status")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Status)); err != nil {
 		return err
 	}
 
 	// t.Receiver (peer.ID) (string)
+	if len("Receiver") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Receiver\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Receiver"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Receiver")); err != nil {
+		return err
+	}
+
 	if len(t.Receiver) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Receiver was too long")
 	}
@@ -1266,17 +2015,49 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.TotalSent (uint64) (uint64)
+	if len("TotalSent") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"TotalSent\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("TotalSent"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("TotalSent")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.TotalSent)); err != nil {
 		return err
 	}
 
 	// t.FundsReceived (big.Int) (struct)
+	if len("FundsReceived") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FundsReceived\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FundsReceived"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FundsReceived")); err != nil {
+		return err
+	}
+
 	if err := t.FundsReceived.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -1289,6 +2070,16 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.CurrentInterval (uint64) (uint64)
+	if len("CurrentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CurrentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CurrentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CurrentInterval")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.CurrentInterval)); err != nil {
 		return err
@@ -1307,158 +2098,207 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 10 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("ProviderDealState: map struct too large (%d)", extra)
 	}
 
-	// t.DealProposal (retrievalmarket.DealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
-		}
-
-	}
-	// t.StoreID (multistore.StoreID) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.StoreID = multistore.StoreID(extra)
-
-	}
-	// t.ChannelID (datatransfer.ChannelID) (struct)
-
-	{
-
-		if err := t.ChannelID.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ChannelID: %w", err)
-		}
-
-	}
-	// t.PieceInfo (piecestore.PieceInfo) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.PieceInfo = new(piecestore.PieceInfo)
-			if err := t.PieceInfo.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.PieceInfo pointer: %w", err)
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.DealProposal (retrievalmarket.DealProposal) (struct)
+		case "DealProposal":
+
+			{
+
+				if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
+				}
+
 			}
-		}
+			// t.StoreID (multistore.StoreID) (uint64)
+		case "StoreID":
 
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.StoreID = multistore.StoreID(extra)
+
+			}
+			// t.ChannelID (datatransfer.ChannelID) (struct)
+		case "ChannelID":
+
+			{
+
+				if err := t.ChannelID.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.ChannelID: %w", err)
+				}
+
+			}
+			// t.PieceInfo (piecestore.PieceInfo) (struct)
+		case "PieceInfo":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.PieceInfo = new(piecestore.PieceInfo)
+					if err := t.PieceInfo.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.PieceInfo pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Status (retrievalmarket.DealStatus) (uint64)
+		case "Status":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Status = DealStatus(extra)
+
+			}
+			// t.Receiver (peer.ID) (string)
+		case "Receiver":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Receiver = peer.ID(sval)
+			}
+			// t.TotalSent (uint64) (uint64)
+		case "TotalSent":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.TotalSent = uint64(extra)
+
+			}
+			// t.FundsReceived (big.Int) (struct)
+		case "FundsReceived":
+
+			{
+
+				if err := t.FundsReceived.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.FundsReceived: %w", err)
+				}
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+			// t.CurrentInterval (uint64) (uint64)
+		case "CurrentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.CurrentInterval = uint64(extra)
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.Status (retrievalmarket.DealStatus) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Status = DealStatus(extra)
-
-	}
-	// t.Receiver (peer.ID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Receiver = peer.ID(sval)
-	}
-	// t.TotalSent (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.TotalSent = uint64(extra)
-
-	}
-	// t.FundsReceived (big.Int) (struct)
-
-	{
-
-		if err := t.FundsReceived.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FundsReceived: %w", err)
-		}
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.CurrentInterval (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.CurrentInterval = uint64(extra)
-
-	}
 	return nil
 }
-
-var lengthBufPaymentInfo = []byte{130}
-
 func (t *PaymentInfo) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufPaymentInfo); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PayCh (address.Address) (struct)
+	if len("PayCh") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PayCh\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PayCh"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PayCh")); err != nil {
+		return err
+	}
+
 	if err := t.PayCh.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Lane (uint64) (uint64)
+	if len("Lane") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Lane\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Lane"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Lane")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Lane)); err != nil {
 		return err
@@ -1477,59 +2317,101 @@ func (t *PaymentInfo) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("PaymentInfo: map struct too large (%d)", extra)
 	}
 
-	// t.PayCh (address.Address) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.PayCh.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PayCh: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-	}
-	// t.Lane (uint64) (uint64)
+		switch name {
+		// t.PayCh (address.Address) (struct)
+		case "PayCh":
 
-	{
+			{
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
+				if err := t.PayCh.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PayCh: %w", err)
+				}
+
+			}
+			// t.Lane (uint64) (uint64)
+		case "Lane":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.Lane = uint64(extra)
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.Lane = uint64(extra)
-
 	}
+
 	return nil
 }
-
-var lengthBufRetrievalPeer = []byte{131}
-
 func (t *RetrievalPeer) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufRetrievalPeer); err != nil {
+	if _, err := w.Write([]byte{163}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Address (address.Address) (struct)
+	if len("Address") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Address\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Address"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Address")); err != nil {
+		return err
+	}
+
 	if err := t.Address.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.ID (peer.ID) (string)
+	if len("ID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ID")); err != nil {
+		return err
+	}
+
 	if len(t.ID) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.ID was too long")
 	}
@@ -1542,6 +2424,16 @@ func (t *RetrievalPeer) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PieceCID (cid.Cid) (struct)
+	if len("PieceCID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCID")); err != nil {
+		return err
+	}
 
 	if t.PieceCID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -1566,88 +2458,151 @@ func (t *RetrievalPeer) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 3 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("RetrievalPeer: map struct too large (%d)", extra)
 	}
 
-	// t.Address (address.Address) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.Address.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Address: %w", err)
-		}
-
-	}
-	// t.ID (peer.ID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.ID = peer.ID(sval)
-	}
-	// t.PieceCID (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
-			}
-
-			t.PieceCID = &c
+			name = string(sval)
 		}
 
+		switch name {
+		// t.Address (address.Address) (struct)
+		case "Address":
+
+			{
+
+				if err := t.Address.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Address: %w", err)
+				}
+
+			}
+			// t.ID (peer.ID) (string)
+		case "ID":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.ID = peer.ID(sval)
+			}
+			// t.PieceCID (cid.Cid) (struct)
+		case "PieceCID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PieceCID: %w", err)
+					}
+
+					t.PieceCID = &c
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufAsk = []byte{132}
-
 func (t *Ask) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufAsk); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.PricePerByte (big.Int) (struct)
+	if len("PricePerByte") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PricePerByte\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PricePerByte"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PricePerByte")); err != nil {
+		return err
+	}
+
 	if err := t.PricePerByte.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.UnsealPrice (big.Int) (struct)
+	if len("UnsealPrice") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"UnsealPrice\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("UnsealPrice"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("UnsealPrice")); err != nil {
+		return err
+	}
+
 	if err := t.UnsealPrice.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.PaymentInterval (uint64) (uint64)
+	if len("PaymentInterval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentInterval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentInterval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentInterval")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PaymentInterval)); err != nil {
 		return err
 	}
 
 	// t.PaymentIntervalIncrease (uint64) (uint64)
+	if len("PaymentIntervalIncrease") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PaymentIntervalIncrease\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PaymentIntervalIncrease"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PaymentIntervalIncrease")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PaymentIntervalIncrease)); err != nil {
 		return err
@@ -1666,59 +2621,84 @@ func (t *Ask) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Ask: map struct too large (%d)", extra)
 	}
 
-	// t.PricePerByte (big.Int) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.PricePerByte.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.PricePerByte: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.PricePerByte (big.Int) (struct)
+		case "PricePerByte":
+
+			{
+
+				if err := t.PricePerByte.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.PricePerByte: %w", err)
+				}
+
+			}
+			// t.UnsealPrice (big.Int) (struct)
+		case "UnsealPrice":
+
+			{
+
+				if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
+				}
+
+			}
+			// t.PaymentInterval (uint64) (uint64)
+		case "PaymentInterval":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PaymentInterval = uint64(extra)
+
+			}
+			// t.PaymentIntervalIncrease (uint64) (uint64)
+		case "PaymentIntervalIncrease":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PaymentIntervalIncrease = uint64(extra)
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.UnsealPrice (big.Int) (struct)
 
-	{
-
-		if err := t.UnsealPrice.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.UnsealPrice: %w", err)
-		}
-
-	}
-	// t.PaymentInterval (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PaymentInterval = uint64(extra)
-
-	}
-	// t.PaymentIntervalIncrease (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PaymentIntervalIncrease = uint64(extra)
-
-	}
 	return nil
 }

--- a/storagemarket/impl/blockrecorder/blockrecorder.go
+++ b/storagemarket/impl/blockrecorder/blockrecorder.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ipld/go-car"
 )
 
-//go:generate cbor-gen-for PieceBlockMetadata
+//go:generate cbor-gen-for --map-encoding PieceBlockMetadata
 
 // PieceBlockMetadata is a record of where a given CID lives in a piece,
 // in terms of its offset and size

--- a/storagemarket/impl/requestvalidation/types.go
+++ b/storagemarket/impl/requestvalidation/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 )
 
-//go:generate cbor-gen-for StorageDataTransferVoucher
+//go:generate cbor-gen-for --map-encoding StorageDataTransferVoucher
 
 var (
 	// ErrWrongVoucherType means the voucher was not the correct type can validate against

--- a/storagemarket/network/types.go
+++ b/storagemarket/network/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 )
 
-//go:generate cbor-gen-for AskRequest AskResponse Proposal Response SignedResponse DealStatusRequest DealStatusResponse
+//go:generate cbor-gen-for --map-encoding AskRequest AskResponse Proposal Response SignedResponse DealStatusRequest DealStatusResponse
 
 // Proposal is the data sent over the network from client to provider when proposing
 // a deal

--- a/storagemarket/network/types_cbor_gen.go
+++ b/storagemarket/network/types_cbor_gen.go
@@ -15,18 +15,29 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufAskRequest = []byte{129}
-
 func (t *AskRequest) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufAskRequest); err != nil {
+	if _, err := w.Write([]byte{161}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.Miner (address.Address) (struct)
+	if len("Miner") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Miner\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Miner"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Miner")); err != nil {
+		return err
+	}
+
 	if err := t.Miner.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -43,38 +54,70 @@ func (t *AskRequest) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("AskRequest: map struct too large (%d)", extra)
 	}
 
-	// t.Miner (address.Address) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.Miner.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.Miner (address.Address) (struct)
+		case "Miner":
+
+			{
+
+				if err := t.Miner.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Miner: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufAskResponse = []byte{129}
-
 func (t *AskResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufAskResponse); err != nil {
+	if _, err := w.Write([]byte{161}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.Ask (storagemarket.SignedStorageAsk) (struct)
+	if len("Ask") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Ask\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Ask"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Ask")); err != nil {
+		return err
+	}
+
 	if err := t.Ask.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -91,58 +134,112 @@ func (t *AskResponse) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 1 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("AskResponse: map struct too large (%d)", extra)
 	}
 
-	// t.Ask (storagemarket.SignedStorageAsk) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.Ask = new(storagemarket.SignedStorageAsk)
-			if err := t.Ask.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
-			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.Ask (storagemarket.SignedStorageAsk) (struct)
+		case "Ask":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Ask = new(storagemarket.SignedStorageAsk)
+					if err := t.Ask.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
+					}
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufProposal = []byte{131}
-
 func (t *Proposal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufProposal); err != nil {
+	if _, err := w.Write([]byte{163}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.DealProposal (market.ClientDealProposal) (struct)
+	if len("DealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.DealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Piece (storagemarket.DataRef) (struct)
+	if len("Piece") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Piece\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Piece"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Piece")); err != nil {
+		return err
+	}
+
 	if err := t.Piece.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.FastRetrieval (bool) (bool)
+	if len("FastRetrieval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FastRetrieval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FastRetrieval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FastRetrieval")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
 		return err
 	}
@@ -159,92 +256,134 @@ func (t *Proposal) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 3 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Proposal: map struct too large (%d)", extra)
 	}
 
-	// t.DealProposal (market.ClientDealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.DealProposal = new(market.ClientDealProposal)
-			if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.DealProposal pointer: %w", err)
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.DealProposal (market.ClientDealProposal) (struct)
+		case "DealProposal":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.DealProposal = new(market.ClientDealProposal)
+					if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.DealProposal pointer: %w", err)
+					}
+				}
+
 			}
-		}
+			// t.Piece (storagemarket.DataRef) (struct)
+		case "Piece":
 
-	}
-	// t.Piece (storagemarket.DataRef) (struct)
+			{
 
-	{
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Piece = new(storagemarket.DataRef)
+					if err := t.Piece.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Piece pointer: %w", err)
+					}
+				}
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			}
+			// t.FastRetrieval (bool) (bool)
+		case "FastRetrieval":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.Piece = new(storagemarket.DataRef)
-			if err := t.Piece.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Piece pointer: %w", err)
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
 			}
+			switch extra {
+			case 20:
+				t.FastRetrieval = false
+			case 21:
+				t.FastRetrieval = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
+	}
 
-	}
-	// t.FastRetrieval (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.FastRetrieval = false
-	case 21:
-		t.FastRetrieval = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
 	return nil
 }
-
-var lengthBufResponse = []byte{132}
-
 func (t *Response) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufResponse); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.State (uint64) (uint64)
+	if len("State") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"State\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("State"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("State")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.State)); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -257,12 +396,32 @@ func (t *Response) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Proposal (cid.Cid) (struct)
+	if len("Proposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Proposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Proposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Proposal")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.Proposal); err != nil {
 		return xerrors.Errorf("failed to write cid field t.Proposal: %w", err)
 	}
 
 	// t.PublishMessage (cid.Cid) (struct)
+	if len("PublishMessage") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PublishMessage\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PublishMessage"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PublishMessage")); err != nil {
+		return err
+	}
 
 	if t.PublishMessage == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -287,92 +446,138 @@ func (t *Response) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Response: map struct too large (%d)", extra)
 	}
 
-	// t.State (uint64) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.State = uint64(extra)
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.Proposal (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.Proposal: %w", err)
-		}
-
-		t.Proposal = c
-
-	}
-	// t.PublishMessage (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PublishMessage: %w", err)
-			}
-
-			t.PublishMessage = &c
+			name = string(sval)
 		}
 
+		switch name {
+		// t.State (uint64) (uint64)
+		case "State":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.State = uint64(extra)
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+			// t.Proposal (cid.Cid) (struct)
+		case "Proposal":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.Proposal: %w", err)
+				}
+
+				t.Proposal = c
+
+			}
+			// t.PublishMessage (cid.Cid) (struct)
+		case "PublishMessage":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PublishMessage: %w", err)
+					}
+
+					t.PublishMessage = &c
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufSignedResponse = []byte{130}
-
 func (t *SignedResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufSignedResponse); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.Response (network.Response) (struct)
+	if len("Response") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Response\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Response"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Response")); err != nil {
+		return err
+	}
+
 	if err := t.Response.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Signature (crypto.Signature) (struct)
+	if len("Signature") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Signature\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Signature"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Signature")); err != nil {
+		return err
+	}
+
 	if err := t.Signature.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -389,65 +594,106 @@ func (t *SignedResponse) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("SignedResponse: map struct too large (%d)", extra)
 	}
 
-	// t.Response (network.Response) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.Response.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Response: %w", err)
-		}
-
-	}
-	// t.Signature (crypto.Signature) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.Signature = new(crypto.Signature)
-			if err := t.Signature.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
-			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.Response (network.Response) (struct)
+		case "Response":
+
+			{
+
+				if err := t.Response.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Response: %w", err)
+				}
+
+			}
+			// t.Signature (crypto.Signature) (struct)
+		case "Signature":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Signature = new(crypto.Signature)
+					if err := t.Signature.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
+					}
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
+
 	return nil
 }
-
-var lengthBufDealStatusRequest = []byte{130}
-
 func (t *DealStatusRequest) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealStatusRequest); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Proposal (cid.Cid) (struct)
+	if len("Proposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Proposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Proposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Proposal")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.Proposal); err != nil {
 		return xerrors.Errorf("failed to write cid field t.Proposal: %w", err)
 	}
 
 	// t.Signature (crypto.Signature) (struct)
+	if len("Signature") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Signature\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Signature"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Signature")); err != nil {
+		return err
+	}
+
 	if err := t.Signature.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -464,55 +710,99 @@ func (t *DealStatusRequest) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealStatusRequest: map struct too large (%d)", extra)
 	}
 
-	// t.Proposal (cid.Cid) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.Proposal: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-		t.Proposal = c
+		switch name {
+		// t.Proposal (cid.Cid) (struct)
+		case "Proposal":
 
-	}
-	// t.Signature (crypto.Signature) (struct)
+			{
 
-	{
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.Proposal: %w", err)
+				}
 
-		if err := t.Signature.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Signature: %w", err)
+				t.Proposal = c
+
+			}
+			// t.Signature (crypto.Signature) (struct)
+		case "Signature":
+
+			{
+
+				if err := t.Signature.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Signature: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }
-
-var lengthBufDealStatusResponse = []byte{130}
-
 func (t *DealStatusResponse) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDealStatusResponse); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.DealState (storagemarket.ProviderDealState) (struct)
+	if len("DealState") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealState\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealState"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealState")); err != nil {
+		return err
+	}
+
 	if err := t.DealState.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Signature (crypto.Signature) (struct)
+	if len("Signature") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Signature\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Signature"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Signature")); err != nil {
+		return err
+	}
+
 	if err := t.Signature.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -529,31 +819,54 @@ func (t *DealStatusResponse) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DealStatusResponse: map struct too large (%d)", extra)
 	}
 
-	// t.DealState (storagemarket.ProviderDealState) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.DealState.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealState: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-	}
-	// t.Signature (crypto.Signature) (struct)
+		switch name {
+		// t.DealState (storagemarket.ProviderDealState) (struct)
+		case "DealState":
 
-	{
+			{
 
-		if err := t.Signature.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Signature: %w", err)
+				if err := t.DealState.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.DealState: %w", err)
+				}
+
+			}
+			// t.Signature (crypto.Signature) (struct)
+		case "Signature":
+
+			{
+
+				if err := t.Signature.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Signature: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -15,7 +15,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/filestore"
 )
 
-//go:generate cbor-gen-for ClientDeal MinerDeal Balance SignedStorageAsk StorageAsk StorageDeal DataRef ProviderDealState
+//go:generate cbor-gen-for --map-encoding ClientDeal MinerDeal Balance SignedStorageAsk StorageAsk StorageDeal DataRef ProviderDealState
 
 // DealProtocolID is the ID for the libp2p protocol for proposing storage deals.
 const DealProtocolID = "/fil/storage/mk/1.0.1"

--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -18,31 +18,60 @@ import (
 
 var _ = xerrors.Errorf
 
-var lengthBufClientDeal = []byte{145}
-
 func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufClientDeal); err != nil {
+	if _, err := w.Write([]byte{177}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.ClientDealProposal (market.ClientDealProposal) (struct)
+	if len("ClientDealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ClientDealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ClientDealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ClientDealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.ClientDealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.ProposalCid (cid.Cid) (struct)
+	if len("ProposalCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ProposalCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ProposalCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ProposalCid")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.ProposalCid); err != nil {
 		return xerrors.Errorf("failed to write cid field t.ProposalCid: %w", err)
 	}
 
 	// t.AddFundsCid (cid.Cid) (struct)
+	if len("AddFundsCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AddFundsCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AddFundsCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AddFundsCid")); err != nil {
+		return err
+	}
 
 	if t.AddFundsCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -55,12 +84,33 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.State (uint64) (uint64)
+	if len("State") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"State\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("State"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("State")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.State)); err != nil {
 		return err
 	}
 
 	// t.Miner (peer.ID) (string)
+	if len("Miner") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Miner\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Miner"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Miner")); err != nil {
+		return err
+	}
+
 	if len(t.Miner) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Miner was too long")
 	}
@@ -73,22 +123,65 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.MinerWorker (address.Address) (struct)
+	if len("MinerWorker") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MinerWorker\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MinerWorker"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MinerWorker")); err != nil {
+		return err
+	}
+
 	if err := t.MinerWorker.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+	if len("DealID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealID)); err != nil {
 		return err
 	}
 
 	// t.DataRef (storagemarket.DataRef) (struct)
+	if len("DataRef") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DataRef\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DataRef"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DataRef")); err != nil {
+		return err
+	}
+
 	if err := t.DataRef.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -101,6 +194,16 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PublishMessage (cid.Cid) (struct)
+	if len("PublishMessage") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PublishMessage\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PublishMessage"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PublishMessage")); err != nil {
+		return err
+	}
 
 	if t.PublishMessage == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -113,6 +216,17 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.SlashEpoch (abi.ChainEpoch) (int64)
+	if len("SlashEpoch") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SlashEpoch\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SlashEpoch"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SlashEpoch")); err != nil {
+		return err
+	}
+
 	if t.SlashEpoch >= 0 {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SlashEpoch)); err != nil {
 			return err
@@ -124,23 +238,64 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PollRetryCount (uint64) (uint64)
+	if len("PollRetryCount") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PollRetryCount\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PollRetryCount"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PollRetryCount")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PollRetryCount)); err != nil {
 		return err
 	}
 
 	// t.PollErrorCount (uint64) (uint64)
+	if len("PollErrorCount") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PollErrorCount\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PollErrorCount"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PollErrorCount")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PollErrorCount)); err != nil {
 		return err
 	}
 
 	// t.FastRetrieval (bool) (bool)
+	if len("FastRetrieval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FastRetrieval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FastRetrieval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FastRetrieval")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
 		return err
 	}
 
 	// t.StoreID (multistore.StoreID) (uint64)
+	if len("StoreID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"StoreID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StoreID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("StoreID")); err != nil {
+		return err
+	}
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -153,11 +308,33 @@ func (t *ClientDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.FundsReserved (big.Int) (struct)
+	if len("FundsReserved") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FundsReserved\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FundsReserved"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FundsReserved")); err != nil {
+		return err
+	}
+
 	if err := t.FundsReserved.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.CreationTime (typegen.CborTime) (struct)
+	if len("CreationTime") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CreationTime\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CreationTime"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CreationTime")); err != nil {
+		return err
+	}
+
 	if err := t.CreationTime.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -174,295 +351,361 @@ func (t *ClientDeal) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 17 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("ClientDeal: map struct too large (%d)", extra)
 	}
 
-	// t.ClientDealProposal (market.ClientDealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
-		}
-
-	}
-	// t.ProposalCid (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
-		}
-
-		t.ProposalCid = c
-
-	}
-	// t.AddFundsCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-
-			c, err := cbg.ReadCid(br)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
 			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
-			}
-
-			t.AddFundsCid = &c
-		}
-
-	}
-	// t.State (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.State = uint64(extra)
-
-	}
-	// t.Miner (peer.ID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Miner = peer.ID(sval)
-	}
-	// t.MinerWorker (address.Address) (struct)
-
-	{
-
-		if err := t.MinerWorker.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.MinerWorker: %w", err)
-		}
-
-	}
-	// t.DealID (abi.DealID) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.DealID = abi.DealID(extra)
-
-	}
-	// t.DataRef (storagemarket.DataRef) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-			t.DataRef = new(DataRef)
-			if err := t.DataRef.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.DataRef pointer: %w", err)
-			}
-		}
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.PublishMessage (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PublishMessage: %w", err)
+			name = string(sval)
+		}
+
+		switch name {
+		// t.ClientDealProposal (market.ClientDealProposal) (struct)
+		case "ClientDealProposal":
+
+			{
+
+				if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
+				}
+
 			}
+			// t.ProposalCid (cid.Cid) (struct)
+		case "ProposalCid":
 
-			t.PublishMessage = &c
-		}
+			{
 
-	}
-	// t.SlashEpoch (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
+				}
+
+				t.ProposalCid = c
+
 			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
+			// t.AddFundsCid (cid.Cid) (struct)
+		case "AddFundsCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
+					}
+
+					t.AddFundsCid = &c
+				}
+
 			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+			// t.State (uint64) (uint64)
+		case "State":
 
-		t.SlashEpoch = abi.ChainEpoch(extraI)
-	}
-	// t.PollRetryCount (uint64) (uint64)
+			{
 
-	{
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.State = uint64(extra)
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PollRetryCount = uint64(extra)
-
-	}
-	// t.PollErrorCount (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PollErrorCount = uint64(extra)
-
-	}
-	// t.FastRetrieval (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.FastRetrieval = false
-	case 21:
-		t.FastRetrieval = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.StoreID (multistore.StoreID) (uint64)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
 			}
+			// t.Miner (peer.ID) (string)
+		case "Miner":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Miner = peer.ID(sval)
+			}
+			// t.MinerWorker (address.Address) (struct)
+		case "MinerWorker":
+
+			{
+
+				if err := t.MinerWorker.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.MinerWorker: %w", err)
+				}
+
+			}
+			// t.DealID (abi.DealID) (uint64)
+		case "DealID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.DealID = abi.DealID(extra)
+
+			}
+			// t.DataRef (storagemarket.DataRef) (struct)
+		case "DataRef":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.DataRef = new(DataRef)
+					if err := t.DataRef.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.DataRef pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Message (string) (string)
+		case "Message":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Message = string(sval)
+			}
+			// t.PublishMessage (cid.Cid) (struct)
+		case "PublishMessage":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PublishMessage: %w", err)
+					}
+
+					t.PublishMessage = &c
+				}
+
+			}
+			// t.SlashEpoch (abi.ChainEpoch) (int64)
+		case "SlashEpoch":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.SlashEpoch = abi.ChainEpoch(extraI)
+			}
+			// t.PollRetryCount (uint64) (uint64)
+		case "PollRetryCount":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PollRetryCount = uint64(extra)
+
+			}
+			// t.PollErrorCount (uint64) (uint64)
+		case "PollErrorCount":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PollErrorCount = uint64(extra)
+
+			}
+			// t.FastRetrieval (bool) (bool)
+		case "FastRetrieval":
+
 			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 			if err != nil {
 				return err
 			}
-			if maj != cbg.MajUnsignedInt {
-				return fmt.Errorf("wrong type for uint64 field")
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
 			}
-			typed := multistore.StoreID(extra)
-			t.StoreID = &typed
+			switch extra {
+			case 20:
+				t.FastRetrieval = false
+			case 21:
+				t.FastRetrieval = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.StoreID (multistore.StoreID) (uint64)
+		case "StoreID":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					typed := multistore.StoreID(extra)
+					t.StoreID = &typed
+				}
+
+			}
+			// t.FundsReserved (big.Int) (struct)
+		case "FundsReserved":
+
+			{
+
+				if err := t.FundsReserved.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.FundsReserved: %w", err)
+				}
+
+			}
+			// t.CreationTime (typegen.CborTime) (struct)
+		case "CreationTime":
+
+			{
+
+				if err := t.CreationTime.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.CreationTime: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
-	// t.FundsReserved (big.Int) (struct)
 
-	{
-
-		if err := t.FundsReserved.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FundsReserved: %w", err)
-		}
-
-	}
-	// t.CreationTime (typegen.CborTime) (struct)
-
-	{
-
-		if err := t.CreationTime.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.CreationTime: %w", err)
-		}
-
-	}
 	return nil
 }
-
-var lengthBufMinerDeal = []byte{146}
-
 func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufMinerDeal); err != nil {
+	if _, err := w.Write([]byte{178}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.ClientDealProposal (market.ClientDealProposal) (struct)
+	if len("ClientDealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ClientDealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ClientDealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ClientDealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.ClientDealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.ProposalCid (cid.Cid) (struct)
+	if len("ProposalCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ProposalCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ProposalCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ProposalCid")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.ProposalCid); err != nil {
 		return xerrors.Errorf("failed to write cid field t.ProposalCid: %w", err)
 	}
 
 	// t.AddFundsCid (cid.Cid) (struct)
+	if len("AddFundsCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AddFundsCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AddFundsCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AddFundsCid")); err != nil {
+		return err
+	}
 
 	if t.AddFundsCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -475,6 +718,16 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PublishCid (cid.Cid) (struct)
+	if len("PublishCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PublishCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PublishCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PublishCid")); err != nil {
+		return err
+	}
 
 	if t.PublishCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -487,6 +740,17 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Miner (peer.ID) (string)
+	if len("Miner") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Miner\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Miner"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Miner")); err != nil {
+		return err
+	}
+
 	if len(t.Miner) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Miner was too long")
 	}
@@ -499,6 +763,17 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Client (peer.ID) (string)
+	if len("Client") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Client\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Client"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Client")); err != nil {
+		return err
+	}
+
 	if len(t.Client) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Client was too long")
 	}
@@ -511,12 +786,33 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.State (uint64) (uint64)
+	if len("State") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"State\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("State"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("State")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.State)); err != nil {
 		return err
 	}
 
 	// t.PiecePath (filestore.Path) (string)
+	if len("PiecePath") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PiecePath\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PiecePath"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PiecePath")); err != nil {
+		return err
+	}
+
 	if len(t.PiecePath) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.PiecePath was too long")
 	}
@@ -529,6 +825,17 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.MetadataPath (filestore.Path) (string)
+	if len("MetadataPath") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MetadataPath\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MetadataPath"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MetadataPath")); err != nil {
+		return err
+	}
+
 	if len(t.MetadataPath) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.MetadataPath was too long")
 	}
@@ -541,6 +848,17 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.SlashEpoch (abi.ChainEpoch) (int64)
+	if len("SlashEpoch") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SlashEpoch\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SlashEpoch"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SlashEpoch")); err != nil {
+		return err
+	}
+
 	if t.SlashEpoch >= 0 {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SlashEpoch)); err != nil {
 			return err
@@ -552,11 +870,33 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.FastRetrieval (bool) (bool)
+	if len("FastRetrieval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FastRetrieval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FastRetrieval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FastRetrieval")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -569,6 +909,16 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.StoreID (multistore.StoreID) (uint64)
+	if len("StoreID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"StoreID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("StoreID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("StoreID")); err != nil {
+		return err
+	}
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -581,27 +931,81 @@ func (t *MinerDeal) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.FundsReserved (big.Int) (struct)
+	if len("FundsReserved") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FundsReserved\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FundsReserved"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FundsReserved")); err != nil {
+		return err
+	}
+
 	if err := t.FundsReserved.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Ref (storagemarket.DataRef) (struct)
+	if len("Ref") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Ref\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Ref"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Ref")); err != nil {
+		return err
+	}
+
 	if err := t.Ref.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.AvailableForRetrieval (bool) (bool)
+	if len("AvailableForRetrieval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AvailableForRetrieval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AvailableForRetrieval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AvailableForRetrieval")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.AvailableForRetrieval); err != nil {
 		return err
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+	if len("DealID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealID)); err != nil {
 		return err
 	}
 
 	// t.CreationTime (typegen.CborTime) (struct)
+	if len("CreationTime") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"CreationTime\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("CreationTime"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("CreationTime")); err != nil {
+		return err
+	}
+
 	if err := t.CreationTime.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -618,297 +1022,357 @@ func (t *MinerDeal) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 18 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("MinerDeal: map struct too large (%d)", extra)
 	}
 
-	// t.ClientDealProposal (market.ClientDealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
-		}
-
-	}
-	// t.ProposalCid (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
-		}
-
-		t.ProposalCid = c
-
-	}
-	// t.AddFundsCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-
-			c, err := cbg.ReadCid(br)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
 			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
-			}
-
-			t.AddFundsCid = &c
-		}
-
-	}
-	// t.PublishCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PublishCid: %w", err)
+			name = string(sval)
+		}
+
+		switch name {
+		// t.ClientDealProposal (market.ClientDealProposal) (struct)
+		case "ClientDealProposal":
+
+			{
+
+				if err := t.ClientDealProposal.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.ClientDealProposal: %w", err)
+				}
+
 			}
+			// t.ProposalCid (cid.Cid) (struct)
+		case "ProposalCid":
 
-			t.PublishCid = &c
-		}
+			{
 
-	}
-	// t.Miner (peer.ID) (string)
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
+				}
 
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
+				t.ProposalCid = c
 
-		t.Miner = peer.ID(sval)
-	}
-	// t.Client (peer.ID) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Client = peer.ID(sval)
-	}
-	// t.State (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.State = uint64(extra)
-
-	}
-	// t.PiecePath (filestore.Path) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.PiecePath = filestore.Path(sval)
-	}
-	// t.MetadataPath (filestore.Path) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.MetadataPath = filestore.Path(sval)
-	}
-	// t.SlashEpoch (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
 			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
+			// t.AddFundsCid (cid.Cid) (struct)
+		case "AddFundsCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
+					}
+
+					t.AddFundsCid = &c
+				}
+
 			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
+			// t.PublishCid (cid.Cid) (struct)
+		case "PublishCid":
 
-		t.SlashEpoch = abi.ChainEpoch(extraI)
-	}
-	// t.FastRetrieval (bool) (bool)
+			{
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.FastRetrieval = false
-	case 21:
-		t.FastRetrieval = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.Message (string) (string)
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
 
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PublishCid: %w", err)
+					}
 
-		t.Message = string(sval)
-	}
-	// t.StoreID (multistore.StoreID) (uint64)
+					t.PublishCid = &c
+				}
 
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
 			}
+			// t.Miner (peer.ID) (string)
+		case "Miner":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Miner = peer.ID(sval)
+			}
+			// t.Client (peer.ID) (string)
+		case "Client":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.Client = peer.ID(sval)
+			}
+			// t.State (uint64) (uint64)
+		case "State":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.State = uint64(extra)
+
+			}
+			// t.PiecePath (filestore.Path) (string)
+		case "PiecePath":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.PiecePath = filestore.Path(sval)
+			}
+			// t.MetadataPath (filestore.Path) (string)
+		case "MetadataPath":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.MetadataPath = filestore.Path(sval)
+			}
+			// t.SlashEpoch (abi.ChainEpoch) (int64)
+		case "SlashEpoch":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.SlashEpoch = abi.ChainEpoch(extraI)
+			}
+			// t.FastRetrieval (bool) (bool)
+		case "FastRetrieval":
+
 			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
 			if err != nil {
 				return err
 			}
-			if maj != cbg.MajUnsignedInt {
-				return fmt.Errorf("wrong type for uint64 field")
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
 			}
-			typed := multistore.StoreID(extra)
-			t.StoreID = &typed
-		}
+			switch extra {
+			case 20:
+				t.FastRetrieval = false
+			case 21:
+				t.FastRetrieval = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.Message (string) (string)
+		case "Message":
 
-	}
-	// t.FundsReserved (big.Int) (struct)
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
 
-	{
+				t.Message = string(sval)
+			}
+			// t.StoreID (multistore.StoreID) (uint64)
+		case "StoreID":
 
-		if err := t.FundsReserved.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.FundsReserved: %w", err)
-		}
+			{
 
-	}
-	// t.Ref (storagemarket.DataRef) (struct)
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+					if err != nil {
+						return err
+					}
+					if maj != cbg.MajUnsignedInt {
+						return fmt.Errorf("wrong type for uint64 field")
+					}
+					typed := multistore.StoreID(extra)
+					t.StoreID = &typed
+				}
 
-	{
+			}
+			// t.FundsReserved (big.Int) (struct)
+		case "FundsReserved":
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+			{
+
+				if err := t.FundsReserved.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.FundsReserved: %w", err)
+				}
+
+			}
+			// t.Ref (storagemarket.DataRef) (struct)
+		case "Ref":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Ref = new(DataRef)
+					if err := t.Ref.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Ref pointer: %w", err)
+					}
+				}
+
+			}
+			// t.AvailableForRetrieval (bool) (bool)
+		case "AvailableForRetrieval":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.Ref = new(DataRef)
-			if err := t.Ref.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Ref pointer: %w", err)
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
 			}
+			switch extra {
+			case 20:
+				t.AvailableForRetrieval = false
+			case 21:
+				t.AvailableForRetrieval = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
+			}
+			// t.DealID (abi.DealID) (uint64)
+		case "DealID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.DealID = abi.DealID(extra)
+
+			}
+			// t.CreationTime (typegen.CborTime) (struct)
+		case "CreationTime":
+
+			{
+
+				if err := t.CreationTime.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.CreationTime: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
-	// t.AvailableForRetrieval (bool) (bool)
 
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.AvailableForRetrieval = false
-	case 21:
-		t.AvailableForRetrieval = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
-	// t.DealID (abi.DealID) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.DealID = abi.DealID(extra)
-
-	}
-	// t.CreationTime (typegen.CborTime) (struct)
-
-	{
-
-		if err := t.CreationTime.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.CreationTime: %w", err)
-		}
-
-	}
 	return nil
 }
-
-var lengthBufBalance = []byte{130}
-
 func (t *Balance) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufBalance); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.Locked (big.Int) (struct)
+	if len("Locked") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Locked\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Locked"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Locked")); err != nil {
+		return err
+	}
+
 	if err := t.Locked.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Available (big.Int) (struct)
+	if len("Available") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Available\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Available"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Available")); err != nil {
+		return err
+	}
+
 	if err := t.Available.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -925,52 +1389,96 @@ func (t *Balance) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("Balance: map struct too large (%d)", extra)
 	}
 
-	// t.Locked (big.Int) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.Locked.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Locked: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-	}
-	// t.Available (big.Int) (struct)
+		switch name {
+		// t.Locked (big.Int) (struct)
+		case "Locked":
 
-	{
+			{
 
-		if err := t.Available.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Available: %w", err)
+				if err := t.Locked.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Locked: %w", err)
+				}
+
+			}
+			// t.Available (big.Int) (struct)
+		case "Available":
+
+			{
+
+				if err := t.Available.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Available: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }
-
-var lengthBufSignedStorageAsk = []byte{130}
-
 func (t *SignedStorageAsk) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufSignedStorageAsk); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.Ask (storagemarket.StorageAsk) (struct)
+	if len("Ask") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Ask\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Ask"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Ask")); err != nil {
+		return err
+	}
+
 	if err := t.Ask.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Signature (crypto.Signature) (struct)
+	if len("Signature") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Signature\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Signature"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Signature")); err != nil {
+		return err
+	}
+
 	if err := t.Signature.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -987,96 +1495,180 @@ func (t *SignedStorageAsk) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("SignedStorageAsk: map struct too large (%d)", extra)
 	}
 
-	// t.Ask (storagemarket.StorageAsk) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-			t.Ask = new(StorageAsk)
-			if err := t.Ask.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
-			}
+
+			name = string(sval)
 		}
 
+		switch name {
+		// t.Ask (storagemarket.StorageAsk) (struct)
+		case "Ask":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Ask = new(StorageAsk)
+					if err := t.Ask.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Ask pointer: %w", err)
+					}
+				}
+
+			}
+			// t.Signature (crypto.Signature) (struct)
+		case "Signature":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Signature = new(crypto.Signature)
+					if err := t.Signature.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
+					}
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
+		}
 	}
-	// t.Signature (crypto.Signature) (struct)
 
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-			t.Signature = new(crypto.Signature)
-			if err := t.Signature.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Signature pointer: %w", err)
-			}
-		}
-
-	}
 	return nil
 }
-
-var lengthBufStorageAsk = []byte{136}
-
 func (t *StorageAsk) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufStorageAsk); err != nil {
+	if _, err := w.Write([]byte{168}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.Price (big.Int) (struct)
+	if len("Price") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Price\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Price"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Price")); err != nil {
+		return err
+	}
+
 	if err := t.Price.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.VerifiedPrice (big.Int) (struct)
+	if len("VerifiedPrice") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"VerifiedPrice\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("VerifiedPrice"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("VerifiedPrice")); err != nil {
+		return err
+	}
+
 	if err := t.VerifiedPrice.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.MinPieceSize (abi.PaddedPieceSize) (uint64)
+	if len("MinPieceSize") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MinPieceSize\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MinPieceSize"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MinPieceSize")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MinPieceSize)); err != nil {
 		return err
 	}
 
 	// t.MaxPieceSize (abi.PaddedPieceSize) (uint64)
+	if len("MaxPieceSize") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"MaxPieceSize\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("MaxPieceSize"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("MaxPieceSize")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.MaxPieceSize)); err != nil {
 		return err
 	}
 
 	// t.Miner (address.Address) (struct)
+	if len("Miner") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Miner\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Miner"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Miner")); err != nil {
+		return err
+	}
+
 	if err := t.Miner.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.Timestamp (abi.ChainEpoch) (int64)
+	if len("Timestamp") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Timestamp\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Timestamp"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Timestamp")); err != nil {
+		return err
+	}
+
 	if t.Timestamp >= 0 {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Timestamp)); err != nil {
 			return err
@@ -1088,6 +1680,17 @@ func (t *StorageAsk) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Expiry (abi.ChainEpoch) (int64)
+	if len("Expiry") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Expiry\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Expiry"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Expiry")); err != nil {
+		return err
+	}
+
 	if t.Expiry >= 0 {
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.Expiry)); err != nil {
 			return err
@@ -1099,6 +1702,16 @@ func (t *StorageAsk) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.SeqNo (uint64) (uint64)
+	if len("SeqNo") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"SeqNo\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("SeqNo"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("SeqNo")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.SeqNo)); err != nil {
 		return err
@@ -1117,153 +1730,203 @@ func (t *StorageAsk) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 8 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("StorageAsk: map struct too large (%d)", extra)
 	}
 
-	// t.Price (big.Int) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.Price.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Price: %w", err)
-		}
-
-	}
-	// t.VerifiedPrice (big.Int) (struct)
-
-	{
-
-		if err := t.VerifiedPrice.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.VerifiedPrice: %w", err)
-		}
-
-	}
-	// t.MinPieceSize (abi.PaddedPieceSize) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.MinPieceSize = abi.PaddedPieceSize(extra)
-
-	}
-	// t.MaxPieceSize (abi.PaddedPieceSize) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.MaxPieceSize = abi.PaddedPieceSize(extra)
-
-	}
-	// t.Miner (address.Address) (struct)
-
-	{
-
-		if err := t.Miner.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.Miner: %w", err)
-		}
-
-	}
-	// t.Timestamp (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
 			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
+
+			name = string(sval)
+		}
+
+		switch name {
+		// t.Price (big.Int) (struct)
+		case "Price":
+
+			{
+
+				if err := t.Price.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Price: %w", err)
+				}
+
 			}
-			extraI = -1 - extraI
+			// t.VerifiedPrice (big.Int) (struct)
+		case "VerifiedPrice":
+
+			{
+
+				if err := t.VerifiedPrice.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.VerifiedPrice: %w", err)
+				}
+
+			}
+			// t.MinPieceSize (abi.PaddedPieceSize) (uint64)
+		case "MinPieceSize":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MinPieceSize = abi.PaddedPieceSize(extra)
+
+			}
+			// t.MaxPieceSize (abi.PaddedPieceSize) (uint64)
+		case "MaxPieceSize":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.MaxPieceSize = abi.PaddedPieceSize(extra)
+
+			}
+			// t.Miner (address.Address) (struct)
+		case "Miner":
+
+			{
+
+				if err := t.Miner.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.Miner: %w", err)
+				}
+
+			}
+			// t.Timestamp (abi.ChainEpoch) (int64)
+		case "Timestamp":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Timestamp = abi.ChainEpoch(extraI)
+			}
+			// t.Expiry (abi.ChainEpoch) (int64)
+		case "Expiry":
+			{
+				maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
+				var extraI int64
+				if err != nil {
+					return err
+				}
+				switch maj {
+				case cbg.MajUnsignedInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 positive overflow")
+					}
+				case cbg.MajNegativeInt:
+					extraI = int64(extra)
+					if extraI < 0 {
+						return fmt.Errorf("int64 negative oveflow")
+					}
+					extraI = -1 - extraI
+				default:
+					return fmt.Errorf("wrong type for int64 field: %d", maj)
+				}
+
+				t.Expiry = abi.ChainEpoch(extraI)
+			}
+			// t.SeqNo (uint64) (uint64)
+		case "SeqNo":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.SeqNo = uint64(extra)
+
+			}
+
 		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
-		t.Timestamp = abi.ChainEpoch(extraI)
 	}
-	// t.Expiry (abi.ChainEpoch) (int64)
-	{
-		maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-		var extraI int64
-		if err != nil {
-			return err
-		}
-		switch maj {
-		case cbg.MajUnsignedInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 positive overflow")
-			}
-		case cbg.MajNegativeInt:
-			extraI = int64(extra)
-			if extraI < 0 {
-				return fmt.Errorf("int64 negative oveflow")
-			}
-			extraI = -1 - extraI
-		default:
-			return fmt.Errorf("wrong type for int64 field: %d", maj)
-		}
 
-		t.Expiry = abi.ChainEpoch(extraI)
-	}
-	// t.SeqNo (uint64) (uint64)
-
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.SeqNo = uint64(extra)
-
-	}
 	return nil
 }
-
-var lengthBufStorageDeal = []byte{130}
-
 func (t *StorageDeal) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufStorageDeal); err != nil {
+	if _, err := w.Write([]byte{162}); err != nil {
 		return err
 	}
 
+	scratch := make([]byte, 9)
+
 	// t.DealProposal (market.DealProposal) (struct)
+	if len("DealProposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealProposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealProposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealProposal")); err != nil {
+		return err
+	}
+
 	if err := t.DealProposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.DealState (market.DealState) (struct)
+	if len("DealState") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealState\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealState"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealState")); err != nil {
+		return err
+	}
+
 	if err := t.DealState.MarshalCBOR(w); err != nil {
 		return err
 	}
@@ -1280,49 +1943,80 @@ func (t *StorageDeal) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("StorageDeal: map struct too large (%d)", extra)
 	}
 
-	// t.DealProposal (market.DealProposal) (struct)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
+				return err
+			}
+
+			name = string(sval)
 		}
 
-	}
-	// t.DealState (market.DealState) (struct)
+		switch name {
+		// t.DealProposal (market.DealProposal) (struct)
+		case "DealProposal":
 
-	{
+			{
 
-		if err := t.DealState.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealState: %w", err)
+				if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
+				}
+
+			}
+			// t.DealState (market.DealState) (struct)
+		case "DealState":
+
+			{
+
+				if err := t.DealState.UnmarshalCBOR(br); err != nil {
+					return xerrors.Errorf("unmarshaling t.DealState: %w", err)
+				}
+
+			}
+
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
+
 	return nil
 }
-
-var lengthBufDataRef = []byte{132}
-
 func (t *DataRef) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufDataRef); err != nil {
+	if _, err := w.Write([]byte{164}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.TransferType (string) (string)
+	if len("TransferType") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"TransferType\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("TransferType"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("TransferType")); err != nil {
+		return err
+	}
+
 	if len(t.TransferType) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.TransferType was too long")
 	}
@@ -1335,12 +2029,32 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Root (cid.Cid) (struct)
+	if len("Root") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Root\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Root"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Root")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteCidBuf(scratch, w, t.Root); err != nil {
 		return xerrors.Errorf("failed to write cid field t.Root: %w", err)
 	}
 
 	// t.PieceCid (cid.Cid) (struct)
+	if len("PieceCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceCid")); err != nil {
+		return err
+	}
 
 	if t.PieceCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -1353,6 +2067,16 @@ func (t *DataRef) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
+	if len("PieceSize") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PieceSize\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PieceSize"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PieceSize")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.PieceSize)); err != nil {
 		return err
@@ -1371,95 +2095,138 @@ func (t *DataRef) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 4 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("DataRef: map struct too large (%d)", extra)
 	}
 
-	// t.TransferType (string) (string)
+	var name string
+	n := extra
 
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
+	for i := uint64(0); i < n; i++ {
 
-		t.TransferType = string(sval)
-	}
-	// t.Root (cid.Cid) (struct)
-
-	{
-
-		c, err := cbg.ReadCid(br)
-		if err != nil {
-			return xerrors.Errorf("failed to read cid field t.Root: %w", err)
-		}
-
-		t.Root = c
-
-	}
-	// t.PieceCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
+			if err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PieceCid: %w", err)
+			name = string(sval)
+		}
+
+		switch name {
+		// t.TransferType (string) (string)
+		case "TransferType":
+
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+
+				t.TransferType = string(sval)
+			}
+			// t.Root (cid.Cid) (struct)
+		case "Root":
+
+			{
+
+				c, err := cbg.ReadCid(br)
+				if err != nil {
+					return xerrors.Errorf("failed to read cid field t.Root: %w", err)
+				}
+
+				t.Root = c
+
+			}
+			// t.PieceCid (cid.Cid) (struct)
+		case "PieceCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PieceCid: %w", err)
+					}
+
+					t.PieceCid = &c
+				}
+
+			}
+			// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
+		case "PieceSize":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.PieceSize = abi.UnpaddedPieceSize(extra)
+
 			}
 
-			t.PieceCid = &c
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
-	// t.PieceSize (abi.UnpaddedPieceSize) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.PieceSize = abi.UnpaddedPieceSize(extra)
-
-	}
 	return nil
 }
-
-var lengthBufProviderDealState = []byte{136}
-
 func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	if t == nil {
 		_, err := w.Write(cbg.CborNull)
 		return err
 	}
-	if _, err := w.Write(lengthBufProviderDealState); err != nil {
+	if _, err := w.Write([]byte{168}); err != nil {
 		return err
 	}
 
 	scratch := make([]byte, 9)
 
 	// t.State (uint64) (uint64)
+	if len("State") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"State\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("State"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("State")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.State)); err != nil {
 		return err
 	}
 
 	// t.Message (string) (string)
+	if len("Message") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Message\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Message"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Message")); err != nil {
+		return err
+	}
+
 	if len(t.Message) > cbg.MaxLength {
 		return xerrors.Errorf("Value in field t.Message was too long")
 	}
@@ -1472,11 +2239,32 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.Proposal (market.DealProposal) (struct)
+	if len("Proposal") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"Proposal\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("Proposal"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("Proposal")); err != nil {
+		return err
+	}
+
 	if err := t.Proposal.MarshalCBOR(w); err != nil {
 		return err
 	}
 
 	// t.ProposalCid (cid.Cid) (struct)
+	if len("ProposalCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"ProposalCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("ProposalCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("ProposalCid")); err != nil {
+		return err
+	}
 
 	if t.ProposalCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -1489,6 +2277,16 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.AddFundsCid (cid.Cid) (struct)
+	if len("AddFundsCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"AddFundsCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("AddFundsCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("AddFundsCid")); err != nil {
+		return err
+	}
 
 	if t.AddFundsCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -1501,6 +2299,16 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.PublishCid (cid.Cid) (struct)
+	if len("PublishCid") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"PublishCid\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("PublishCid"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("PublishCid")); err != nil {
+		return err
+	}
 
 	if t.PublishCid == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -1513,12 +2321,33 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 	}
 
 	// t.DealID (abi.DealID) (uint64)
+	if len("DealID") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"DealID\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("DealID"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("DealID")); err != nil {
+		return err
+	}
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.DealID)); err != nil {
 		return err
 	}
 
 	// t.FastRetrieval (bool) (bool)
+	if len("FastRetrieval") > cbg.MaxLength {
+		return xerrors.Errorf("Value in field \"FastRetrieval\" was too long")
+	}
+
+	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("FastRetrieval"))); err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, string("FastRetrieval")); err != nil {
+		return err
+	}
+
 	if err := cbg.WriteBool(w, t.FastRetrieval); err != nil {
 		return err
 	}
@@ -1535,153 +2364,182 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
+	if maj != cbg.MajMap {
+		return fmt.Errorf("cbor input should be of type map")
 	}
 
-	if extra != 8 {
-		return fmt.Errorf("cbor input had wrong number of fields")
+	if extra > cbg.MaxLength {
+		return fmt.Errorf("ProviderDealState: map struct too large (%d)", extra)
 	}
 
-	// t.State (uint64) (uint64)
+	var name string
+	n := extra
 
-	{
+	for i := uint64(0); i < n; i++ {
 
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.State = uint64(extra)
-
-	}
-	// t.Message (string) (string)
-
-	{
-		sval, err := cbg.ReadStringBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		t.Message = string(sval)
-	}
-	// t.Proposal (market.DealProposal) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-			t.Proposal = new(market.DealProposal)
-			if err := t.Proposal.UnmarshalCBOR(br); err != nil {
-				return xerrors.Errorf("unmarshaling t.Proposal pointer: %w", err)
-			}
-		}
-
-	}
-	// t.ProposalCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
-				return err
-			}
-
-			c, err := cbg.ReadCid(br)
+		{
+			sval, err := cbg.ReadStringBuf(br, scratch)
 			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
-			}
-
-			t.ProposalCid = &c
-		}
-
-	}
-	// t.AddFundsCid (cid.Cid) (struct)
-
-	{
-
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
 				return err
 			}
 
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
+			name = string(sval)
+		}
+
+		switch name {
+		// t.State (uint64) (uint64)
+		case "State":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.State = uint64(extra)
+
 			}
+			// t.Message (string) (string)
+		case "Message":
 
-			t.AddFundsCid = &c
-		}
+			{
+				sval, err := cbg.ReadStringBuf(br, scratch)
+				if err != nil {
+					return err
+				}
 
-	}
-	// t.PublishCid (cid.Cid) (struct)
+				t.Message = string(sval)
+			}
+			// t.Proposal (market.DealProposal) (struct)
+		case "Proposal":
 
-	{
+			{
 
-		b, err := br.ReadByte()
-		if err != nil {
-			return err
-		}
-		if b != cbg.CborNull[0] {
-			if err := br.UnreadByte(); err != nil {
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+					t.Proposal = new(market.DealProposal)
+					if err := t.Proposal.UnmarshalCBOR(br); err != nil {
+						return xerrors.Errorf("unmarshaling t.Proposal pointer: %w", err)
+					}
+				}
+
+			}
+			// t.ProposalCid (cid.Cid) (struct)
+		case "ProposalCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.ProposalCid: %w", err)
+					}
+
+					t.ProposalCid = &c
+				}
+
+			}
+			// t.AddFundsCid (cid.Cid) (struct)
+		case "AddFundsCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.AddFundsCid: %w", err)
+					}
+
+					t.AddFundsCid = &c
+				}
+
+			}
+			// t.PublishCid (cid.Cid) (struct)
+		case "PublishCid":
+
+			{
+
+				b, err := br.ReadByte()
+				if err != nil {
+					return err
+				}
+				if b != cbg.CborNull[0] {
+					if err := br.UnreadByte(); err != nil {
+						return err
+					}
+
+					c, err := cbg.ReadCid(br)
+					if err != nil {
+						return xerrors.Errorf("failed to read cid field t.PublishCid: %w", err)
+					}
+
+					t.PublishCid = &c
+				}
+
+			}
+			// t.DealID (abi.DealID) (uint64)
+		case "DealID":
+
+			{
+
+				maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+				if err != nil {
+					return err
+				}
+				if maj != cbg.MajUnsignedInt {
+					return fmt.Errorf("wrong type for uint64 field")
+				}
+				t.DealID = abi.DealID(extra)
+
+			}
+			// t.FastRetrieval (bool) (bool)
+		case "FastRetrieval":
+
+			maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
+			if err != nil {
 				return err
 			}
-
-			c, err := cbg.ReadCid(br)
-			if err != nil {
-				return xerrors.Errorf("failed to read cid field t.PublishCid: %w", err)
+			if maj != cbg.MajOther {
+				return fmt.Errorf("booleans must be major type 7")
+			}
+			switch extra {
+			case 20:
+				t.FastRetrieval = false
+			case 21:
+				t.FastRetrieval = true
+			default:
+				return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 			}
 
-			t.PublishCid = &c
+		default:
+			return fmt.Errorf("unknown struct field %d: '%s'", i, name)
 		}
-
 	}
-	// t.DealID (abi.DealID) (uint64)
 
-	{
-
-		maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-		if maj != cbg.MajUnsignedInt {
-			return fmt.Errorf("wrong type for uint64 field")
-		}
-		t.DealID = abi.DealID(extra)
-
-	}
-	// t.FastRetrieval (bool) (bool)
-
-	maj, extra, err = cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajOther {
-		return fmt.Errorf("booleans must be major type 7")
-	}
-	switch extra {
-	case 20:
-		t.FastRetrieval = false
-	case 21:
-		t.FastRetrieval = true
-	default:
-		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
-	}
 	return nil
 }


### PR DESCRIPTION
Since we're already making one format breaking change, i figured we could make another one, to prevent the previous breaking change from being a breaking change in the future. If we use map encodings (like we do in the storage-fsm) then adding a new field doesnt break everything else.