### PR TITLE
Test Restart for ClientEventDealPublished AND ClientEventDealActivated

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -489,7 +489,7 @@ func (p *Provider) HandleDealStatusStream(s network.DealStatusStream) {
 	}
 
 	if err := s.WriteDealStatusResponse(response); err != nil {
-		log.Errorf("failed to write deal status response: %s", err)
+		log.Warnf("failed to write deal status response: %s", err)
 		return
 	}
 }

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/stretchr/testify/require"
@@ -116,6 +117,14 @@ type FakeCommonNode struct {
 	WaitForMessageRetBytes  []byte
 	WaitForMessageNodeError error
 	WaitForMessageCalls     []cid.Cid
+
+	DelayFakeCommonNode DelayFakeCommonNode
+}
+
+// DelayFakeCommonNode allows configuring delay in the FakeCommonNode functions
+type DelayFakeCommonNode struct {
+	OnDealSectorCommitted  bool
+	OnDealExpiredOrSlashed bool
 }
 
 // GetChainHead returns the state id in the storage market state
@@ -189,6 +198,9 @@ func (n *FakeCommonNode) DealProviderCollateralBounds(ctx context.Context, size 
 
 // OnDealSectorCommitted returns immediately, and returns stubbed errors
 func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, cb storagemarket.DealSectorCommittedCallback) error {
+	if n.DelayFakeCommonNode.OnDealSectorCommitted {
+		time.Sleep(500 * time.Millisecond)
+	}
 	if n.DealCommittedSyncError == nil {
 		cb(n.DealCommittedAsyncError)
 	}
@@ -197,6 +209,10 @@ func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider add
 
 // OnDealExpiredOrSlashed simulates waiting for a deal to be expired or slashed, but provides stubbed behavior
 func (n *FakeCommonNode) OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired storagemarket.DealExpiredCallback, onDealSlashed storagemarket.DealSlashedCallback) error {
+	if n.DelayFakeCommonNode.OnDealExpiredOrSlashed {
+		time.Sleep(500 * time.Millisecond)
+	}
+
 	if n.WaitForDealCompletionError != nil {
 		return n.WaitForDealCompletionError
 	}


### PR DESCRIPTION
Closes https://github.com/filecoin-project/lotus/issues/3443.

Also, downgrades stream reset log in `HandleDealStatusStream` to `WARN` instead of `ERROR`.