### PR TITLE
Retrieval: use time-based deal ID instead of stored counter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/filecoin-project/go-state-types v0.0.0-20201102161440-c8033295a1fc
 	github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe
 	github.com/filecoin-project/go-statestore v0.1.0
-	github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b
 	github.com/filecoin-project/specs-actors v0.9.13
 	github.com/filecoin-project/specs-actors/v2 v2.3.2
 	github.com/hannahhoward/cbor-gen-for v0.0.0-20200817222906-ea96cece81f1

--- a/retrievalmarket/impl/client_test.go
+++ b/retrievalmarket/impl/client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
-	"github.com/filecoin-project/go-storedcounter"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
@@ -40,19 +39,11 @@ import (
 func TestClient_Construction(t *testing.T) {
 
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	storedCounter := storedcounter.New(ds, datastore.NewKey("nextDealID"))
 	multiStore, err := multistore.NewMultiDstore(ds)
 	require.NoError(t, err)
 	dt := tut.NewTestDataTransfer()
 	net := tut.NewTestRetrievalMarketNetwork(tut.TestNetworkParams{})
-	_, err = retrievalimpl.NewClient(
-		net,
-		multiStore,
-		dt,
-		testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-		&tut.TestPeerResolver{},
-		ds,
-		storedCounter)
+	_, err = retrievalimpl.NewClient(net, multiStore, dt, testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}), &tut.TestPeerResolver{}, ds)
 	require.NoError(t, err)
 
 	require.Len(t, dt.Subscribers, 1)
@@ -80,7 +71,6 @@ func TestClient_Query(t *testing.T) {
 	ctx := context.Background()
 
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	storedCounter := storedcounter.New(ds, datastore.NewKey("nextDealID"))
 	multiStore, err := multistore.NewMultiDstore(ds)
 	require.NoError(t, err)
 	dt := tut.NewTestDataTransfer()
@@ -117,14 +107,7 @@ func TestClient_Query(t *testing.T) {
 		})
 		node := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{})
 		node.ExpectKnownAddresses(rpeer, nil)
-		c, err := retrievalimpl.NewClient(
-			net,
-			multiStore,
-			dt,
-			node,
-			&tut.TestPeerResolver{},
-			ds,
-			storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, node, &tut.TestPeerResolver{}, ds)
 		require.NoError(t, err)
 
 		resp, err := c.Query(ctx, rpeer, pcid, retrievalmarket.QueryParams{})
@@ -140,14 +123,7 @@ func TestClient_Query(t *testing.T) {
 		})
 		node := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{})
 		node.ExpectKnownAddresses(rpeer, nil)
-		c, err := retrievalimpl.NewClient(
-			net,
-			multiStore,
-			dt,
-			node,
-			&tut.TestPeerResolver{},
-			ds,
-			storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, node, &tut.TestPeerResolver{}, ds)
 		require.NoError(t, err)
 
 		_, err = c.Query(ctx, rpeer, pcid, retrievalmarket.QueryParams{})
@@ -170,14 +146,7 @@ func TestClient_Query(t *testing.T) {
 		})
 		node := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{})
 		node.ExpectKnownAddresses(rpeer, nil)
-		c, err := retrievalimpl.NewClient(
-			net,
-			multiStore,
-			dt,
-			node,
-			&tut.TestPeerResolver{},
-			ds,
-			storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, node, &tut.TestPeerResolver{}, ds)
 		require.NoError(t, err)
 
 		statusCode, err := c.Query(ctx, rpeer, pcid, retrievalmarket.QueryParams{})
@@ -199,14 +168,7 @@ func TestClient_Query(t *testing.T) {
 		})
 		node := testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{})
 		node.ExpectKnownAddresses(rpeer, nil)
-		c, err := retrievalimpl.NewClient(
-			net,
-			multiStore,
-			dt,
-			node,
-			&tut.TestPeerResolver{},
-			ds,
-			storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, node, &tut.TestPeerResolver{}, ds)
 		require.NoError(t, err)
 
 		statusCode, err := c.Query(ctx, rpeer, pcid, retrievalmarket.QueryParams{})
