### PR TITLE
clear deal message when deal accepted

### DIFF
--- a/storagemarket/impl/clientstates/client_fsm.go
+++ b/storagemarket/impl/clientstates/client_fsm.go
@@ -153,6 +153,7 @@ var ClientEvents = fsm.Events{
 		From(storagemarket.StorageDealCheckForAcceptance).To(storagemarket.StorageDealProposalAccepted).
 		Action(func(deal *storagemarket.ClientDeal, publishMessage *cid.Cid) error {
 			deal.PublishMessage = publishMessage
+			deal.Message = ""
 			return nil
 		}),
 	fsm.Event(storagemarket.ClientEventStreamCloseError).


### PR DESCRIPTION
When a deal has been accepted we should clear the deal message.
Otherwise it will still say something like "Provider state: StorageDealVerifyData"