### PR TITLE
Murmuration Labs: Use BitScreen to detect CIDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
-	github.com/murmuration-labs/bitscreen v0.1.0
+	github.com/Murmuration-Labs/bitscreen v0.1.1
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
+	github.com/murmuration-labs/bitscreen v0.1.0
 )
 
 replace github.com/filecoin-project/filecoin-ffi => ./extern/filecoin-ffi

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -189,10 +189,11 @@ From then on, the statemachine controls the deal flow in the client. Other compo
 Documentation of the client state machine can be found at https://godoc.org/github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
-	//log.Warn("RETRIEVAL - RETRIEVE -- hello world 2.")
-	//if(true) {
-	//	return 0, xerrors.Errorf("This is a made up error!")
-	//}
+	log.Warn("RETRIEVAL - RETRIEVE -- hello world 2222.")
+	log.Warn("33333")
+	if(true) {
+		return 0, xerrors.Errorf("This is a made up error!")
+	}
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		return 0, err

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -4,6 +4,18 @@ import (
 	"context"
 	"errors"
 
+	"github.com/filecoin-project/go-address"
+	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
+	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/dtutils"
+	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
+	"github.com/filecoin-project/go-fil-markets/shared"
+	"github.com/filecoin-project/go-multistore"
+	"github.com/filecoin-project/go-state-types/abi"
+	"github.com/filecoin-project/go-state-types/big"
+	"github.com/filecoin-project/go-statemachine/fsm"
+	"github.com/filecoin-project/go-storedcounter"
 	"github.com/hannahhoward/go-pubsub"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -11,20 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
-	"github.com/filecoin-project/go-address"
-	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-multistore"
-	"github.com/filecoin-project/go-state-types/abi"
-	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-statemachine/fsm"
-	"github.com/filecoin-project/go-storedcounter"
-
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates"
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/dtutils"
-	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
-	"github.com/filecoin-project/go-fil-markets/shared"
-	bitscreen "github.com/murmuration-labs/bitscreen"
+	bitscreen "github.com/Murmuration-Labs/bitscreen"
 )
 
 var log = logging.Logger("retrieval")
@@ -189,7 +188,7 @@ Documentation of the client state machine can be found at https://godoc.org/gith
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
 
-	_,err := bitscreen.FindCid(payloadCID,"/path/to/bitscreenlist")
+	_, err := bitscreen.Screen(payloadCID)
 	if err != nil {
 		return 0, err
 	}

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -190,6 +190,9 @@ Documentation of the client state machine can be found at https://godoc.org/gith
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
 	log.Warn("RETRIEVAL - RETRIEVE -- hello world.")
+	if(true) {
+		return 0, xerrors.Errorf("This is a made up error!")
+	}
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		return 0, err

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -190,9 +190,9 @@ Documentation of the client state machine can be found at https://godoc.org/gith
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
 	log.Warn("RETRIEVAL - RETRIEVE -- hello world.")
