### PR TITLE
close the reader after unsealing into blockstore

### DIFF
--- a/retrievalmarket/impl/providerstates/provider_states.go
+++ b/retrievalmarket/impl/providerstates/provider_states.go
@@ -21,7 +21,7 @@ import (
 type ProviderDealEnvironment interface {
 	// Node returns the node interface for this deal
 	Node() rm.RetrievalProviderNode
-	ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.Reader) error
+	ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.ReadCloser) error
 	TrackTransfer(deal rm.ProviderDealState) error
 	UntrackTransfer(deal rm.ProviderDealState) error
 	DeleteStore(storeID multistore.StoreID) error
@@ -29,7 +29,7 @@ type ProviderDealEnvironment interface {
 	CloseDataTransfer(context.Context, datatransfer.ChannelID) error
 }
 
-func firstSuccessfulUnseal(ctx context.Context, node rm.RetrievalProviderNode, pieceInfo piecestore.PieceInfo) (io.Reader, error) {
+func firstSuccessfulUnseal(ctx context.Context, node rm.RetrievalProviderNode, pieceInfo piecestore.PieceInfo) (io.ReadCloser, error) {
 	lastErr := xerrors.New("no sectors found to unseal from")
 	for _, deal := range pieceInfo.Deals {
 		reader, err := node.UnsealSector(ctx, deal.SectorID, deal.Offset.Unpadded(), deal.Length.Unpadded())

--- a/retrievalmarket/migrations/migrations_test.go
+++ b/retrievalmarket/migrations/migrations_test.go
@@ -266,7 +266,7 @@ func (te *mockProviderEnv) DeleteStore(storeID multistore.StoreID) error {
 	return nil
 }
 
-func (te *mockProviderEnv) ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.Reader) error {
+func (te *mockProviderEnv) ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.ReadCloser) error {
 	return nil
 }
 

--- a/retrievalmarket/testing/test_provider_deal_environment.go
+++ b/retrievalmarket/testing/test_provider_deal_environment.go
@@ -40,7 +40,7 @@ func (te *TestProviderDealEnvironment) DeleteStore(storeID multistore.StoreID) e
 	return te.DeleteStoreError
 }
 
-func (te *TestProviderDealEnvironment) ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.Reader) error {
+func (te *TestProviderDealEnvironment) ReadIntoBlockstore(storeID multistore.StoreID, pieceData io.ReadCloser) error {
 	return te.ReadIntoBlockstoreError
 }
 


### PR DESCRIPTION
There seems to be an issue where the error message when unsealing fails is getting swallowed: https://github.com/filecoin-project/lotus/issues/5829
To make sure any read errors are surfaced, this PR explicitly closes the reader after reading the the unsealed data into the blockstore and returns any error.