### PR TITLE
Convert label JSON to CBOR

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	github.com/libp2p/go-libp2p v0.10.0
 	github.com/libp2p/go-libp2p-core v0.6.0
 	github.com/multiformats/go-multiaddr v0.2.2
-	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200814224545-656e08ce49ee
 	golang.org/x/exp v0.0.0-20190121172915-509febef88a4

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/libp2p/go-libp2p v0.10.0
 	github.com/libp2p/go-libp2p-core v0.6.0
 	github.com/multiformats/go-multiaddr v0.2.2
+	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200814224545-656e08ce49ee
 	golang.org/x/exp v0.0.0-20190121172915-509febef88a4

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/polydawn/refmt/json"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -78,7 +79,10 @@ func LabelField(payloadCID cid.Cid) ([]byte, error) {
 		})
 	})
 	buf := new(bytes.Buffer)
-	err := dagjson.Encoder(nd, buf)
+	err := dagjson.Marshal(nd, json.NewEncoder(buf, json.EncodeOptions{
+		Line:   []byte{},
+		Indent: []byte{},
+	}))
 	if err != nil {
 		return nil, err
 	}

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -6,11 +6,10 @@ import (
 	"context"
 
 	"github.com/ipfs/go-cid"
-	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/polydawn/refmt/json"
 	"golang.org/x/xerrors"
 
 	"github.com/filecoin-project/go-address"
@@ -79,10 +78,7 @@ func LabelField(payloadCID cid.Cid) ([]byte, error) {
 		})
 	})
 	buf := new(bytes.Buffer)
-	err := dagjson.Marshal(nd, json.NewEncoder(buf, json.EncodeOptions{
-		Line:   []byte{},
-		Indent: []byte{},
-	}))
+	err := dagcbor.Encoder(nd, buf)
 	if err != nil {
 		return nil, err
 	}

--- a/storagemarket/impl/clientutils/clientutils_test.go
+++ b/storagemarket/impl/clientutils/clientutils_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/stretchr/testify/require"
@@ -151,13 +151,10 @@ func (t *testPieceIO) ReadPiece(storeID *multistore.StoreID, r io.Reader) (cid.C
 
 func TestLabelField(t *testing.T) {
 	payloadCID := shared_testutil.GenerateCids(1)[0]
-
-	expectedString := fmt.Sprintf("{\"pcids\": [{\"/\": \"%s\"}]}", payloadCID.String())
 	label, err := clientutils.LabelField(payloadCID)
-	require.Equal(t, expectedString, string(label))
 	require.NoError(t, err)
 	nb := basicnode.Style.Any.NewBuilder()
-	err = dagjson.Decoder(nb, bytes.NewReader(label))
+	err = dagcbor.Decoder(nb, bytes.NewReader(label))
 	require.NoError(t, err)
 	nd := nb.Build()
 	pcidsNd, err := nd.LookupString("pcids")

--- a/storagemarket/impl/clientutils/clientutils_test.go
+++ b/storagemarket/impl/clientutils/clientutils_test.go
@@ -152,7 +152,9 @@ func (t *testPieceIO) ReadPiece(storeID *multistore.StoreID, r io.Reader) (cid.C
 func TestLabelField(t *testing.T) {
 	payloadCID := shared_testutil.GenerateCids(1)[0]
 
+	expectedString := fmt.Sprintf("{\"pcids\": [{\"/\": \"%s\"}]}", payloadCID.String())
 	label, err := clientutils.LabelField(payloadCID)
+	require.Equal(t, expectedString, string(label))
 	require.NoError(t, err)
 	nb := basicnode.Style.Any.NewBuilder()
 	err = dagjson.Decoder(nb, bytes.NewReader(label))


### PR DESCRIPTION
# Goals

Shorten the label field by using CBOR

# Implementation

Use CBOR instead of json (previously was using different options with JSON encoder to avoid whitespace)