### PR TITLE
Safe reader closer for PieceReaders

### DIFF
--- a/storagemarket/impl/providerstates/safereadercloser.go
+++ b/storagemarket/impl/providerstates/safereadercloser.go
@@ -1,0 +1,40 @@
+package providerstates
+
+import (
+	"io"
+	"sync"
+
+	"golang.org/x/xerrors"
+)
+
+type safeReaderCloser struct {
+	r io.Reader
+	c io.Closer
+
+	lk sync.Mutex
+	isClosed bool
+}
+
+func (s *safeReaderCloser) Read(p []byte) (int, error) {
+	s.lk.Lock()
+
+	if s.isClosed {
+		s.lk.Unlock()
+		return 0, xerrors.New("read from closed reader")
+	}
+	s.lk.Unlock()
+
+	return s.r.Read(p)
+}
+
+func (s *safeReaderCloser) Close() error {
+	s.lk.Lock()
+	defer s.lk.Unlock()
+
+	if !s.isClosed {
+		s.isClosed = true
+		return s.c.Close()
+	}
+
+	return nil
+}

--- a/storagemarket/impl/providerstates/safereadercloser.go
+++ b/storagemarket/impl/providerstates/safereadercloser.go
@@ -11,7 +11,7 @@ type safeReaderCloser struct {
 	r io.Reader
 	c io.Closer
 
-	lk sync.Mutex
+	lk       sync.Mutex
 	isClosed bool
 }
 

--- a/storagemarket/impl/providerstates/safereadercloser_test.go
+++ b/storagemarket/impl/providerstates/safereadercloser_test.go
@@ -1,0 +1,31 @@
+package providerstates
+
+import (
+	"strings"
+	"testing"
+
+	"io/ioutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeReaderCloser(t *testing.T) {
+	r := strings.NewReader("test")
+
+	sr := &safeReaderCloser{
+		r: r,
+		c: ioutil.NopCloser(r),
+	}
+
+	// valid read
+	bz := make([]byte, 3)
+	n, err := sr.Read(bz)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "tes", string(bz))
+
+	// read after close
+	require.NoError(t, sr.Close())
+	_, err = sr.Read(make([]byte, 1))
+	require.Contains(t, err.Error(), "read from closed reader")
+}


### PR DESCRIPTION
For https://github.com/filecoin-project/lotus/issues/7111.

As per @magik6k there is a small edge case in the JSON-RPC magic that can cause a read from the piece reader even after it's been closed by us after the AddPiece call returns. We should handle that gracefully.