### PR TITLE
remove wrong peer check in push deal validation

### DIFF
--- a/storagemarket/impl/requestvalidation/common.go
+++ b/storagemarket/impl/requestvalidation/common.go
@@ -15,7 +15,6 @@ import (
 // Will succeed only if:
 // - voucher has correct type
 // - voucher references an active deal
-// - referenced deal matches the client
 // - referenced deal matches the given base CID
 // - referenced deal is in an acceptable state
 func ValidatePush(
@@ -50,7 +49,6 @@ func ValidatePush(
 // Will succeed only if:
 // - voucher has correct type
 // - voucher references an active deal
-// - referenced deal matches the receiver (miner)
 // - referenced deal matches the given base CID
 // - referenced deal is in an acceptable state
 func ValidatePull(

--- a/storagemarket/impl/requestvalidation/common.go
+++ b/storagemarket/impl/requestvalidation/common.go
@@ -34,9 +34,6 @@ func ValidatePush(
 	if err != nil {
 		return xerrors.Errorf("Proposal CID %s: %w", dealVoucher.Proposal.String(), ErrNoDeal)
 	}
-	if deal.Client != sender {
-		return xerrors.Errorf("Deal Peer %s, Data Transfer Peer %s: %w", deal.Client.String(), sender.String(), ErrWrongPeer)
-	}
 
 	if !deal.Ref.Root.Equals(baseCid) {
 		return xerrors.Errorf("Deal Payload CID %s, Data Transfer CID %s: %w", deal.Proposal.PieceCID.String(), baseCid.String(), ErrWrongPiece)

--- a/storagemarket/impl/requestvalidation/common.go
+++ b/storagemarket/impl/requestvalidation/common.go
@@ -68,9 +68,6 @@ func ValidatePull(
 		return xerrors.Errorf("Proposal CID %s: %w", dealVoucher.Proposal.String(), ErrNoDeal)
 	}
 
-	if deal.Miner != receiver {
-		return xerrors.Errorf("Deal Peer %s, Data Transfer Peer %s: %w", deal.Miner.String(), receiver.String(), ErrWrongPeer)
-	}
 	if !deal.DataRef.Root.Equals(baseCid) {
 		return xerrors.Errorf("Deal Payload CID %s, Data Transfer CID %s: %w", deal.Proposal.PieceCID.String(), baseCid.String(), ErrWrongPiece)
 	}

--- a/storagemarket/impl/requestvalidation/request_validation_test.go
+++ b/storagemarket/impl/requestvalidation/request_validation_test.go
@@ -234,21 +234,6 @@ func AssertValidatesPulls(t *testing.T, validator datatransfer.RequestValidator,
 			t.Fatal("Pull should fail if there is no deal stored")
 		}
 	})
-	t.Run("ValidatePull fails wrong client", func(t *testing.T) {
-		otherMiner := peer.ID("otherminer")
-		clientDeal, err := newClientDeal(otherMiner, storagemarket.StorageDealProposalAccepted)
-		if err != nil {
-			t.Fatal("error creating client deal")
-		}
-		if err := state.Begin(clientDeal.ProposalCid, &clientDeal); err != nil {
-			t.Fatal("deal tracking failed")
-		}
-		payloadCid := clientDeal.DataRef.Root
-		_, err = validator.ValidatePull(false, datatransfer.ChannelID{}, receiver, &rv.StorageDataTransferVoucher{clientDeal.ProposalCid}, payloadCid, nil)
-		if !xerrors.Is(err, rv.ErrWrongPeer) {
-			t.Fatal("Pull should fail if miner address is incorrect")
-		}
-	})
 	t.Run("ValidatePull fails wrong piece ref", func(t *testing.T) {
 		clientDeal, err := newClientDeal(receiver, storagemarket.StorageDealProposalAccepted)
 		if err != nil {

--- a/storagemarket/impl/requestvalidation/request_validation_test.go
+++ b/storagemarket/impl/requestvalidation/request_validation_test.go
@@ -176,21 +176,6 @@ func AssertPushValidator(t *testing.T, validator datatransfer.RequestValidator, 
 			t.Fatal("Push should fail if there is no deal stored")
 		}
 	})
-	t.Run("ValidatePush fails wrong miner", func(t *testing.T) {
-		otherClient := peer.ID("otherclient")
-		minerDeal, err := newMinerDeal(otherClient, storagemarket.StorageDealProposalAccepted)
-		if err != nil {
-			t.Fatal("error creating client deal")
-		}
-		if err := state.Begin(minerDeal.ProposalCid, &minerDeal); err != nil {
-			t.Fatal("deal tracking failed")
-		}
-		ref := minerDeal.Ref
-		_, err = validator.ValidatePush(false, datatransfer.ChannelID{}, sender, &rv.StorageDataTransferVoucher{minerDeal.ProposalCid}, ref.Root, nil)
-		if !xerrors.Is(err, rv.ErrWrongPeer) {
-			t.Fatal("Push should fail if miner address is incorrect")
-		}
-	})
 	t.Run("ValidatePush fails wrong piece ref", func(t *testing.T) {
 		minerDeal, err := newMinerDeal(sender, storagemarket.StorageDealProposalAccepted)
 		if err != nil {


### PR DESCRIPTION
We should not have this check, restricting data transfer to only the specific peer who made the deal cuts out a lot of potential architectures (and is silly anyways given the ephemeral nature of libp2p peer IDs). Knowledge of the proposal CID and the miners desire of the data being pushed in the first place should be validation enough.