### PR TITLE
Fix test hang

### DIFF
--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -185,6 +185,7 @@ func TestMakeDealOffline(t *testing.T) {
 	defer cancel()
 	h := newHarness(t, ctx, true)
 	require.NoError(t, h.Client.Start(ctx))
+	require.NoError(t, h.Provider.Start(ctx))
 
 	carBuf := new(bytes.Buffer)
 


### PR DESCRIPTION
TestMakeDealOffline was hanging due to provider not starting