### PR TITLE
fix first make error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ $(FFI_DEPS): .filecoin-build ;
 	git submodule update --init --recursive
 	@touch $@
 
-build: .filecoin-build .update-modules
+build: .update-modules .filecoin-build
 	go build ./...
 
 test: build


### PR DESCRIPTION
Clone and first make all report error:
```sh
➜  go-fil-markets git:(fix-makefile) make all
/Library/Developer/CommandLineTools/usr/bin/make -C ./extern/filecoin-ffi/ .install-filcrypto
make[1]: *** No rule to make target `.install-filcrypto'.  Stop.
make: *** [.filecoin-build] Error 2
```