### PR TITLE
close file descriptors + log piece handoff to sealing subsystem

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -336,6 +336,7 @@ func (p *Provider) ImportDataForDeal(ctx context.Context, propCid cid.Cid, data 
 			uint64(d.Proposal.PieceSize),
 		)
 		if err != nil {
+			cleanup()
 			return err
 		}
 		pieceCid, _ = commcid.DataCommitmentV1ToCID(rawPaddedCommp)
@@ -348,9 +349,7 @@ func (p *Provider) ImportDataForDeal(ctx context.Context, propCid cid.Cid, data 
 	}
 
 	log.Debugw("will fire ProviderEventVerifiedData for imported file", "propCid", propCid)
-	if err := tempfi.Close(); err != nil {
-		log.Errorw("failed to close temp imported local file", "propCid", propCid, "err", err)
-	}
+
 	return p.deals.Send(propCid, storagemarket.ProviderEventVerifiedData, tempfi.Path(), filestore.Path(""))
 }
 

--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -301,7 +301,7 @@ func (p *Provider) ImportDataForDeal(ctx context.Context, propCid cid.Cid, data 
 		cleanup()
 		return xerrors.Errorf("importing deal data failed: %w", err)
 	}
-	log.Debugw("finished copying imported file to local file", propCid, "propCid")
+	log.Debugw("finished copying imported file to local file", "propCid", propCid)
 
 	_ = n // TODO: verify n?
 
@@ -318,14 +318,14 @@ func (p *Provider) ImportDataForDeal(ctx context.Context, propCid cid.Cid, data 
 		cleanup()
 		return xerrors.Errorf("failed to determine proof type: %w", err)
 	}
-	log.Debugw("fetched proof type", propCid, "propCid")
+	log.Debugw("fetched proof type", "propCid", propCid)
 
 	pieceCid, err := generatePieceCommitment(proofType, tempfi, carSize)
 	if err != nil {
 		cleanup()
 		return xerrors.Errorf("failed to generate commP: %w", err)
 	}
-	log.Debugw("generated pieceCid for imported file", propCid, "propCid")
+	log.Debugw("generated pieceCid for imported file", "propCid", propCid)
 
 	if carSizePadded := padreader.PaddedSize(carSize).Padded(); carSizePadded < d.Proposal.PieceSize {
 		// need to pad up!

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -313,6 +313,10 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 		// Hand the deal off to the process that adds it to a sector
 		log.Infow("handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 		packingInfo, err = handoffDeal(ctx.Context(), environment, deal, file, uint64(file.Size()))
+		if err := file.Close(); err != nil {
+			log.Errorw("failed to close imported CAR file", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid, "err", err)
+		}
+
 		if err != nil {
 			err = xerrors.Errorf("packing piece at path %s: %w", deal.PiecePath, err)
 			return ctx.Trigger(storagemarket.ProviderEventDealHandoffFailed, err)

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -338,7 +338,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 		if err := v2r.Close(); err != nil {
 			return ctx.Trigger(storagemarket.ProviderEventDealHandoffFailed, xerrors.Errorf("failed to close CARv2 reader: %w", err))
 		}
-		log.Infow("closed CARv1 reader after handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
+		log.Infow("closed car datareader after handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 		if packingErr != nil {
 			err = xerrors.Errorf("packing piece %s: %w", deal.Ref.PieceCid, packingErr)
 			return ctx.Trigger(storagemarket.ProviderEventDealHandoffFailed, err)

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -334,6 +334,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 		if err := v2r.Close(); err != nil {
 			return ctx.Trigger(storagemarket.ProviderEventDealHandoffFailed, xerrors.Errorf("failed to close CARv2 reader: %w", err))
 		}
+		log.Infow("closed CARv1 reader after handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 		if packingErr != nil {
 			err = xerrors.Errorf("packing piece %s: %w", deal.Ref.PieceCid, packingErr)
 			return ctx.Trigger(storagemarket.ProviderEventDealHandoffFailed, err)

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -311,6 +311,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 		carFilePath = string(file.OsPath())
 
 		// Hand the deal off to the process that adds it to a sector
+		log.Infow("handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 		packingInfo, err = handoffDeal(ctx.Context(), environment, deal, file, uint64(file.Size()))
 		if err != nil {
 			err = xerrors.Errorf("packing piece at path %s: %w", deal.PiecePath, err)
@@ -327,6 +328,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 
 		// Hand the deal off to the process that adds it to a sector
 		var packingErr error
+		log.Infow("handing off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 		packingInfo, packingErr = handoffDeal(ctx.Context(), environment, deal, v2r.DataReader(), v2r.Header.DataSize)
 		// Close the reader as we're done reading from it.
 		if err := v2r.Close(); err != nil {
@@ -351,6 +353,7 @@ func HandoffDeal(ctx fsm.Context, environment ProviderDealEnvironment, deal stor
 		log.Error(err)
 	}
 
+	log.Infow("successfully handed off deal to sealing subsystem", "pieceCid", deal.Proposal.PieceCID, "proposalCid", deal.ProposalCid)
 	return ctx.Trigger(storagemarket.ProviderEventDealHandedOff)
 }
 


### PR DESCRIPTION
To debug https://github.com/filecoin-project/lotus/issues/7144.

- Log import of a file for an offline deal.
- Log the handing off a Piece to the sealing subsystem to add it to a sector.
- Add some missing file closes.