### PR TITLE
Remove passthrough methods

### DIFF
--- a/storagemarket/README.md
+++ b/storagemarket/README.md
@@ -144,16 +144,6 @@ func PublishDeals(ctx context.Context, deal MinerDeal) (cid.Cid, error)
 ```
 Post the deal to chain, returning the posted message CID.
 
-#### ListProviderDeals
-```go
-func ListProviderDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken,
-                  ) ([]StorageDeal, error)
-```
-
-List all storage deals for storage provider `addr`, as of `tok`. Return a slice of `StorageDeal`.
-`StorageDeal` is a local combination of a storage deal proposal and a current deal 
-state. See [storagemarket/types.go](./types.go)
-
 #### OnDealComplete
 ```go
 func OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize abi.UnpaddedPieceSize, 
@@ -213,13 +203,6 @@ Register callbacks to be called when a deal expires or is slashed.
 func GetChainHead(ctx context.Context) (shared.TipSetToken, abi.ChainEpoch, error)
 ```
 Get the current chain head. Return its TipSetToken and its abi.ChainEpoch.
-
-#### ListClientDeals
-```go
-func ListClientDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken,
-                 ) ([]StorageDeal, error)
-```
-List all deals associated with storage client `addr`, as of `tok`. Return a slice of `StorageDeal`.
 
 #### ListStorageProviders
 ```go

