### PR TITLE
Store final/actual cid for publish message

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -433,7 +433,7 @@ func (c *Client) AddPaymentEscrow(ctx context.Context, addr address.Address, amo
 		return err
 	}
 
-	err = c.node.WaitForMessage(ctx, mcid, func(code exitcode.ExitCode, bytes []byte, err error) error {
+	err = c.node.WaitForMessage(ctx, mcid, func(code exitcode.ExitCode, bytes []byte, finalCid cid.Cid, err error) error {
 		if err != nil {
 			done <- xerrors.Errorf("AddFunds errored: %w", err)
 		} else if code != exitcode.Ok {

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -79,7 +79,7 @@ func EnsureClientFunds(ctx fsm.Context, environment ClientDealEnvironment, deal 
 func WaitForFunding(ctx fsm.Context, environment ClientDealEnvironment, deal storagemarket.ClientDeal) error {
 	node := environment.Node()
 
-	return node.WaitForMessage(ctx.Context(), *deal.AddFundsCid, func(code exitcode.ExitCode, bytes []byte, err error) error {
+	return node.WaitForMessage(ctx.Context(), *deal.AddFundsCid, func(code exitcode.ExitCode, bytes []byte, finalCid cid.Cid, err error) error {
 		if err != nil {
 			return ctx.Trigger(storagemarket.ClientEventEnsureFundsFailed, xerrors.Errorf("AddFunds err: %w", err))
 		}

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -335,7 +335,7 @@ func (p *Provider) AddStorageCollateral(ctx context.Context, amount abi.TokenAmo
 		return err
 	}
 
-	err = p.spn.WaitForMessage(ctx, mcid, func(code exitcode.ExitCode, bytes []byte, err error) error {
+	err = p.spn.WaitForMessage(ctx, mcid, func(code exitcode.ExitCode, bytes []byte, finalCid cid.Cid, err error) error {
 		if err != nil {
 			done <- xerrors.Errorf("AddFunds errored: %w", err)
 		} else if code != exitcode.Ok {

--- a/storagemarket/impl/providerstates/provider_fsm.go
+++ b/storagemarket/impl/providerstates/provider_fsm.go
@@ -65,8 +65,8 @@ var ProviderEvents = fsm.Events{
 		FromMany(storagemarket.StorageDealProviderFunding, storagemarket.StorageDealEnsureProviderFunds).To(storagemarket.StorageDealPublish),
 	fsm.Event(storagemarket.ProviderEventDealPublishInitiated).
 		From(storagemarket.StorageDealPublish).To(storagemarket.StorageDealPublishing).
-		Action(func(deal *storagemarket.MinerDeal, publishCid cid.Cid) error {
-			deal.PublishCid = &publishCid
+		Action(func(deal *storagemarket.MinerDeal, finalCid cid.Cid) error {
+			deal.PublishCid = &finalCid
 			return nil
 		}),
 	fsm.Event(storagemarket.ProviderEventDealPublishError).
@@ -83,8 +83,9 @@ var ProviderEvents = fsm.Events{
 		}),
 	fsm.Event(storagemarket.ProviderEventDealPublished).
 		From(storagemarket.StorageDealPublishing).To(storagemarket.StorageDealStaged).
-		Action(func(deal *storagemarket.MinerDeal, dealID abi.DealID) error {
+		Action(func(deal *storagemarket.MinerDeal, dealID abi.DealID, finalCid cid.Cid) error {
 			deal.DealID = dealID
+			deal.PublishCid = &finalCid
 			return nil
 		}),
 	fsm.Event(storagemarket.ProviderEventFileStoreErrored).

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -222,7 +222,7 @@ func EnsureProviderFunds(ctx fsm.Context, environment ProviderDealEnvironment, d
 func WaitForFunding(ctx fsm.Context, environment ProviderDealEnvironment, deal storagemarket.MinerDeal) error {
 	node := environment.Node()
 
-	return node.WaitForMessage(ctx.Context(), *deal.AddFundsCid, func(code exitcode.ExitCode, bytes []byte, err error) error {
+	return node.WaitForMessage(ctx.Context(), *deal.AddFundsCid, func(code exitcode.ExitCode, bytes []byte, finalCid cid.Cid, err error) error {
 		if err != nil {
 			return ctx.Trigger(storagemarket.ProviderEventNodeErrored, xerrors.Errorf("AddFunds errored: %w", err))
 		}
@@ -253,7 +253,7 @@ func PublishDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 
 // WaitForPublish waits for the publish message on chain and sends the deal id back to the client
 func WaitForPublish(ctx fsm.Context, environment ProviderDealEnvironment, deal storagemarket.MinerDeal) error {
-	return environment.Node().WaitForMessage(ctx.Context(), *deal.PublishCid, func(code exitcode.ExitCode, retBytes []byte, err error) error {
+	return environment.Node().WaitForMessage(ctx.Context(), *deal.PublishCid, func(code exitcode.ExitCode, retBytes []byte, finalCid cid.Cid, err error) error {
 		if err != nil {
 			return ctx.Trigger(storagemarket.ProviderEventDealPublishError, xerrors.Errorf("PublishStorageDeals errored: %w", err))
 		}
@@ -275,7 +275,7 @@ func WaitForPublish(ctx fsm.Context, environment ProviderDealEnvironment, deal s
 			_ = ctx.Trigger(storagemarket.ProviderEventFundsReleased, deal.FundsReserved)
 		}
 
-		return ctx.Trigger(storagemarket.ProviderEventDealPublished, retval.IDs[0])
+		return ctx.Trigger(storagemarket.ProviderEventDealPublished, retval.IDs[0], finalCid)
 	})
 }
 

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -46,7 +46,7 @@ type StorageCommon interface {
 	VerifySignature(ctx context.Context, signature crypto.Signature, signer address.Address, plaintext []byte, tok shared.TipSetToken) (bool, error)
 
 	// WaitForMessage waits until a message appears on chain. If it is already on chain, the callback is called immediately
-	WaitForMessage(ctx context.Context, mcid cid.Cid, onCompletion func(exitcode.ExitCode, []byte, error) error) error
+	WaitForMessage(ctx context.Context, mcid cid.Cid, onCompletion func(exitcode.ExitCode, []byte, cid.Cid, error) error) error
 
 	// SignsBytes signs the given data with the given address's private key
 	SignBytes(ctx context.Context, signer address.Address, b []byte) (*crypto.Signature, error)

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -114,6 +114,7 @@ type FakeCommonNode struct {
 	WaitForMessageError     error
 	WaitForMessageExitCode  exitcode.ExitCode
 	WaitForMessageRetBytes  []byte
+	WaitForMessageFinalCid  cid.Cid
 	WaitForMessageNodeError error
 	WaitForMessageCalls     []cid.Cid
 }
@@ -147,7 +148,7 @@ func (n *FakeCommonNode) EnsureFunds(ctx context.Context, addr, wallet address.A
 }
 
 // WaitForMessage simulates waiting for a message to appear on chain
-func (n *FakeCommonNode) WaitForMessage(ctx context.Context, mcid cid.Cid, onCompletion func(exitcode.ExitCode, []byte, error) error) error {
+func (n *FakeCommonNode) WaitForMessage(ctx context.Context, mcid cid.Cid, onCompletion func(exitcode.ExitCode, []byte, cid.Cid, error) error) error {
 	n.WaitForMessageCalls = append(n.WaitForMessageCalls, mcid)
 
 	if n.WaitForMessageError != nil {
@@ -159,7 +160,12 @@ func (n *FakeCommonNode) WaitForMessage(ctx context.Context, mcid cid.Cid, onCom
 		return nil
 	}
 
-	return onCompletion(n.WaitForMessageExitCode, n.WaitForMessageRetBytes, n.WaitForMessageNodeError)
+	finalCid := n.WaitForMessageFinalCid
+	if finalCid.Equals(cid.Undef) {
+		finalCid = mcid
+	}
+
+	return onCompletion(n.WaitForMessageExitCode, n.WaitForMessageRetBytes, finalCid, n.WaitForMessageNodeError)
 }
 
 // GetBalance returns the funds in the storage market state


### PR DESCRIPTION
## Problem
The cid of a message can change when published to the chain because of gas fee changes.  Since the Provider passes a cid back to the client when queried for deal status, it could send the incorrect cid back to the client, causing the client to fail to verify the published deal.

## Solution
Store the actual/final cid in the `MinerDeal`

### Notes
This is the market-side fix for https://github.com/filecoin-project/lotus/issues/3703