### PR TITLE
Consider ClientCollateral when validating deal proposal

### DIFF
--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -111,7 +111,7 @@ func ValidateDealProposal(ctx fsm.Context, environment ProviderDealEnvironment, 
 
 	// This doesn't guarantee that the client won't withdraw / lock those funds
 	// but it's a decent first filter
-	if clientMarketBalance.Available.LessThan(proposal.TotalStorageFee()) {
+	if clientMarketBalance.Available.LessThan(proposal.ClientBalanceRequirement()) {
 		return ctx.Trigger(storagemarket.ProviderEventDealRejected, xerrors.New("clientMarketBalance.Available too small"))
 	}
 


### PR DESCRIPTION
## Problem
Previously, we weren't including the client collateral when considering storage deal proposals; it was assumed it was always 0.

## Solution
Use `ClientBalanceRequirement()` when verifying client funds, which includes the client collateral.

Resolves filecoin-project/lotus/issues/3864