### PR TITLE
Ignore deal ID in OnDealSectorPreCommitted / OnDealSectorCommitted

### DIFF
--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -242,7 +242,7 @@ func VerifyDealPreCommitted(ctx fsm.Context, environment ClientDealEnvironment, 
 		}
 	}
 
-	err := environment.Node().OnDealSectorPreCommitted(ctx.Context(), deal.Proposal.Provider, deal.DealID, deal.Proposal, deal.PublishMessage, cb)
+	err := environment.Node().OnDealSectorPreCommitted(ctx.Context(), deal.Proposal.Provider, deal.Proposal, *deal.PublishMessage, cb)
 
 	if err != nil {
 		return ctx.Trigger(storagemarket.ClientEventDealPrecommitFailed, err)
@@ -260,7 +260,7 @@ func VerifyDealActivated(ctx fsm.Context, environment ClientDealEnvironment, dea
 		}
 	}
 
-	if err := environment.Node().OnDealSectorCommitted(ctx.Context(), deal.Proposal.Provider, deal.DealID, deal.SectorNumber, deal.Proposal, deal.PublishMessage, cb); err != nil {
+	if err := environment.Node().OnDealSectorCommitted(ctx.Context(), deal.Proposal.Provider, deal.SectorNumber, deal.Proposal, *deal.PublishMessage, cb); err != nil {
 		return ctx.Trigger(storagemarket.ClientEventDealActivationFailed, err)
 	}
 

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -588,6 +588,7 @@ func makeExecutor(ctx context.Context,
 		dealState, err := tut.MakeTestClientDeal(initialState, clientDealProposal, envParams.manualTransfer)
 		assert.NoError(t, err)
 		dealState.AddFundsCid = &tut.GenerateCids(1)[0]
+		dealState.PublishMessage = &tut.GenerateCids(1)[0]
 		dealState.FastRetrieval = dealParams.fastRetrieval
 		dealState.TransferChannelID = &datatransfer.ChannelID{}
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -430,7 +430,7 @@ func VerifyDealPreCommitted(ctx fsm.Context, environment ProviderDealEnvironment
 		}
 	}
 
-	err := environment.Node().OnDealSectorPreCommitted(ctx.Context(), deal.Proposal.Provider, deal.DealID, deal.Proposal, deal.PublishCid, cb)
+	err := environment.Node().OnDealSectorPreCommitted(ctx.Context(), deal.Proposal.Provider, deal.Proposal, *deal.PublishCid, cb)
 
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealPrecommitFailed, err)
@@ -449,7 +449,7 @@ func VerifyDealActivated(ctx fsm.Context, environment ProviderDealEnvironment, d
 		}
 	}
 
-	err := environment.Node().OnDealSectorCommitted(ctx.Context(), deal.Proposal.Provider, deal.DealID, deal.SectorNumber, deal.Proposal, deal.PublishCid, cb)
+	err := environment.Node().OnDealSectorCommitted(ctx.Context(), deal.Proposal.Provider, deal.SectorNumber, deal.Proposal, *deal.PublishCid, cb)
 
 	if err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealActivationFailed, err)

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -61,10 +61,10 @@ type StorageCommon interface {
 	DealProviderCollateralBounds(ctx context.Context, size abi.PaddedPieceSize, isVerified bool) (abi.TokenAmount, abi.TokenAmount, error)
 
 	// OnDealSectorPreCommitted waits for a deal's sector to be pre-committed
-	OnDealSectorPreCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, proposal market.DealProposal, publishCid *cid.Cid, cb DealSectorPreCommittedCallback) error
+	OnDealSectorPreCommitted(ctx context.Context, provider address.Address, proposal market.DealProposal, publishCid cid.Cid, cb DealSectorPreCommittedCallback) error
 
 	// OnDealSectorCommitted waits for a deal's sector to be sealed and proved, indicating the deal is active
-	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid *cid.Cid, cb DealSectorCommittedCallback) error
+	OnDealSectorCommitted(ctx context.Context, provider address.Address, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid cid.Cid, cb DealSectorCommittedCallback) error
 
 	// OnDealExpiredOrSlashed registers callbacks to be called when the deal expires or is slashed
 	OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired DealExpiredCallback, onDealSlashed DealSlashedCallback) error

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -200,7 +200,7 @@ func (n *FakeCommonNode) DealProviderCollateralBounds(ctx context.Context, size 
 }
 
 // OnDealSectorPreCommitted returns immediately, and returns stubbed errors
-func (n *FakeCommonNode) OnDealSectorPreCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, proposal market.DealProposal, publishCid *cid.Cid, cb storagemarket.DealSectorPreCommittedCallback) error {
+func (n *FakeCommonNode) OnDealSectorPreCommitted(ctx context.Context, provider address.Address, proposal market.DealProposal, publishCid cid.Cid, cb storagemarket.DealSectorPreCommittedCallback) error {
 	if n.DelayFakeCommonNode.OnDealSectorPreCommitted {
 		select {
 		case <-ctx.Done():
@@ -215,7 +215,7 @@ func (n *FakeCommonNode) OnDealSectorPreCommitted(ctx context.Context, provider 
 }
 
 // OnDealSectorCommitted returns immediately, and returns stubbed errors
-func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid *cid.Cid, cb storagemarket.DealSectorCommittedCallback) error {
+func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider address.Address, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid cid.Cid, cb storagemarket.DealSectorCommittedCallback) error {
 	if n.DelayFakeCommonNode.OnDealSectorCommitted {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
The deal ID may change if there is a reorg after the publish deals message has landed. So we use the publish message CID and the deal proposal to get the deal instead of using the deal ID.