### PR TITLE
Fix panil on transfer id not present

### DIFF
--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -145,6 +145,10 @@ func ProposeDeal(ctx fsm.Context, environment ClientDealEnvironment, deal storag
 func RestartDataTransfer(ctx fsm.Context, environment ClientDealEnvironment, deal storagemarket.ClientDeal) error {
 	log.Infof("restarting data transfer for deal deal %s", deal.ProposalCid)
 
+	if deal.TransferChannelID == nil {
+		return ctx.Trigger(storagemarket.ClientEventDataTransferRestartFailed, xerrors.New("channelId on client deal is nil"))
+	}
+
 	// restart the push data transfer. This will complete asynchronously and the
 	// completion of the data transfer will trigger a change in deal state
 	err := environment.RestartDataTransfer(ctx.Context(),


### PR DESCRIPTION
For legacy deals in transferring state, we did not record the restart ID for the transfer so we can't restart them. So we need to fail the deal.

Right now we are just trying to restart anyway which causes a nil panic -- eek!