### PR TITLE
Pass deal proposal instead of deal ID to OnDealExpiredOrSlashed

### DIFF
--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -300,7 +300,7 @@ func WaitForDealCompletion(ctx fsm.Context, environment ClientDealEnvironment, d
 		}
 	}
 
-	if err := node.OnDealExpiredOrSlashed(ctx.Context(), deal.DealID, expiredCb, slashedCb); err != nil {
+	if err := node.OnDealExpiredOrSlashed(ctx.Context(), *deal.PublishMessage, deal.Proposal, expiredCb, slashedCb); err != nil {
 		return ctx.Trigger(storagemarket.ClientEventDealCompletionFailed, err)
 	}
 

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -610,6 +610,7 @@ func makeExecutor(ctx context.Context,
 		dealState, err := tut.MakeTestClientDeal(initialState, clientDealProposal, envParams.manualTransfer)
 		assert.NoError(t, err)
 		dealState.AddFundsCid = &tut.GenerateCids(1)[0]
+		dealState.PublishMessage = &tut.GenerateCids(1)[0]
 		dealState.FastRetrieval = dealParams.fastRetrieval
 		dealState.TransferChannelID = &datatransfer.ChannelID{}
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -512,7 +512,7 @@ func WaitForDealCompletion(ctx fsm.Context, environment ProviderDealEnvironment,
 		}
 	}
 
-	if err := node.OnDealExpiredOrSlashed(ctx.Context(), deal.DealID, expiredCb, slashedCb); err != nil {
+	if err := node.OnDealExpiredOrSlashed(ctx.Context(), *deal.PublishCid, deal.Proposal, expiredCb, slashedCb); err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealCompletionFailed, err)
 	}
 

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -67,7 +67,7 @@ type StorageCommon interface {
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid *cid.Cid, cb DealSectorCommittedCallback) error
 
 	// OnDealExpiredOrSlashed registers callbacks to be called when the deal expires or is slashed
-	OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired DealExpiredCallback, onDealSlashed DealSlashedCallback) error
+	OnDealExpiredOrSlashed(ctx context.Context, publishCid cid.Cid, proposal market.DealProposal, onDealExpired DealExpiredCallback, onDealSlashed DealSlashedCallback) error
 }
 
 // PackingResult returns information about how a deal was put into a sector

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -230,7 +230,7 @@ func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider add
 }
 
 // OnDealExpiredOrSlashed simulates waiting for a deal to be expired or slashed, but provides stubbed behavior
-func (n *FakeCommonNode) OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired storagemarket.DealExpiredCallback, onDealSlashed storagemarket.DealSlashedCallback) error {
+func (n *FakeCommonNode) OnDealExpiredOrSlashed(ctx context.Context, publishCid cid.Cid, proposal market.DealProposal, onDealExpired storagemarket.DealExpiredCallback, onDealSlashed storagemarket.DealSlashedCallback) error {
 	if n.DelayFakeCommonNode.OnDealExpiredOrSlashed {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
The deal ID may change if there is a reorg after the deal publish message lands on chain, so pass the deal proposal instead