### PR TITLE
enable data rate monitoring for retrieval after payment channel create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.3
 	github.com/filecoin-project/go-cbor-util v0.0.0-20191219014500-08c40a1e63a2
 	github.com/filecoin-project/go-commp-utils v0.0.0-20201119054358-b88f7a96a434
-	github.com/filecoin-project/go-data-transfer v1.4.0
+	github.com/filecoin-project/go-data-transfer v1.1.1-0.20210330094219-74b8bb238970
 	github.com/filecoin-project/go-ds-versioning v0.1.0
 	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-data-transfer v1.0.1 h1:5sYKDbstyDsdJpVP4UGUW6+BgCNfgnH8hQgf0E3ZAno=
 github.com/filecoin-project/go-data-transfer v1.0.1/go.mod h1:UxvfUAY9v3ub0a21BSK9u3pB2aq30Y0KMsG+w9/ysyo=
-github.com/filecoin-project/go-data-transfer v1.4.0 h1:SRpFUp7WQdJe6iSmt7HfhMGDk7tniTVIlfmvQVBZhN8=
-github.com/filecoin-project/go-data-transfer v1.4.0/go.mod h1:n8kbDQXWrY1c4UgfMa9KERxNCWbOTDwdNhf2MpN9dpo=
+github.com/filecoin-project/go-data-transfer v1.1.1-0.20210330094219-74b8bb238970 h1:qwPb/unJ2a2Lzp9DHWHIklONC4dax0laEL83IqruquM=
+github.com/filecoin-project/go-data-transfer v1.1.1-0.20210330094219-74b8bb238970/go.mod h1:n8kbDQXWrY1c4UgfMa9KERxNCWbOTDwdNhf2MpN9dpo=
 github.com/filecoin-project/go-ds-versioning v0.1.0 h1:y/X6UksYTsK8TLCI7rttCKEvl8btmWxyFMEeeWGUxIQ=
 github.com/filecoin-project/go-ds-versioning v0.1.0/go.mod h1:mp16rb4i2QPmxBnmanUx8i/XANp+PFCCJWiAb+VW4/s=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200716160307-8f644712406f h1:GxJzR3oRIMTPtpZ0b7QF8FKPK6/iPAc7trhlL5k/g+s=

--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -451,6 +451,10 @@ func (c *clientDealEnvironment) CloseDataTransfer(ctx context.Context, channelID
 	return c.c.dataTransfer.CloseDataTransferChannel(ctx, channelID)
 }
 
+func (c *clientDealEnvironment) EnableDataRateMonitoring(channelID datatransfer.ChannelID) error {
+	return c.c.dataTransfer.EnableDataRateMonitoring(channelID)
+}
+
 type clientStoreGetter struct {
 	c *Client
 }

--- a/retrievalmarket/impl/clientstates/client_states_test.go
+++ b/retrievalmarket/impl/clientstates/client_states_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
+	"github.com/filecoin-project/go-data-transfer/testutil"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-statemachine/fsm"
@@ -52,6 +53,10 @@ func (e *fakeEnvironment) SendDataTransferVoucher(_ context.Context, _ datatrans
 
 func (e *fakeEnvironment) CloseDataTransfer(_ context.Context, _ datatransfer.ChannelID) error {
 	return e.CloseDataTransferError
+}
+
+func (e *fakeEnvironment) EnableDataRateMonitoring(id datatransfer.ChannelID) error {
+	return nil
 }
 
 func TestProposeDeal(t *testing.T) {
@@ -617,12 +622,12 @@ var defaultUnsealFundsPaid = abi.NewTokenAmount(0)
 
 func makeDealState(status retrievalmarket.DealStatus) *retrievalmarket.ClientDealState {
 	paymentInfo := &retrievalmarket.PaymentInfo{}
-
 	switch status {
 	case retrievalmarket.DealStatusNew, retrievalmarket.DealStatusAccepted, retrievalmarket.DealStatusPaymentChannelCreating:
 		paymentInfo = nil
 	}
 
+	peers := testutil.GeneratePeers(2)
 	return &retrievalmarket.ClientDealState{
 		TotalFunds:       defaultTotalFunds,
 		MinerWallet:      address.TestAddress,
@@ -638,6 +643,11 @@ func makeDealState(status retrievalmarket.DealStatus) *retrievalmarket.ClientDea
 		DealProposal: retrievalmarket.DealProposal{
 			ID:     retrievalmarket.DealID(10),
 			Params: retrievalmarket.NewParamsV0(defaultPricePerByte, 0, defaultIntervalIncrease),
+		},
+		ChannelID: &datatransfer.ChannelID{
+			Initiator: peers[0],
+			Responder: peers[1],
+			ID:        100,
 		},
 	}
 }

--- a/retrievalmarket/migrations/migrations_test.go
+++ b/retrievalmarket/migrations/migrations_test.go
@@ -255,6 +255,12 @@ func (e *mockClientEnv) CloseDataTransfer(_ context.Context, _ datatransfer.Chan
 	return nil
 }
 
+func (e *mockClientEnv) EnableDataRateMonitoring(id datatransfer.ChannelID) error {
+	return nil
+}
+
+var _ clientstates.ClientDealEnvironment = (*mockClientEnv)(nil)
+
 type mockProviderEnv struct {
 }
 
@@ -285,3 +291,5 @@ func (te *mockProviderEnv) ResumeDataTransfer(_ context.Context, _ datatransfer.
 func (te *mockProviderEnv) CloseDataTransfer(_ context.Context, _ datatransfer.ChannelID) error {
 	return nil
 }
+
+var _ providerstates.ProviderDealEnvironment = (*mockProviderEnv)(nil)

--- a/shared_testutil/test_datatransfer.go
+++ b/shared_testutil/test_datatransfer.go
@@ -91,6 +91,10 @@ func (tdt *TestDataTransfer) OpenPullDataChannel(ctx context.Context, to peer.ID
 	return datatransfer.ChannelID{}, nil
 }
 
+func (tdt *TestDataTransfer) EnableDataRateMonitoring(chid datatransfer.ChannelID) error {
+	return nil
+}
+
 // SendVoucher does nothing
 func (tdt *TestDataTransfer) SendVoucher(ctx context.Context, chid datatransfer.ChannelID, voucher datatransfer.Voucher) error {
 	return nil


### PR DESCRIPTION
Depends on https://github.com/filecoin-project/go-data-transfer/pull/182

Currently the push or pull channel data rate monitoring starts automatically when the channel is opened.

However for retrieval we open a pull channel, then create a payment channel. It can take a long time to open a payment channel, which means that the data-rate will be zero during that time, and the pull channel monitor will try to restart the connection.

This PR enables data rate monitoring for retrieval only after the payment channel has been created.

TODO:
- [x] Enable data-rate monitoring after the payment channel has been created
- [ ] Add a mechanism to enable / disable auto-start of data rate monitoring separately for push vs pull channels
  The channel monitor configuration has a flag `EnableDataRateMonitoring` that indicates whether to start monitoring the data-rate as soon as the channel is opened. This flag applies to both push and pull channels.
  We want it to apply only for retrieval (pull channel).
- [ ] Add a mechanism to disable data-rate monitoring
  When the client runs out of funds, it tries to add more funds to the payment channel. In that case the client should stop monitoring the data-rate.
- [ ] Integration test that verifies the channel will not be restarted while waiting for the payment channel to be created
- [ ] Integration test that verifies the channel will not be restarted while waiting for the funds to be added to the payment channel