### PR TITLE
Configurable Retry Parameters (to speedup tests)

### DIFF
--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -88,7 +88,7 @@ func requireSetupTestClientAndProvider(bgCtx context.Context, t *testing.T, payC
 	retrievalmarket.RetrievalPeer,
 	retrievalmarket.RetrievalProvider) {
 	testData := tut.NewLibp2pTestData(bgCtx, t)
-	nw1 := rmnet.NewFromLibp2pHost(testData.Host1)
+	nw1 := rmnet.NewFromLibp2pHost(testData.Host1, rmnet.RetryParameters(100*time.Millisecond, 1*time.Second, 5))
 	cids := tut.GenerateCids(2)
 	rcNode1 := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{
 		PayCh:          payChAddr,
@@ -102,7 +102,7 @@ func requireSetupTestClientAndProvider(bgCtx context.Context, t *testing.T, payC
 	require.NoError(t, err)
 	client, err := retrievalimpl.NewClient(nw1, testData.MultiStore1, dt1, rcNode1, &tut.TestPeerResolver{}, testData.Ds1, testData.RetrievalStoredCounter1)
 	require.NoError(t, err)
-	nw2 := rmnet.NewFromLibp2pHost(testData.Host2)
+	nw2 := rmnet.NewFromLibp2pHost(testData.Host2, rmnet.RetryParameters(0, 0, 0))
 	providerNode := testnodes.NewTestRetrievalProviderNode()
 	pieceStore := tut.NewTestPieceStore()
 	expectedCIDs := tut.GenerateCids(3)
@@ -386,7 +386,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			}
 
 			// ------- SET UP CLIENT
-			nw1 := rmnet.NewFromLibp2pHost(testData.Host1)
+			nw1 := rmnet.NewFromLibp2pHost(testData.Host1, rmnet.RetryParameters(0, 0, 0))
 			createdChan, newLaneAddr, createdVoucher, clientNode, client, err := setupClient(bgCtx, t, clientPaymentChannel, expectedVoucher, nw1, testData, testCase.addFunds, testCase.channelAvailableFunds)
 			require.NoError(t, err)
 
@@ -596,7 +596,7 @@ func setupProvider(
 	providerNode retrievalmarket.RetrievalProviderNode,
 	decider retrievalimpl.DealDecider,
 ) retrievalmarket.RetrievalProvider {
-	nw2 := rmnet.NewFromLibp2pHost(testData.Host2)
+	nw2 := rmnet.NewFromLibp2pHost(testData.Host2, rmnet.RetryParameters(0, 0, 0))
 	pieceStore := tut.NewTestPieceStore()
 	expectedPiece := tut.GenerateCids(1)[0]
 	cidInfo := piecestore.CIDInfo{

--- a/retrievalmarket/network/libp2p_impl_test.go
+++ b/retrievalmarket/network/libp2p_impl_test.go
@@ -121,7 +121,7 @@ func TestLibp2pRetrievalMarketNetwork_StopHandlingRequests(t *testing.T) {
 	bgCtx := context.Background()
 	td := shared_testutil.NewLibp2pTestData(bgCtx, t)
 
-	fromNetwork := network.NewFromLibp2pHost(td.Host1)
+	fromNetwork := network.NewFromLibp2pHost(td.Host1, network.RetryParameters(0, 0, 0))
 	toNetwork := network.NewFromLibp2pHost(td.Host2)
 	toHost := td.Host2.ID()
 

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -41,6 +41,7 @@ import (
 	stormkt "github.com/filecoin-project/go-fil-markets/storagemarket/impl"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/funds"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/storedask"
+	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	stornet "github.com/filecoin-project/go-fil-markets/storagemarket/network"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/testnodes"
 )
@@ -266,7 +267,7 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	require.NoError(t, err)
 
 	client, err := stormkt.NewClient(
-		stornet.NewFromLibp2pHost(td.Host1),
+		stornet.NewFromLibp2pHost(td.Host1, stornet.RetryParameters(0, 0, 0)),
 		td.Bs1,
 		td.MultiStore1,
 		dt1,
@@ -289,7 +290,7 @@ func newStorageHarness(ctx context.Context, t *testing.T) *storageHarness {
 	require.NoError(t, err)
 
 	provider, err := stormkt.NewProvider(
-		stornet.NewFromLibp2pHost(td.Host2),
+		stornet.NewFromLibp2pHost(td.Host2, network.RetryParameters(0, 0, 0)),
 		td.Ds2,
 		fs,
 		td.MultiStore2,
@@ -405,7 +406,7 @@ func newRetrievalHarness(ctx context.Context, t *testing.T, sh *storageHarness, 
 		IntegrationTest:        true,
 	})
 
-	nw1 := rmnet.NewFromLibp2pHost(sh.TestData.Host1)
+	nw1 := rmnet.NewFromLibp2pHost(sh.TestData.Host1, rmnet.RetryParameters(0, 0, 0))
 	client, err := retrievalimpl.NewClient(nw1, sh.TestData.MultiStore1, sh.DTClient, clientNode, sh.PeerResolver, sh.TestData.Ds1, sh.TestData.RetrievalStoredCounter1)
 	require.NoError(t, err)
 
@@ -435,7 +436,7 @@ func newRetrievalHarness(ctx context.Context, t *testing.T, sh *storageHarness, 
 		require.NoError(t, err)
 	}
 
-	nw2 := rmnet.NewFromLibp2pHost(sh.TestData.Host2)
+	nw2 := rmnet.NewFromLibp2pHost(sh.TestData.Host2, rmnet.RetryParameters(0, 0, 0))
 	pieceStore := tut.NewTestPieceStore()
 	expectedPiece := tut.GenerateCids(1)[0]
 	cidInfo := piecestore.CIDInfo{

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -483,7 +483,7 @@ func newHarnessWithTestData(t *testing.T, ctx context.Context, td *shared_testut
 	require.NoError(t, err)
 
 	client, err := storageimpl.NewClient(
-		network.NewFromLibp2pHost(td.Host1),
+		network.NewFromLibp2pHost(td.Host1, network.RetryParameters(0, 0, 0)),
 		td.Bs1,
 		td.MultiStore1,
 		dt1,
@@ -507,7 +507,7 @@ func newHarnessWithTestData(t *testing.T, ctx context.Context, td *shared_testut
 	assert.NoError(t, err)
 
 	provider, err := storageimpl.NewProvider(
-		network.NewFromLibp2pHost(td.Host2),
+		network.NewFromLibp2pHost(td.Host2, network.RetryParameters(0, 0, 0)),
 		td.Ds2,
 		fs,
 		td.MultiStore2,

--- a/storagemarket/network/libp2p_impl_test.go
+++ b/storagemarket/network/libp2p_impl_test.go
@@ -47,7 +47,7 @@ func TestOpenStreamWithRetries(t *testing.T) {
 	ctx := context.Background()
 	td := shared_testutil.NewLibp2pTestData(ctx, t)
 
-	fromNetwork := network.NewFromLibp2pHost(td.Host1)
+	fromNetwork := network.NewFromLibp2pHost(td.Host1, network.RetryParameters(1*time.Second, 10*time.Second, 5))
 	toNetwork := network.NewFromLibp2pHost(td.Host2)
 	toHost := td.Host2.ID()
 
@@ -356,7 +356,7 @@ func TestLibp2pStorageMarketNetwork_StopHandlingRequests(t *testing.T) {
 	bgCtx := context.Background()
 	td := shared_testutil.NewLibp2pTestData(bgCtx, t)
 
-	fromNetwork := network.NewFromLibp2pHost(td.Host1)
+	fromNetwork := network.NewFromLibp2pHost(td.Host1, network.RetryParameters(0, 0, 0))
 	toNetwork := network.NewFromLibp2pHost(td.Host2)
 	toHost := td.Host2.ID()
 


### PR DESCRIPTION
# Goals

- Remove need to for further PRs to change network retry parameters by making them a configuration option
- Make tests run quickly again

# Implementation

- add the var args config option pattern to the Libp2p impls for storage and retrieval market networks
- add an options to change all the retry parameters
- set parameters to avoid retries in relevant tests