### PR TITLE
openStream: avoid time.Sleep in exponential backoff

### DIFF
--- a/retrievalmarket/network/libp2p_impl.go
+++ b/retrievalmarket/network/libp2p_impl.go
@@ -107,8 +107,11 @@ func (impl *libp2pRetrievalMarketNetwork) openStream(ctx context.Context, id pee
 		if nAttempts == impl.maxStreamOpenAttempts {
 			return nil, xerrors.Errorf("exhausted %d attempts but failed to open stream, err: %w", int(impl.maxStreamOpenAttempts), err)
 		}
-		d := b.Duration()
-		time.Sleep(d)
+		select {
+		case <-ctx.Done():
+			return nil, xerrors.Errorf("backoff canceled by context")
+		case <-time.After(b.Duration()):
+		}
 	}
 }
 

--- a/retrievalmarket/network/libp2p_impl.go
+++ b/retrievalmarket/network/libp2p_impl.go
@@ -107,10 +107,12 @@ func (impl *libp2pRetrievalMarketNetwork) openStream(ctx context.Context, id pee
 		if nAttempts == impl.maxStreamOpenAttempts {
 			return nil, xerrors.Errorf("exhausted %d attempts but failed to open stream, err: %w", int(impl.maxStreamOpenAttempts), err)
 		}
+		ebt := time.NewTimer(b.Duration())
 		select {
 		case <-ctx.Done():
+			ebt.Stop()
 			return nil, xerrors.Errorf("backoff canceled by context")
-		case <-time.After(b.Duration()):
+		case <-ebt.C:
 		}
 	}
 }

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -152,10 +152,12 @@ func (impl *libp2pStorageMarketNetwork) openStream(ctx context.Context, id peer.
 		if nAttempts == impl.maxStreamOpenAttempts {
 			return nil, xerrors.Errorf("exhausted %d attempts but failed to open stream, err: %w", int(impl.maxStreamOpenAttempts), err)
 		}
+		ebt := time.NewTimer(b.Duration())
 		select {
 		case <-ctx.Done():
+			ebt.Stop()
 			return nil, xerrors.Errorf("backoff canceled by context")
-		case <-time.After(b.Duration()):
+		case <-ebt.C:
 		}
 	}
 }

--- a/storagemarket/network/libp2p_impl.go
+++ b/storagemarket/network/libp2p_impl.go
@@ -152,8 +152,11 @@ func (impl *libp2pStorageMarketNetwork) openStream(ctx context.Context, id peer.
 		if nAttempts == impl.maxStreamOpenAttempts {
 			return nil, xerrors.Errorf("exhausted %d attempts but failed to open stream, err: %w", int(impl.maxStreamOpenAttempts), err)
 		}
-		d := b.Duration()
-		time.Sleep(d)
+		select {
+		case <-ctx.Done():
+			return nil, xerrors.Errorf("backoff canceled by context")
+		case <-time.After(b.Duration()):
+		}
 	}
 }
 


### PR DESCRIPTION
The backoff logic was doing `time.Sleep(...)` which isn't nice for handling cancelation.