### PR TITLE
Encode cid directly in label field rather than try to use structured data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/libp2p/go-libp2p v0.10.0
 	github.com/libp2p/go-libp2p-core v0.6.0
 	github.com/multiformats/go-multiaddr v0.2.2
+	github.com/multiformats/go-multibase v0.0.3
 	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200814224545-656e08ce49ee

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -359,7 +359,7 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, params storagemarket.Pr
 		PieceSize:            pieceSize.Padded(),
 		Client:               params.Addr,
 		Provider:             params.Info.Address,
-		Label:                string(label),
+		Label:                label,
 		StartEpoch:           params.StartEpoch,
 		EndEpoch:             params.EndEpoch,
 		StoragePricePerEpoch: params.Price,

--- a/storagemarket/impl/clientutils/clientutils_test.go
+++ b/storagemarket/impl/clientutils/clientutils_test.go
@@ -1,7 +1,6 @@
 package clientutils_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -11,9 +10,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/codec/dagcbor"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-address"
@@ -153,16 +149,7 @@ func TestLabelField(t *testing.T) {
 	payloadCID := shared_testutil.GenerateCids(1)[0]
 	label, err := clientutils.LabelField(payloadCID)
 	require.NoError(t, err)
-	nb := basicnode.Style.Any.NewBuilder()
-	err = dagcbor.Decoder(nb, bytes.NewReader(label))
+	resultCid, err := cid.Decode(label)
 	require.NoError(t, err)
-	nd := nb.Build()
-	pcidsNd, err := nd.LookupString("pcids")
-	require.NoError(t, err)
-	linkNd, err := pcidsNd.LookupIndex(0)
-	require.NoError(t, err)
-	link, err := linkNd.AsLink()
-	require.NoError(t, err)
-	resultCid := link.(cidlink.Link).Cid
 	require.True(t, payloadCID.Equals(resultCid))
 }


### PR DESCRIPTION
# Goals

Because of issues with encoding the CID in a CBOR struct inside a string field for label, but also not wanting to pad things out with JSON, we're switching to encoding the CID directly as Multibase string.

# Implementation

- Write label field as a multibase string 
   - Use base58 for Cid V0 (only one supported)
   - Use base64 for Cid V1 (base32 is default but we're trying to keep things more compact)