### PR TITLE
Add TestBounceConnectionDataTransfer

### DIFF
--- a/storagemarket/impl/clientstates/client_fsm.go
+++ b/storagemarket/impl/clientstates/client_fsm.go
@@ -79,7 +79,7 @@ var ClientEvents = fsm.Events{
 		FromMany(storagemarket.StorageDealStartDataTransfer, storagemarket.StorageDealTransferring).
 		To(storagemarket.StorageDealFailing).
 		Action(func(deal *storagemarket.ClientDeal, err error) error {
-			deal.Message = xerrors.Errorf("failed to initiate data transfer: %w", err).Error()
+			deal.Message = xerrors.Errorf("failed to complete data transfer: %w", err).Error()
 			return nil
 		}),
 


### PR DESCRIPTION
Verifies that when the connection goes down then is restored during a transfer, the deal completes successfully.

This test has surfaced the following issue:
https://github.com/filecoin-project/go-data-transfer/issues/153

Once that issue has been resolved, the test can be merged.