### PR TITLE
Persist cids recieved from the data transfer channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,5 @@ require (
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
+
+replace github.com/filecoin-project/go-data-transfer => /Users/aarshshah/go/src/github.com/filecoin-project/go-data-transfer

--- a/go.mod
+++ b/go.mod
@@ -46,4 +46,4 @@ require (
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi
 
-replace github.com/filecoin-project/go-data-transfer => /Users/aarshshah/go/src/github.com/filecoin-project/go-data-transfer
+replace github.com/filecoin-project/go-data-transfer => github.com/filecoin-project/go-data-transfer v0.6.4-0.20200902104812-5681a611ffad

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:a
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
+github.com/filecoin-project/go-data-transfer v0.6.4-0.20200902104812-5681a611ffad h1:4bxv1bFRIiEhmhH7djOTWIpNla3zb9WDflRi2udezN0=
+github.com/filecoin-project/go-data-transfer v0.6.4-0.20200902104812-5681a611ffad/go.mod h1:PmBKVXkhh67/tnEdJXQwDHl5mT+7Tbcwe1NPninqhnM=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1:GxJzR3oRIMTPtpZ0b7QF8FKPK6/iPAc7trhlL5k/g+s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2 h1:a
 github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2/go.mod h1:pqTiPHobNkOVM5thSRsHYjyQfq7O5QSCMhvuu9JoDlg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
-github.com/filecoin-project/go-data-transfer v0.6.3 h1:7TLwm8nuodHYD/uiwJjKc/PGRR+LwqM8jmlZqgWuUfY=
-github.com/filecoin-project/go-data-transfer v0.6.3/go.mod h1:PmBKVXkhh67/tnEdJXQwDHl5mT+7Tbcwe1NPninqhnM=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1:GxJzR3oRIMTPtpZ0b7QF8FKPK6/iPAc7trhlL5k/g+s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
 github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=

--- a/retrievalmarket/impl/dtutils/dtutils.go
+++ b/retrievalmarket/impl/dtutils/dtutils.go
@@ -86,7 +86,7 @@ const noEvent = rm.ClientEvent(math.MaxUint64)
 
 func clientEvent(event datatransfer.Event, channelState datatransfer.ChannelState) (rm.ClientEvent, []interface{}) {
 	switch event.Code {
-	case datatransfer.Progress:
+	case datatransfer.DataReceived:
 		return rm.ClientEventBlocksReceived, []interface{}{channelState.Received()}
 	case datatransfer.FinishTransfer:
 		return rm.ClientEventAllBlocksReceived, nil

--- a/retrievalmarket/impl/dtutils/dtutils_test.go
+++ b/retrievalmarket/impl/dtutils/dtutils_test.go
@@ -109,7 +109,7 @@ func TestClientDataTransferSubscriber(t *testing.T) {
 			ignored: true,
 		},
 		"progress": {
-			code: datatransfer.Progress,
+			code: datatransfer.DataReceived,
 			state: shared_testutil.TestChannelParams{
 				Vouchers: []datatransfer.Voucher{&dealProposal},
 				Status:   datatransfer.Ongoing,

--- a/shared_testutil/testchannel.go
+++ b/shared_testutil/testchannel.go
@@ -26,6 +26,7 @@ type TestChannelParams struct {
 	Status         datatransfer.Status
 	Vouchers       []datatransfer.Voucher
 	VoucherResults []datatransfer.VoucherResult
+	ReceivedCids   []cid.Cid
 }
 
 // TestChannel implements a datatransfer channel with set values
@@ -43,6 +44,7 @@ type TestChannel struct {
 	status         datatransfer.Status
 	vouchers       []datatransfer.Voucher
 	voucherResults []datatransfer.VoucherResult
+	receivedCids   []cid.Cid
 }
 
 // FakeDTType is a fake voucher type
@@ -68,6 +70,7 @@ func NewTestChannel(params TestChannelParams) datatransfer.ChannelState {
 		received:       rand.Uint64(),
 		vouchers:       []datatransfer.Voucher{FakeDTType{}},
 		voucherResults: []datatransfer.VoucherResult{FakeDTType{}},
+		receivedCids:   nil,
 	}
 	if params.TransferID != 0 {
 		tc.transferID = params.TransferID
@@ -102,6 +105,10 @@ func NewTestChannel(params TestChannelParams) datatransfer.ChannelState {
 	if params.Received != 0 {
 		tc.received = params.Received
 	}
+	if params.ReceivedCids != nil {
+		tc.receivedCids = params.ReceivedCids
+	}
+
 	return tc
 }
 
@@ -134,6 +141,11 @@ func (tc *TestChannel) Sender() peer.ID {
 // Recipient returns the peer id for the node that is receiving data
 func (tc *TestChannel) Recipient() peer.ID {
 	return tc.recipient
+}
+
+// ReceivedCids returns the cids received on the channel
+func (tc *TestChannel) ReceivedCids() []cid.Cid {
+	return tc.receivedCids
 }
 
 // TotalSize returns the total size for the data being transferred

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -44,6 +44,8 @@ type StoredAsk interface {
 
 // Provider is the production implementation of the StorageProvider interface
 type Provider struct {
+	ds datastore.Batching
+
 	net network.StorageMarketNetwork
 
 	proofType abi.RegisteredSealProof
@@ -112,6 +114,7 @@ func NewProvider(net network.StorageMarketNetwork,
 	pio := pieceio.NewPieceIOWithStore(carIO, fs, nil, multiStore)
 
 	h := &Provider{
+		ds:           ds,
 		net:          net,
 		proofType:    rt,
 		spn:          spn,
@@ -141,7 +144,7 @@ func NewProvider(net network.StorageMarketNetwork,
 	h.Configure(options...)
 
 	// register a data transfer event handler -- this will send events to the state machines based on DT events
-	h.unsubDataTransfer = dataTransfer.SubscribeToEvents(dtutils.ProviderDataTransferSubscriber(deals))
+	h.unsubDataTransfer = dataTransfer.SubscribeToEvents(dtutils.ProviderDataTransferSubscriber(ds, deals))
 
 	err = dataTransfer.RegisterVoucherType(&requestvalidation.StorageDataTransferVoucher{}, requestvalidation.NewUnifiedRequestValidator(&providerPushDeals{h}, nil))
 	if err != nil {

--- a/storagemarket/impl/provider_environments.go
+++ b/storagemarket/impl/provider_environments.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
@@ -35,6 +36,10 @@ func (p *providerDealEnvironment) Address() address.Address {
 
 func (p *providerDealEnvironment) Node() storagemarket.StorageProviderNode {
 	return p.p.spn
+}
+
+func (p *providerDealEnvironment) DataStore() datastore.Batching {
+	return p.p.ds
 }
 
 func (p *providerDealEnvironment) Ask() storagemarket.StorageAsk {

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
@@ -1119,7 +1120,9 @@ func makeExecutor(ctx context.Context,
 		if params.TagsProposal {
 			expectedTags[dealState.ProposalCid.String()] = struct{}{}
 		}
+
 		environment := &fakeEnvironment{
+			ds:                      datastore.NewMapDatastore(),
 			expectedTags:            expectedTags,
 			receivedTags:            make(map[string]struct{}),
 			address:                 params.Address,
@@ -1170,6 +1173,7 @@ func makeExecutor(ctx context.Context,
 }
 
 type fakeEnvironment struct {
+	ds                      datastore.Batching
 	address                 address.Address
 	node                    *testnodes.FakeProviderNode
 	ask                     storagemarket.StorageAsk
@@ -1191,6 +1195,10 @@ type fakeEnvironment struct {
 	receivedTags            map[string]struct{}
 	dealFunds               *tut.TestDealFunds
 	peerTagger              *tut.TestPeerTagger
+}
+
+func (fe *fakeEnvironment) DataStore() datastore.Batching {
+	return fe.ds
 }
 
 func (fe *fakeEnvironment) Address() address.Address {


### PR DESCRIPTION
For filecoin-project/lotus#3417.

@hannahhoward This is step 1 which persists and cleans-up the received cids in the provider.

This PR is against a long running feature branch.

Depends on https://github.com/filecoin-project/go-data-transfer/pull/71.