### PR TITLE
Revert "refactor: pass deal proposal instead of deal ID to OnDealExpiredOrSlashed (#476)"

### DIFF
--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -309,7 +309,7 @@ func WaitForDealCompletion(ctx fsm.Context, environment ClientDealEnvironment, d
 		}
 	}
 
-	if err := node.OnDealExpiredOrSlashed(ctx.Context(), *deal.PublishMessage, deal.Proposal, expiredCb, slashedCb); err != nil {
+	if err := node.OnDealExpiredOrSlashed(ctx.Context(), deal.DealID, expiredCb, slashedCb); err != nil {
 		return ctx.Trigger(storagemarket.ClientEventDealCompletionFailed, err)
 	}
 

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -610,7 +610,6 @@ func makeExecutor(ctx context.Context,
 		dealState, err := tut.MakeTestClientDeal(initialState, clientDealProposal, envParams.manualTransfer)
 		assert.NoError(t, err)
 		dealState.AddFundsCid = &tut.GenerateCids(1)[0]
-		dealState.PublishMessage = &tut.GenerateCids(1)[0]
 		dealState.FastRetrieval = dealParams.fastRetrieval
 		dealState.TransferChannelID = &datatransfer.ChannelID{}
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -507,7 +507,7 @@ func WaitForDealCompletion(ctx fsm.Context, environment ProviderDealEnvironment,
 		}
 	}
 
-	if err := node.OnDealExpiredOrSlashed(ctx.Context(), *deal.PublishCid, deal.Proposal, expiredCb, slashedCb); err != nil {
+	if err := node.OnDealExpiredOrSlashed(ctx.Context(), deal.DealID, expiredCb, slashedCb); err != nil {
 		return ctx.Trigger(storagemarket.ProviderEventDealCompletionFailed, err)
 	}
 

--- a/storagemarket/nodes.go
+++ b/storagemarket/nodes.go
@@ -67,7 +67,7 @@ type StorageCommon interface {
 	OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid *cid.Cid, cb DealSectorCommittedCallback) error
 
 	// OnDealExpiredOrSlashed registers callbacks to be called when the deal expires or is slashed
-	OnDealExpiredOrSlashed(ctx context.Context, publishCid cid.Cid, proposal market.DealProposal, onDealExpired DealExpiredCallback, onDealSlashed DealSlashedCallback) error
+	OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired DealExpiredCallback, onDealSlashed DealSlashedCallback) error
 }
 
 // PackingResult returns information about how a deal was put into a sector

--- a/storagemarket/testnodes/testnodes.go
+++ b/storagemarket/testnodes/testnodes.go
@@ -231,7 +231,7 @@ func (n *FakeCommonNode) OnDealSectorCommitted(ctx context.Context, provider add
 }
 
 // OnDealExpiredOrSlashed simulates waiting for a deal to be expired or slashed, but provides stubbed behavior
-func (n *FakeCommonNode) OnDealExpiredOrSlashed(ctx context.Context, publishCid cid.Cid, proposal market.DealProposal, onDealExpired storagemarket.DealExpiredCallback, onDealSlashed storagemarket.DealSlashedCallback) error {
+func (n *FakeCommonNode) OnDealExpiredOrSlashed(ctx context.Context, dealID abi.DealID, onDealExpired storagemarket.DealExpiredCallback, onDealSlashed storagemarket.DealSlashedCallback) error {
 	if n.DelayFakeCommonNode.OnDealExpiredOrSlashed {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This reverts commit 2e06ce3307ed3a7c23f4abba907d7020c1f732e7.

I wrote up a quick test (possibly buggy) on the Lotus side (see https://github.com/filecoin-project/lotus/pull/5431#issuecomment-899768787), and unfortunately it didn't produce the results I expected.

Given that this is on master and we need to make a release to get the dagstore changes out, I had two options:

1. Merge the lotus change anyway without tests -- which made me feel uneasy.
2. Back out this change from master and make a 1.8.0 release this module without it.

I'm sad to choose 2, but I prefer for something to stay broken in master for a few more days, than to possibly introduce other unintended side-effects.