### PR TITLE
Move publish deals msg response parsing from markets into lotus

### DIFF
--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -77,12 +77,22 @@ type PackingResult struct {
 	Size         abi.PaddedPieceSize
 }
 
+// PublishDealsWaitResult is the result of a call to wait for publish deals to
+// appear on chain
+type PublishDealsWaitResult struct {
+	DealID   abi.DealID
+	FinalCid cid.Cid
+}
+
 // StorageProviderNode are node dependencies for a StorageProvider
 type StorageProviderNode interface {
 	StorageCommon
 
 	// PublishDeals publishes a deal on chain, returns the message cid, but does not wait for message to appear
 	PublishDeals(ctx context.Context, deal MinerDeal) (cid.Cid, error)
+
+	// WaitForPublishDeals waits for a deal publish message to land on chain.
+	WaitForPublishDeals(ctx context.Context, mcid cid.Cid, proposal market.DealProposal) (*PublishDealsWaitResult, error)
 
 	// OnDealComplete is called when a deal is complete and on chain, and data has been transferred and is ready to be added to a sector
 	OnDealComplete(ctx context.Context, deal MinerDeal, pieceSize abi.UnpaddedPieceSize, pieceReader io.Reader) (*PackingResult, error)

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -338,6 +338,7 @@ type FakeProviderNode struct {
 	PieceSectorID                       uint64
 	PublishDealID                       abi.DealID
 	PublishDealsError                   error
+	WaitForPublishDealsError            error
 	OnDealCompleteError                 error
 	LastOnDealCompleteBytes             []byte
 	OnDealCompleteCalls                 []storagemarket.MinerDeal
@@ -352,6 +353,24 @@ func (n *FakeProviderNode) PublishDeals(ctx context.Context, deal storagemarket.
 		return shared_testutil.GenerateCids(1)[0], nil
 	}
 	return cid.Undef, n.PublishDealsError
+}
+
+// WaitForPublishDeals simulates waiting for the deal to be published and
+// calling the callback with the results
+func (n *FakeProviderNode) WaitForPublishDeals(ctx context.Context, mcid cid.Cid, proposal market.DealProposal) (*storagemarket.PublishDealsWaitResult, error) {
+	if n.WaitForPublishDealsError != nil {
+		return nil, n.WaitForPublishDealsError
+	}
+
+	finalCid := n.WaitForMessageFinalCid
+	if finalCid.Equals(cid.Undef) {
+		finalCid = mcid
+	}
+
+	return &storagemarket.PublishDealsWaitResult{
+		DealID:   n.PublishDealID,
+		FinalCid: finalCid,
+	}, nil
 }
 
 // OnDealComplete simulates passing of the deal to the storage miner, and does nothing


### PR DESCRIPTION
Now that deals are published with more than one deal ID, move parsing of the publish message response into lotus rather than doing it in markets.