### PR TITLE
price specification by user should match what miner has in their ask

### DIFF
--- a/storagemarket/impl/client.go
+++ b/storagemarket/impl/client.go
@@ -338,6 +338,8 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, params storagemarket.Pr
 		return nil, xerrors.Errorf("computing commP failed: %w", err)
 	}
 
+	pricePerEpoch := big.Mul(big.NewInt(int64(pieceSize.Padded())), params.Price)
+
 	if uint64(pieceSize.Padded()) > params.Info.SectorSize {
 		return nil, fmt.Errorf("cannot propose a deal whose piece size (%d) is greater than sector size (%d)", pieceSize.Padded(), params.Info.SectorSize)
 	}
@@ -363,7 +365,7 @@ func (c *Client) ProposeStorageDeal(ctx context.Context, params storagemarket.Pr
 		Label:                label,
 		StartEpoch:           params.StartEpoch,
 		EndEpoch:             params.EndEpoch,
-		StoragePricePerEpoch: params.Price,
+		StoragePricePerEpoch: pricePerEpoch,
 		ProviderCollateral:   pcMin,
 		ClientCollateral:     big.Zero(),
 		VerifiedDeal:         params.VerifiedDeal,


### PR DESCRIPTION
This was a poor bit of UX that required users to multiply their storage price by the padded size of their data in order to propose the correct thing to the miner.

price should always be specified in the same terms. Miners asks say price in FIL/GB/Epoch, and what the user types should match this.