-	if(true) {
-		return 0, xerrors.Errorf("This is a made up error!")
-	}
+	//if(true) {
+	//	return 0, xerrors.Errorf("This is a made up error!")
+	//}
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		return 0, err

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -117,6 +117,7 @@ func NewClient(
 
 // FindProviders uses PeerResolver interface to locate a list of providers who may have a given payload CID.
 func (c *Client) FindProviders(payloadCID cid.Cid) []retrievalmarket.RetrievalPeer {
+	log.Warn("RETRIEVAL - FIND PROVIDERS -- hello world.")
 	peers, err := c.resolver.GetPeers(payloadCID)
 	if err != nil {
 		log.Errorf("failed to get peers: %s", err)
@@ -134,6 +135,7 @@ The client a new `RetrievalQueryStream` for the chosen peer ID,
 and calls WriteQuery on it, which constructs a data-transfer message and writes it to the Query stream.
 */
 func (c *Client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, payloadCID cid.Cid, params retrievalmarket.QueryParams) (retrievalmarket.QueryResponse, error) {
+	log.Warn("RETRIEVAL - QUERY -- hello world.")
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		log.Warn(err)
@@ -187,6 +189,7 @@ From then on, the statemachine controls the deal flow in the client. Other compo
 Documentation of the client state machine can be found at https://godoc.org/github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
+	log.Warn("RETRIEVAL - RETRIEVE -- hello world.")
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		return 0, err
@@ -291,6 +294,7 @@ func (c *Client) CancelDeal(dealID retrievalmarket.DealID) error {
 
 // GetDeal returns a given deal by deal ID, if it exists
 func (c *Client) GetDeal(dealID retrievalmarket.DealID) (retrievalmarket.ClientDealState, error) {
+	log.Warn("RETRIEVAL - GET DEAL -- hello world.")
 	var out retrievalmarket.ClientDealState
 	if err := c.stateMachines.Get(dealID).Get(&out); err != nil {
 		return retrievalmarket.ClientDealState{}, err
@@ -300,6 +304,7 @@ func (c *Client) GetDeal(dealID retrievalmarket.DealID) (retrievalmarket.ClientD
 
 // ListDeals lists in all known retrieval deals
 func (c *Client) ListDeals() (map[retrievalmarket.DealID]retrievalmarket.ClientDealState, error) {
+	log.Warn("RETRIEVAL - LIST DEALS -- hello world.")
 	var deals []retrievalmarket.ClientDealState
 	err := c.stateMachines.List(&deals)
 	if err != nil {

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/dtutils"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	"github.com/filecoin-project/go-fil-markets/shared"
+	bitscreen "github.com/murmuration-labs/bitscreen"
 )
 
 var log = logging.Logger("retrieval")
@@ -117,7 +118,6 @@ func NewClient(
 
 // FindProviders uses PeerResolver interface to locate a list of providers who may have a given payload CID.
 func (c *Client) FindProviders(payloadCID cid.Cid) []retrievalmarket.RetrievalPeer {
-	log.Warn("RETRIEVAL - FIND PROVIDERS -- hello world.")
 	peers, err := c.resolver.GetPeers(payloadCID)
 	if err != nil {
 		log.Errorf("failed to get peers: %s", err)
@@ -135,7 +135,6 @@ The client a new `RetrievalQueryStream` for the chosen peer ID,
 and calls WriteQuery on it, which constructs a data-transfer message and writes it to the Query stream.
 */
 func (c *Client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, payloadCID cid.Cid, params retrievalmarket.QueryParams) (retrievalmarket.QueryResponse, error) {
-	//log.Warn("RETRIEVAL - QUERY -- hello world.")
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		log.Warn(err)
@@ -189,10 +188,10 @@ From then on, the statemachine controls the deal flow in the client. Other compo
 Documentation of the client state machine can be found at https://godoc.org/github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
-	log.Warn("RETRIEVAL - RETRIEVE -- hello world 2222.")
-	log.Warn("33333")
-	if(true) {
-		return 0, xerrors.Errorf("This is a made up error!")
+
+	_,err := bitscreen.FindCid(payloadCID,"/path/to/bitscreenlist")
+	if err != nil {
+		return 0, err
 	}
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
@@ -298,7 +297,6 @@ func (c *Client) CancelDeal(dealID retrievalmarket.DealID) error {
 
 // GetDeal returns a given deal by deal ID, if it exists
 func (c *Client) GetDeal(dealID retrievalmarket.DealID) (retrievalmarket.ClientDealState, error) {
-	log.Warn("RETRIEVAL - GET DEAL -- hello world.")
 	var out retrievalmarket.ClientDealState
 	if err := c.stateMachines.Get(dealID).Get(&out); err != nil {
 		return retrievalmarket.ClientDealState{}, err
@@ -308,7 +306,6 @@ func (c *Client) GetDeal(dealID retrievalmarket.DealID) (retrievalmarket.ClientD
 
 // ListDeals lists in all known retrieval deals
 func (c *Client) ListDeals() (map[retrievalmarket.DealID]retrievalmarket.ClientDealState, error) {
-	log.Warn("RETRIEVAL - LIST DEALS -- hello world.")
 	var deals []retrievalmarket.ClientDealState
 	err := c.stateMachines.List(&deals)
 	if err != nil {

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -189,7 +189,7 @@ From then on, the statemachine controls the deal flow in the client. Other compo
 Documentation of the client state machine can be found at https://godoc.org/github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
-	log.Warn("RETRIEVAL - RETRIEVE -- hello world.")
+	log.Warn("RETRIEVAL - RETRIEVE -- hello world 2.")
 	//if(true) {
 	//	return 0, xerrors.Errorf("This is a made up error!")
 	//}

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -135,7 +135,7 @@ The client a new `RetrievalQueryStream` for the chosen peer ID,
 and calls WriteQuery on it, which constructs a data-transfer message and writes it to the Query stream.
 */
 func (c *Client) Query(ctx context.Context, p retrievalmarket.RetrievalPeer, payloadCID cid.Cid, params retrievalmarket.QueryParams) (retrievalmarket.QueryResponse, error) {
-	log.Warn("RETRIEVAL - QUERY -- hello world.")
+	//log.Warn("RETRIEVAL - QUERY -- hello world.")
 	err := c.addMultiaddrs(ctx, p)
 	if err != nil {
 		log.Warn(err)
@@ -189,7 +189,7 @@ From then on, the statemachine controls the deal flow in the client. Other compo
 Documentation of the client state machine can be found at https://godoc.org/github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/clientstates
 */
 func (c *Client) Retrieve(ctx context.Context, payloadCID cid.Cid, params retrievalmarket.Params, totalFunds abi.TokenAmount, p retrievalmarket.RetrievalPeer, clientWallet address.Address, minerWallet address.Address, storeID *multistore.StoreID) (retrievalmarket.DealID, error) {
-	log.Warn("RETRIEVAL - RETRIEVE -- hello world 2.")
+	//log.Warn("RETRIEVAL - RETRIEVE -- hello world 2.")
 	//if(true) {
 	//	return 0, xerrors.Errorf("This is a made up error!")
 	//}


### PR DESCRIPTION
Murmuration Labs has been working closely with Protocol Labs to provide a feature set to handle specific CIDs. This PR represents the v1 effort.

Our BitScreen module takes a CID and compares it with a file on the user's server. If the CID exists in the file, an error is thrown indicating that the CID has been detected.

https://github.com/Murmuration-Labs/bitscreen