--- a/storagemarket/client.go
+++ b/storagemarket/client.go
@@ -27,9 +27,6 @@ type StorageClient interface {
 	// ListProviders queries chain state and returns active storage providers
 	ListProviders(ctx context.Context) (<-chan StorageProviderInfo, error)
 
-	// ListDeals lists on-chain deals associated with this storage client
-	ListDeals(ctx context.Context, addr address.Address) ([]StorageDeal, error)
-
 	// ListLocalDeals lists deals initiated by this storage client
 	ListLocalDeals(ctx context.Context) ([]ClientDeal, error)
 

--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -172,16 +172,6 @@ func (c *Client) ListProviders(ctx context.Context) (<-chan storagemarket.Storag
 	return out, nil
 }
 
-// ListDeals lists on-chain deals associated with this storage client
-func (c *Client) ListDeals(ctx context.Context, addr address.Address) ([]storagemarket.StorageDeal, error) {
-	tok, _, err := c.node.GetChainHead(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.node.ListClientDeals(ctx, addr, tok)
-}
-
 // ListLocalDeals lists deals initiated by this storage client
 func (c *Client) ListLocalDeals(ctx context.Context) ([]storagemarket.ClientDeal, error) {
 	var out []storagemarket.ClientDeal

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -316,16 +316,6 @@ func (p *Provider) GetAsk() *storagemarket.SignedStorageAsk {
 	return p.storedAsk.GetAsk()
 }
 
-// ListDeals lists on-chain deals associated with this storage provider
-func (p *Provider) ListDeals(ctx context.Context) ([]storagemarket.StorageDeal, error) {
-	tok, _, err := p.spn.GetChainHead(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return p.spn.ListProviderDeals(ctx, p.actor, tok)
-}
-
 // AddStorageCollateral adds storage collateral
 func (p *Provider) AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error {
 	done := make(chan error, 1)

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -75,9 +75,6 @@ type StorageProviderNode interface {
 	// PublishDeals publishes a deal on chain, returns the message cid, but does not wait for message to appear
 	PublishDeals(ctx context.Context, deal MinerDeal) (cid.Cid, error)
 
-	// ListProviderDeals lists all deals on chain associated with a storage provider
-	ListProviderDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
-
 	// OnDealComplete is called when a deal is complete and on chain, and data has been transferred and is ready to be added to a sector
 	OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize abi.UnpaddedPieceSize, pieceReader io.Reader) (*PackingResult, error)
 
@@ -94,9 +91,6 @@ type StorageProviderNode interface {
 // StorageClientNode are node dependencies for a StorageClient
 type StorageClientNode interface {
 	StorageCommon
-
-	// ListClientDeals lists all on-chain deals associated with a storage client
-	ListClientDeals(ctx context.Context, addr address.Address, tok shared.TipSetToken) ([]StorageDeal, error)
 
 	// GetStorageProviders returns information about known miners
 	ListStorageProviders(ctx context.Context, tok shared.TipSetToken) ([]*StorageProviderInfo, error)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -33,9 +33,6 @@ type StorageProvider interface {
 	// GetAsk returns the storage miner's ask, or nil if one does not exist.
 	GetAsk() *SignedStorageAsk
 
-	// ListDeals lists on-chain deals associated with this storage provider
-	ListDeals(ctx context.Context) ([]StorageDeal, error)
-
 	// ListLocalDeals lists deals processed by this storage provider
 	ListLocalDeals() ([]MinerDeal, error)
 

--- a/storagemarket/types.go
+++ b/storagemarket/types.go
@@ -15,7 +15,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/filestore"
 )
 
-//go:generate cbor-gen-for ClientDeal MinerDeal Balance SignedStorageAsk StorageAsk StorageDeal DataRef ProviderDealState
+//go:generate cbor-gen-for ClientDeal MinerDeal Balance SignedStorageAsk StorageAsk DataRef ProviderDealState
 
 // DealProtocolID is the ID for the libp2p protocol for proposing storage deals.
 const DealProtocolID = "/fil/storage/mk/1.0.1"
@@ -120,12 +120,6 @@ type ClientDeal struct {
 	StoreID        *multistore.StoreID
 	FundsReserved  abi.TokenAmount
 	CreationTime   cbg.CborTime
-}
-
-// StorageDeal is a local combination of a proposal and a current deal state
-type StorageDeal struct {
-	market.DealProposal
-	market.DealState
 }
 
 // StorageProviderInfo describes on chain information about a StorageProvider

--- a/storagemarket/types_cbor_gen.go
+++ b/storagemarket/types_cbor_gen.go
@@ -1247,68 +1247,6 @@ func (t *StorageAsk) UnmarshalCBOR(r io.Reader) error {
 	return nil
 }
 
-var lengthBufStorageDeal = []byte{130}
-
-func (t *StorageDeal) MarshalCBOR(w io.Writer) error {
-	if t == nil {
-		_, err := w.Write(cbg.CborNull)
-		return err
-	}
-	if _, err := w.Write(lengthBufStorageDeal); err != nil {
-		return err
-	}
-
-	// t.DealProposal (market.DealProposal) (struct)
-	if err := t.DealProposal.MarshalCBOR(w); err != nil {
-		return err
-	}
-
-	// t.DealState (market.DealState) (struct)
-	if err := t.DealState.MarshalCBOR(w); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (t *StorageDeal) UnmarshalCBOR(r io.Reader) error {
-	*t = StorageDeal{}
-
-	br := cbg.GetPeeker(r)
-	scratch := make([]byte, 8)
-
-	maj, extra, err := cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-	if maj != cbg.MajArray {
-		return fmt.Errorf("cbor input should be of type array")
-	}
-
-	if extra != 2 {
-		return fmt.Errorf("cbor input had wrong number of fields")
-	}
-
-	// t.DealProposal (market.DealProposal) (struct)
-
-	{
-
-		if err := t.DealProposal.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealProposal: %w", err)
-		}
-
-	}
-	// t.DealState (market.DealState) (struct)
-
-	{
-
-		if err := t.DealState.UnmarshalCBOR(br); err != nil {
-			return xerrors.Errorf("unmarshaling t.DealState: %w", err)
-		}
-
-	}
-	return nil
-}
-
 var lengthBufDataRef = []byte{132}
 
 func (t *DataRef) MarshalCBOR(w io.Writer) error {


### PR DESCRIPTION
# Goals

We have these two methods that have never made any sense to me and I think are not used -- basically -- they just call the node, then return the values back. It seems like it makes way more sense for these methods to just live on the node itself, if they're neccesary (I think they're not in use FWIW). This also removes any reference to market actor existing deal state, which is important for the purposes of the actors upgrade.

# Implementation

Remove the methods, node adapter methods, and unused types