### PR TITLE
Persist retrieval ask on disk

### DIFF
--- a/retrievalmarket/defaults.go
+++ b/retrievalmarket/defaults.go
@@ -1,0 +1,18 @@
+package retrievalmarket
+
+import "github.com/filecoin-project/go-state-types/abi"
+
+// DefaultPricePerByte is the charge per byte retrieved if the miner does
+// not specifically set it
+var DefaultPricePerByte = abi.NewTokenAmount(2)
+
+// DefaultUnsealPrice is the default charge to unseal a sector for retrieval
+var DefaultUnsealPrice = abi.NewTokenAmount(0)
+
+// DefaultPaymentInterval is the baseline interval, set to 1Mb
+// if the miner does not explicitly set it otherwise
+var DefaultPaymentInterval = uint64(1 << 20)
+
+// DefaultPaymentIntervalIncrease is the amount interval increases on each payment,
+// set to to 1Mb if the miner does not explicitly set it otherwise
+var DefaultPaymentIntervalIncrease = uint64(1 << 20)

--- a/retrievalmarket/impl/askstore/askstore_impl.go
+++ b/retrievalmarket/impl/askstore/askstore_impl.go
@@ -1,0 +1,119 @@
+package askstore
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/prometheus/common/log"
+	"golang.org/x/xerrors"
+
+	cborutil "github.com/filecoin-project/go-cbor-util"
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+)
+
+// AskStoreImpl implements AskStore, persisting a retrieval Ask
+// to disk. It also maintains a cache of the current Ask in memory
+type AskStoreImpl struct {
+	lk  sync.RWMutex
+	ask *retrievalmarket.Ask
+	ds  datastore.Batching
+	key datastore.Key
+}
+
+// NewAskStore returns a new instance of AskStoreImpl
+// It will initialize a new default ask and store it if one is not set.
+// Otherwise it loads the current Ask from disk
+func NewAskStore(ds datastore.Batching, key datastore.Key) (*AskStoreImpl, error) {
+	s := &AskStoreImpl{
+		ds:  ds,
+		key: key,
+	}
+
+	if err := s.tryLoadAsk(); err != nil {
+		return nil, err
+	}
+
+	if s.ask == nil {
+		// for now set a default retrieval ask
+		defaultAsk := &retrievalmarket.Ask{
+			PricePerByte:            retrievalimpl.DefaultPricePerByte,
+			UnsealPrice:             big.Zero(),
+			PaymentInterval:         retrievalimpl.DefaultPaymentInterval,
+			PaymentIntervalIncrease: retrievalimpl.DefaultPaymentIntervalIncrease,
+		}
+
+		if err := s.SetAsk(defaultAsk); err != nil {
+			return nil, xerrors.Errorf("failed setting a default retrieval ask: %w", err)
+		}
+	}
+	return s, nil
+}
+
+// SetAsk stores retrieval provider's ask
+func (s *AskStoreImpl) SetAsk(ask *retrievalmarket.Ask) error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	return s.saveAsk(ask)
+}
+
+// GetAsk returns the current retrieval ask, or nil if one does not exist.
+func (s *AskStoreImpl) GetAsk() *retrievalmarket.Ask {
+	s.lk.RLock()
+	defer s.lk.RUnlock()
+	if s.ask == nil {
+		return nil
+	}
+	ask := *s.ask
+	return &ask
+}
+
+func (s *AskStoreImpl) tryLoadAsk() error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	err := s.loadAsk()
+
+	if err != nil {
+		if xerrors.Is(err, datastore.ErrNotFound) {
+			log.Warn("no previous ask found, miner will not accept retrieval deals until an ask is set")
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (s *AskStoreImpl) loadAsk() error {
+	askb, err := s.ds.Get(s.key)
+	if err != nil {
+		return xerrors.Errorf("failed to load most recent retrieval ask from disk: %w", err)
+	}
+
+	var ask retrievalmarket.Ask
+	if err := cborutil.ReadCborRPC(bytes.NewReader(askb), &ask); err != nil {
+		return err
+	}
+
+	s.ask = &ask
+	return nil
+}
+
+func (s *AskStoreImpl) saveAsk(a *retrievalmarket.Ask) error {
+	b, err := cborutil.Dump(a)
+	if err != nil {
+		return err
+	}
+
+	if err := s.ds.Put(s.key, b); err != nil {
+		return err
+	}
+
+	s.ask = a
+	return nil
+}

--- a/retrievalmarket/impl/askstore/askstore_impl.go
+++ b/retrievalmarket/impl/askstore/askstore_impl.go
@@ -5,14 +5,11 @@ import (
 	"sync"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/prometheus/common/log"
 	"golang.org/x/xerrors"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
-	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
 )
 
 // AskStoreImpl implements AskStore, persisting a retrieval Ask
@@ -40,10 +37,10 @@ func NewAskStore(ds datastore.Batching, key datastore.Key) (*AskStoreImpl, error
 	if s.ask == nil {
 		// for now set a default retrieval ask
 		defaultAsk := &retrievalmarket.Ask{
-			PricePerByte:            retrievalimpl.DefaultPricePerByte,
-			UnsealPrice:             big.Zero(),
-			PaymentInterval:         retrievalimpl.DefaultPaymentInterval,
-			PaymentIntervalIncrease: retrievalimpl.DefaultPaymentIntervalIncrease,
+			PricePerByte:            retrievalmarket.DefaultPricePerByte,
+			UnsealPrice:             retrievalmarket.DefaultUnsealPrice,
+			PaymentInterval:         retrievalmarket.DefaultPaymentInterval,
+			PaymentIntervalIncrease: retrievalmarket.DefaultPaymentIntervalIncrease,
 		}
 
 		if err := s.SetAsk(defaultAsk); err != nil {
@@ -80,7 +77,7 @@ func (s *AskStoreImpl) tryLoadAsk() error {
 
 	if err != nil {
 		if xerrors.Is(err, datastore.ErrNotFound) {
-			log.Warn("no previous ask found, miner will not accept retrieval deals until an ask is set")
+			// this is expected
 			return nil
 		}
 		return err

--- a/retrievalmarket/impl/askstore/askstore_impl_test.go
+++ b/retrievalmarket/impl/askstore/askstore_impl_test.go
@@ -1,0 +1,51 @@
+package askstore_test
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	dss "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/askstore"
+)
+
+func TestAskStoreImpl(t *testing.T) {
+	ds := dss.MutexWrap(datastore.NewMapDatastore())
+	store, err := askstore.NewAskStore(ds, datastore.NewKey("retrieval-ask"))
+	require.NoError(t, err)
+
+	// A new store returns the default ask
+	ask := store.GetAsk()
+	require.NotNil(t, ask)
+
+	require.Equal(t, big.Zero(), ask.UnsealPrice)
+	require.Equal(t, retrievalimpl.DefaultPricePerByte, ask.PricePerByte)
+	require.Equal(t, retrievalimpl.DefaultPaymentInterval, ask.PaymentInterval)
+	require.Equal(t, retrievalimpl.DefaultPaymentIntervalIncrease, ask.PaymentIntervalIncrease)
+
+	// Store a new ask
+	newAsk := &retrievalmarket.Ask{
+		PricePerByte:            abi.NewTokenAmount(123),
+		UnsealPrice:             abi.NewTokenAmount(456),
+		PaymentInterval:         789,
+		PaymentIntervalIncrease: 789,
+	}
+	err = store.SetAsk(newAsk)
+	require.NoError(t, err)
+
+	// Fetch new ask
+	stored := store.GetAsk()
+	require.Equal(t, newAsk, stored)
+
+	// Construct a new AskStore and make sure it returns the previously-stored ask
+	newStore, err := askstore.NewAskStore(ds, datastore.NewKey("retrieval-ask"))
+	require.NoError(t, err)
+	stored = newStore.GetAsk()
+	require.Equal(t, newAsk, stored)
+}

--- a/retrievalmarket/impl/askstore/askstore_impl_test.go
+++ b/retrievalmarket/impl/askstore/askstore_impl_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/askstore"
 )
 
@@ -24,10 +22,10 @@ func TestAskStoreImpl(t *testing.T) {
 	ask := store.GetAsk()
 	require.NotNil(t, ask)
 
-	require.Equal(t, big.Zero(), ask.UnsealPrice)
-	require.Equal(t, retrievalimpl.DefaultPricePerByte, ask.PricePerByte)
-	require.Equal(t, retrievalimpl.DefaultPaymentInterval, ask.PaymentInterval)
-	require.Equal(t, retrievalimpl.DefaultPaymentIntervalIncrease, ask.PaymentIntervalIncrease)
+	require.Equal(t, retrievalmarket.DefaultUnsealPrice, ask.UnsealPrice)
+	require.Equal(t, retrievalmarket.DefaultPricePerByte, ask.PricePerByte)
+	require.Equal(t, retrievalmarket.DefaultPaymentInterval, ask.PaymentInterval)
+	require.Equal(t, retrievalmarket.DefaultPaymentIntervalIncrease, ask.PaymentIntervalIncrease)
 
 	// Store a new ask
 	newAsk := &retrievalmarket.Ask{

--- a/retrievalmarket/provider.go
+++ b/retrievalmarket/provider.go
@@ -23,3 +23,9 @@ type RetrievalProvider interface {
 
 	ListDeals() map[ProviderDealIdentifier]ProviderDealState
 }
+
+// AskStore is an interface which provides access to a persisted retrieval Ask
+type AskStore interface {
+	GetAsk() *Ask
+	SetAsk(ask *Ask) error
+}

--- a/storagemarket/impl/storedask/storedask.go
+++ b/storagemarket/impl/storedask/storedask.go
@@ -55,6 +55,7 @@ func NewStoredAsk(ds datastore.Batching, dsKey datastore.Key, spn storagemarket.
 		ds:    ds,
 		spn:   spn,
 		actor: actor,
+		dsKey: dsKey,
 	}
 
 	if err := s.tryLoadAsk(); err != nil {


### PR DESCRIPTION
## Summary
Create a retrievalmarket `AskStore` interface and implementation, which will persist the retrieval ask to disk so that the configuration will persist through restarts.  This is modeled after the storagemarket's `StoredAsk`.

Resolves filecoin-project/lotus/issues/3907