@@ -218,7 +180,6 @@ func TestClient_Query(t *testing.T) {
 
 func TestClient_FindProviders(t *testing.T) {
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	storedCounter := storedcounter.New(ds, datastore.NewKey("nextDealID"))
 	multiStore, err := multistore.NewMultiDstore(ds)
 	require.NoError(t, err)
 	dt := tut.NewTestDataTransfer()
@@ -238,7 +199,7 @@ func TestClient_FindProviders(t *testing.T) {
 		peers := tut.RequireGenerateRetrievalPeers(t, 3)
 		testResolver := tut.TestPeerResolver{Peers: peers}
 
-		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds)
 		require.NoError(t, err)
 
 		testCid := tut.GenerateCids(1)[0]
@@ -247,7 +208,7 @@ func TestClient_FindProviders(t *testing.T) {
 
 	t.Run("when there is an error, returns empty provider list", func(t *testing.T) {
 		testResolver := tut.TestPeerResolver{Peers: []retrievalmarket.RetrievalPeer{}, ResolverError: errors.New("boom")}
-		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds)
 		require.NoError(t, err)
 
 		badCid := tut.GenerateCids(1)[0]
@@ -256,7 +217,7 @@ func TestClient_FindProviders(t *testing.T) {
 
 	t.Run("when there are no providers", func(t *testing.T) {
 		testResolver := tut.TestPeerResolver{Peers: []retrievalmarket.RetrievalPeer{}}
-		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds, storedCounter)
+		c, err := retrievalimpl.NewClient(net, multiStore, dt, &testnodes.TestRetrievalClientNode{}, &testResolver, ds)
 		require.NoError(t, err)
 
 		testCid := tut.GenerateCids(1)[0]
@@ -323,7 +284,6 @@ func TestClient_DuplicateRetrieve(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Set up a retrieval client node with mocks
 			ds := dss.MutexWrap(datastore.NewMapDatastore())
-			storedCounter := storedcounter.New(ds, datastore.NewKey("nextDealID"))
 			multiStore, err := multistore.NewMultiDstore(ds)
 			require.NoError(t, err)
 			dt := tut.NewTestDataTransfer()
@@ -333,14 +293,7 @@ func TestClient_DuplicateRetrieve(t *testing.T) {
 			node.ExpectKnownAddresses(tc.rpeer2, nil)
 
 			// Create the client
-			client, err := retrievalimpl.NewClient(
-				net,
-				multiStore,
-				dt,
-				node,
-				&tut.TestPeerResolver{},
-				ds,
-				storedCounter)
+			client, err := retrievalimpl.NewClient(net, multiStore, dt, node, &tut.TestPeerResolver{}, ds)
 			require.NoError(t, err)
 
 			// Start the client and wait till it's ready
@@ -408,7 +361,6 @@ func TestMigrations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	ds := dss.MutexWrap(datastore.NewMapDatastore())
-	storedCounter := storedcounter.New(ds, datastore.NewKey("nextDealID"))
 	multiStore, err := multistore.NewMultiDstore(ds)
 	require.NoError(t, err)
 	dt := tut.NewTestDataTransfer()
@@ -518,14 +470,7 @@ func TestMigrations(t *testing.T) {
 		err = retrievalDs.Put(datastore.NewKey(fmt.Sprint(deal.ID)), buf.Bytes())
 		require.NoError(t, err)
 	}
-	retrievalClient, err := retrievalimpl.NewClient(
-		net,
-		multiStore,
-		dt,
-		testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}),
-		&tut.TestPeerResolver{},
-		retrievalDs,
-		storedCounter)
+	retrievalClient, err := retrievalimpl.NewClient(net, multiStore, dt, testnodes.NewTestRetrievalClientNode(testnodes.TestRetrievalClientNodeParams{}), &tut.TestPeerResolver{}, retrievalDs)
 	require.NoError(t, err)
 	shared_testutil.StartAndWaitForReady(ctx, t, retrievalClient)
 	deals, err := retrievalClient.ListDeals()

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -108,7 +108,7 @@ func requireSetupTestClientAndProvider(ctx context.Context, t *testing.T, payChA
 	testutil.StartAndWaitForReady(ctx, t, dt1)
 	require.NoError(t, err)
 	clientDs := namespace.Wrap(testData.Ds1, datastore.NewKey("/retrievals/client"))
-	client, err := retrievalimpl.NewClient(nw1, testData.MultiStore1, dt1, rcNode1, &tut.TestPeerResolver{}, clientDs, testData.RetrievalStoredCounter1)
+	client, err := retrievalimpl.NewClient(nw1, testData.MultiStore1, dt1, rcNode1, &tut.TestPeerResolver{}, clientDs)
 	require.NoError(t, err)
 	tut.StartAndWaitForReady(ctx, t, client)
 	nw2 := rmnet.NewFromLibp2pHost(testData.Host2, rmnet.RetryParameters(0, 0, 0, 0))
@@ -497,8 +497,7 @@ CurrentInterval: %d
 				clientStoreID = &id
 			}
 			// *** Retrieve the piece
-			did, err := client.Retrieve(bgCtx, payloadCID, rmParams, expectedTotal, retrievalPeer, clientPaymentChannel, retrievalPeer.Address, clientStoreID)
-			assert.Equal(t, did, retrievalmarket.DealID(0))
+			_, err = client.Retrieve(bgCtx, payloadCID, rmParams, expectedTotal, retrievalPeer, clientPaymentChannel, retrievalPeer.Address, clientStoreID)
 			require.NoError(t, err)
 
 			// verify that client subscribers will be notified of state changes
@@ -617,7 +616,7 @@ func setupClient(
 	require.NoError(t, err)
 	clientDs := namespace.Wrap(testData.Ds1, datastore.NewKey("/retrievals/client"))
 
-	client, err := retrievalimpl.NewClient(nw1, testData.MultiStore1, dt1, clientNode, &tut.TestPeerResolver{}, clientDs, testData.RetrievalStoredCounter1)
+	client, err := retrievalimpl.NewClient(nw1, testData.MultiStore1, dt1, clientNode, &tut.TestPeerResolver{}, clientDs)
 	return &createdChan, &newLaneAddr, &createdVoucher, clientNode, client, err
 }
 

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -154,8 +154,7 @@ func TestStorageRetrieval(t *testing.T) {
 	// *** Retrieve the piece
 
 	clientStoreID := sh.TestData.MultiStore1.Next()
-	did, err := rh.Client.Retrieve(bgCtx, sh.PayloadCid, rmParams, expectedTotal, retrievalPeer, *rh.ExpPaych, retrievalPeer.Address, &clientStoreID)
-	assert.Equal(t, did, retrievalmarket.DealID(0))
+	_, err = rh.Client.Retrieve(bgCtx, sh.PayloadCid, rmParams, expectedTotal, retrievalPeer, *rh.ExpPaych, retrievalPeer.Address, &clientStoreID)
 	require.NoError(t, err)
 
 	ctxTimeout, cancel := context.WithTimeout(bgCtx, 10*time.Second)
@@ -240,7 +239,7 @@ func newRetrievalHarness(ctx context.Context, t *testing.T, sh *testharness.Stor
 
 	nw1 := rmnet.NewFromLibp2pHost(sh.TestData.Host1, rmnet.RetryParameters(0, 0, 0, 0))
 	clientDs := namespace.Wrap(sh.TestData.Ds1, datastore.NewKey("/retrievals/client"))
-	client, err := retrievalimpl.NewClient(nw1, sh.TestData.MultiStore1, sh.DTClient, clientNode, sh.PeerResolver, clientDs, sh.TestData.RetrievalStoredCounter1)
+	client, err := retrievalimpl.NewClient(nw1, sh.TestData.MultiStore1, sh.DTClient, clientNode, sh.PeerResolver, clientDs)
 	require.NoError(t, err)
 	tut.StartAndWaitForReady(ctx, t, client)
 	payloadCID := deal.DataRef.Root

--- a/shared/timecounter.go
+++ b/shared/timecounter.go
@@ -1,0 +1,21 @@
+package shared
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// timeCounter is used to generate a monotonically increasing sequence.
+// It starts at the current time, then increments on each call to next.
+type TimeCounter struct {
+	counter uint64
+}
+
+func NewTimeCounter() *TimeCounter {
+	return &TimeCounter{counter: uint64(time.Now().UnixNano())}
+}
+
+func (tc *TimeCounter) Next() uint64 {
+	counter := atomic.AddUint64(&tc.counter, 1)
+	return counter
+}

--- a/shared/timecounter_test.go
+++ b/shared/timecounter_test.go
@@ -1,0 +1,48 @@
+package shared
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTimeCounter(t *testing.T) {
+	// Test that counter increases between restarts
+	tc1 := NewTimeCounter()
+	time.Sleep(time.Millisecond)
+	tc2 := NewTimeCounter()
+	tc1Next := tc1.Next()
+	tc2Next := tc2.Next()
+	if tc2Next <= tc1Next {
+		t.Fatal("counter should increase for each new counter generator", tc1Next, tc2Next)
+	}
+
+	// Test that the counter always increases
+	for i := 0; i < 100; i++ {
+		first := tc1.Next()
+		second := tc1.Next()
+		if second <= first {
+			t.Fatal("counter should increase monotonically", first, second)
+		}
+	}
+
+	// Test that the counter is thread-safe
+	count := 1000
+	threads := 20
+	counter := tc1.Next()
+	var wg sync.WaitGroup
+	for i := 0; i < threads; i++ {
+		wg.Add(1)
+		go func() {
+			for i := 0; i < count; i++ {
+				tc1.Next()
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	if tc1.Next() != counter+uint64(threads*count+1) {
+		t.Fatal("Next() is not thread safe")
+	}
+}

--- a/shared_testutil/mocknet.go
+++ b/shared_testutil/mocknet.go
@@ -34,34 +34,31 @@ import (
 
 	dtnet "github.com/filecoin-project/go-data-transfer/network"
 	"github.com/filecoin-project/go-multistore"
-	"github.com/filecoin-project/go-storedcounter"
 )
 
 type Libp2pTestData struct {
-	Ctx                     context.Context
-	Ds1                     datastore.Batching
-	Ds2                     datastore.Batching
-	RetrievalStoredCounter1 *storedcounter.StoredCounter
-	RetrievalStoredCounter2 *storedcounter.StoredCounter
-	Bs1                     bstore.Blockstore
-	Bs2                     bstore.Blockstore
-	MultiStore1             *multistore.MultiStore
-	MultiStore2             *multistore.MultiStore
-	DagService1             ipldformat.DAGService
-	DagService2             ipldformat.DAGService
-	DTNet1                  dtnet.DataTransferNetwork
-	DTNet2                  dtnet.DataTransferNetwork
-	DTStore1                datastore.Batching
-	DTStore2                datastore.Batching
-	DTTmpDir1               string
-	DTTmpDir2               string
-	Loader1                 ipld.Loader
-	Loader2                 ipld.Loader
-	Storer1                 ipld.Storer
-	Storer2                 ipld.Storer
-	Host1                   host.Host
-	Host2                   host.Host
-	OrigBytes               []byte
+	Ctx         context.Context
+	Ds1         datastore.Batching
+	Ds2         datastore.Batching
+	Bs1         bstore.Blockstore
+	Bs2         bstore.Blockstore
+	MultiStore1 *multistore.MultiStore
+	MultiStore2 *multistore.MultiStore
+	DagService1 ipldformat.DAGService
+	DagService2 ipldformat.DAGService
+	DTNet1      dtnet.DataTransferNetwork
+	DTNet2      dtnet.DataTransferNetwork
+	DTStore1    datastore.Batching
+	DTStore2    datastore.Batching
+	DTTmpDir1   string
+	DTTmpDir2   string
+	Loader1     ipld.Loader
+	Loader2     ipld.Loader
+	Storer1     ipld.Storer
+	Storer2     ipld.Storer
+	Host1       host.Host
+	Host2       host.Host
+	OrigBytes   []byte
 
 	MockNet mocknet.Mocknet
 }
@@ -105,9 +102,6 @@ func NewLibp2pTestData(ctx context.Context, t *testing.T) *Libp2pTestData {
 
 	testData.Ds1 = dss.MutexWrap(datastore.NewMapDatastore())
 	testData.Ds2 = dss.MutexWrap(datastore.NewMapDatastore())
-
-	testData.RetrievalStoredCounter1 = storedcounter.New(testData.Ds1, datastore.NewKey("nextDealID"))
-	testData.RetrievalStoredCounter2 = storedcounter.New(testData.Ds2, datastore.NewKey("nextDealID"))
 
 	// make a bstore and dag service
 	testData.Bs1 = bstore.NewBlockstore(testData.Ds1)


### PR DESCRIPTION
Fixes https://github.com/filecoin-project/go-fil-markets/issues/519

#### Background

Currently the ID used for a retrieval deal is a counter that increments starting from zero. The counter is stored in state, so if the state is wiped out, the counter restarts from zero.

This can cause issues when for example a client wipes their state, but the provider still has state about deals with IDs 0 - 10. The client's deals will fail until their deal ID counter rises above 10.

#### Solution

This PR changes the retrieval deal ID to be based on the current time, so that it will not repeat if the client's state is wiped.