### PR TITLE
Store provider state when polling for acceptance

### DIFF
--- a/storagemarket/impl/clientstates/client_fsm.go
+++ b/storagemarket/impl/clientstates/client_fsm.go
@@ -1,6 +1,8 @@
 package clientstates
 
 import (
+	"fmt"
+
 	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 
@@ -114,11 +116,12 @@ var ClientEvents = fsm.Events{
 		FromMany(storagemarket.StorageDealTransferring, storagemarket.StorageDealStartDataTransfer).To(storagemarket.StorageDealCheckForAcceptance),
 	fsm.Event(storagemarket.ClientEventWaitForDealState).
 		From(storagemarket.StorageDealCheckForAcceptance).ToNoChange().
-		Action(func(deal *storagemarket.ClientDeal, pollError bool) error {
+		Action(func(deal *storagemarket.ClientDeal, pollError bool, providerState storagemarket.StorageDealStatus) error {
 			deal.PollRetryCount++
 			if pollError {
 				deal.PollErrorCount++
 			}
+			deal.Message = fmt.Sprintf("Provider state: %s", storagemarket.DealStates[providerState])
 			return nil
 		}),
 	fsm.Event(storagemarket.ClientEventResponseDealDidNotMatch).

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -340,6 +340,7 @@ func TestCheckForDealAcceptance(t *testing.T) {
 				tut.AssertDealState(t, storagemarket.StorageDealCheckForAcceptance, deal.State)
 				assert.Equal(t, uint64(1), deal.PollRetryCount)
 				assert.Equal(t, uint64(1), deal.PollErrorCount)
+				assert.Equal(t, "Provider state: StorageDealUnknown", deal.Message)
 			},
 		})
 	})
@@ -351,6 +352,7 @@ func TestCheckForDealAcceptance(t *testing.T) {
 			},
 			inspector: func(deal storagemarket.ClientDeal, env *fakeEnvironment) {
 				tut.AssertDealState(t, storagemarket.StorageDealCheckForAcceptance, deal.State)
+				assert.Equal(t, "Provider state: StorageDealVerifyData", deal.Message)
 			},
 		})
 	})


### PR DESCRIPTION
## Summary
To provide more visibility when negotiating deals, store the provider's deal state in the local `ClientDeal` when waiting for deal acceptance.

Resolves https://github.com/filecoin-project/lotus/issues/5062