### PR TITLE
release: v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # go-fil-markets changelog
 
+# go-fil-markets v1.0.4
+
+Integrate new lotus FundManager
+
+### Changelog
+
+- [Integrate new FundManager](https://github.com/filecoin-project/go-fil-markets/pull/445)
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Dirk McCormick | 1 | +75/-311 | 17 |
+
 # go-fil-markets v1.0.1
 
 Minor bug fixes and interface change for OnDealSectorCommitted


### PR DESCRIPTION
# go-fil-markets v1.0.4

Integrate new lotus FundManager

### Changelog

- [Integrate new FundManager](https://github.com/filecoin-project/go-fil-markets/pull/445)

### Contributors

| Contributor | Commits | Lines ± | Files Changed |
|-------------|---------|---------|---------------|
| Dirk McCormick | 1 | +75/-311 | 17 |