### PR TITLE
Remove temp files

### DIFF
--- a/storagemarket/impl/providerstates/provider_fsm.go
+++ b/storagemarket/impl/providerstates/provider_fsm.go
@@ -72,7 +72,9 @@ var ProviderEvents = fsm.Events{
 		From(storagemarket.StorageDealTransferring).To(storagemarket.StorageDealVerifyData),
 	fsm.Event(storagemarket.ProviderEventDataVerificationFailed).
 		From(storagemarket.StorageDealVerifyData).To(storagemarket.StorageDealFailing).
-		Action(func(deal *storagemarket.MinerDeal, err error) error {
+		Action(func(deal *storagemarket.MinerDeal, err error, path filestore.Path, metadataPath filestore.Path) error {
+			deal.PiecePath = path
+			deal.MetadataPath = metadataPath
 			deal.Message = xerrors.Errorf("deal data verification failed: %w", err).Error()
 			return nil
 		}),

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -202,12 +202,12 @@ func DecideOnProposal(ctx fsm.Context, environment ProviderDealEnvironment, deal
 func VerifyData(ctx fsm.Context, environment ProviderDealEnvironment, deal storagemarket.MinerDeal) error {
 	pieceCid, piecePath, metadataPath, err := environment.GeneratePieceCommitmentToFile(deal.StoreID, deal.Ref.Root, shared.AllSelector())
 	if err != nil {
-		return ctx.Trigger(storagemarket.ProviderEventDataVerificationFailed, xerrors.Errorf("error generating CommP: %w", err))
+		return ctx.Trigger(storagemarket.ProviderEventDataVerificationFailed, xerrors.Errorf("error generating CommP: %w", err), filestore.Path(""), filestore.Path(""))
 	}
 
 	// Verify CommP matches
 	if pieceCid != deal.Proposal.PieceCID {
-		return ctx.Trigger(storagemarket.ProviderEventDataVerificationFailed, xerrors.Errorf("proposal CommP doesn't match calculated CommP"))
+		return ctx.Trigger(storagemarket.ProviderEventDataVerificationFailed, xerrors.Errorf("proposal CommP doesn't match calculated CommP"), piecePath, metadataPath)
 	}
 
 	return ctx.Trigger(storagemarket.ProviderEventVerifiedData, piecePath, metadataPath)

--- a/storagemarket/impl/providerstates/provider_states_test.go
+++ b/storagemarket/impl/providerstates/provider_states_test.go
@@ -350,7 +350,6 @@ func TestVerifyData(t *testing.T) {
 				tut.AssertDealState(t, storagemarket.StorageDealEnsureProviderFunds, deal.State)
 				require.Equal(t, expPath, deal.PiecePath)
 				require.Equal(t, expMetaPath, deal.MetadataPath)
-
 			},
 		},
 		"generate piece CID fails": {
@@ -364,11 +363,15 @@ func TestVerifyData(t *testing.T) {
 		},
 		"piece CIDs do not match": {
 			environmentParams: environmentParams{
-				PieceCid: tut.GenerateCids(1)[0],
+				Path:         expPath,
+				MetadataPath: expMetaPath,
+				PieceCid:     tut.GenerateCids(1)[0],
 			},
 			dealInspector: func(t *testing.T, deal storagemarket.MinerDeal, env *fakeEnvironment) {
 				tut.AssertDealState(t, storagemarket.StorageDealFailing, deal.State)
 				require.Equal(t, "deal data verification failed: proposal CommP doesn't match calculated CommP", deal.Message)
+				require.Equal(t, expPath, deal.PiecePath)
+				require.Equal(t, expMetaPath, deal.MetadataPath)
 			},
 		},
 	}


### PR DESCRIPTION
# Goals

Analysis of code indicates one possible way for stray temp files to be left hanging around is when commP's do not match. In this case, temporary piece files are generated but not recorded on the deal, and are therefore not cleaned up in the StorageDealFailing state.

# Implementation

Save the piecePath and filestorePath when commP does not match so that the files get deleted