### PR TITLE
rm go-multistore dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/filecoin-project/go-ds-versioning v0.1.0
 	github.com/filecoin-project/go-fil-commcid v0.1.0
 	github.com/filecoin-project/go-fil-commp-hashhash v0.1.0
-	github.com/filecoin-project/go-multistore v0.0.3
 	github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1
 	github.com/filecoin-project/go-state-types v0.1.1-0.20210506134452-99b279731c48
 	github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe

--- a/go.sum
+++ b/go.sum
@@ -173,7 +173,6 @@ github.com/filecoin-project/go-hamt-ipld v0.1.5 h1:uoXrKbCQZ49OHpsTCkrThPNelC4W3
 github.com/filecoin-project/go-hamt-ipld v0.1.5/go.mod h1:6Is+ONR5Cd5R6XZoCse1CWaXZc0Hdb/JeX+EQCQzX24=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0 h1:b3UDemBYN2HNfk3KOXNuxgTTxlWi3xVvbQP0IT38fvM=
 github.com/filecoin-project/go-hamt-ipld/v2 v2.0.0/go.mod h1:7aWZdaQ1b16BVoQUYR+eEvrDCGJoPLxFpDynFjYfBjI=
-github.com/filecoin-project/go-multistore v0.0.3 h1:vaRBY4YiA2UZFPK57RNuewypB8u0DzzQwqsL0XarpnI=
 github.com/filecoin-project/go-multistore v0.0.3/go.mod h1:kaNqCC4IhU4B1uyr7YWFHd23TL4KM32aChS0jNkyUvQ=
 github.com/filecoin-project/go-padreader v0.0.0-20200903213702-ed5fae088b20/go.mod h1:mPn+LRRd5gEKNAtc+r3ScpW2JRU/pj4NBKdADYWHiak=
 github.com/filecoin-project/go-padreader v0.0.0-20210723183308-812a16dc01b1 h1:0BogtftbcgyBx4lP2JWM00ZK7/pXmgnrDqKp9aLTgVs=
@@ -316,13 +315,11 @@ github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e h1:3YKHER4n
 github.com/hannahhoward/go-pubsub v0.0.0-20200423002714-8d62886cc36e/go.mod h1:I8h3MITA53gN9OnWGCgaMa0JWVRdXthWw4M3CPM54OY=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=

--- a/retrievalmarket/impl/client_test.go
+++ b/retrievalmarket/impl/client_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 
@@ -370,7 +369,7 @@ func TestMigrations(t *testing.T) {
 	paymentIntervals := make([]uint64, numDeals)
 	paymentIntervalIncreases := make([]uint64, numDeals)
 	unsealPrices := make([]abi.TokenAmount, numDeals)
-	storeIDs := make([]*multistore.StoreID, numDeals)
+	storeIDs := make([]*uint64, numDeals)
 	channelIDs := make([]datatransfer.ChannelID, numDeals)
 	lastPaymentRequesteds := make([]bool, numDeals)
 	allBlocksReceiveds := make([]bool, numDeals)
@@ -401,7 +400,7 @@ func TestMigrations(t *testing.T) {
 		paymentIntervals[i] = rand.Uint64()
 		paymentIntervalIncreases[i] = rand.Uint64()
 		unsealPrices[i] = big.NewInt(rand.Int63())
-		storeID := multistore.StoreID(rand.Uint64())
+		storeID := rand.Uint64()
 		storeIDs[i] = &storeID
 		senders[i] = tut.GeneratePeers(1)[0]
 		channelIDs[i] = datatransfer.ChannelID{

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	spect "github.com/filecoin-project/specs-actors/support/testing"
@@ -1083,7 +1082,7 @@ func TestProviderMigrations(t *testing.T) {
 	paymentIntervals := make([]uint64, numDeals)
 	paymentIntervalIncreases := make([]uint64, numDeals)
 	unsealPrices := make([]abi.TokenAmount, numDeals)
-	storeIDs := make([]multistore.StoreID, numDeals)
+	storeIDs := make([]uint64, numDeals)
 	channelIDs := make([]datatransfer.ChannelID, numDeals)
 	receivers := make([]peer.ID, numDeals)
 	totalSents := make([]uint64, numDeals)
@@ -1109,7 +1108,7 @@ func TestProviderMigrations(t *testing.T) {
 		paymentIntervals[i] = rand.Uint64()
 		paymentIntervalIncreases[i] = rand.Uint64()
 		unsealPrices[i] = big.NewInt(rand.Int63())
-		storeIDs[i] = multistore.StoreID(rand.Uint64())
+		storeIDs[i] = rand.Uint64()
 		receivers[i] = tut.GeneratePeers(1)[0]
 		channelIDs[i] = datatransfer.ChannelID{
 			Responder: selfPeer,

--- a/retrievalmarket/migrations/maptypes/maptypes.go
+++ b/retrievalmarket/migrations/maptypes/maptypes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 
 	"github.com/filecoin-project/go-fil-markets/piecestore"
@@ -18,7 +17,7 @@ import (
 // Version 1 of the ClientDealState
 type ClientDealState1 struct {
 	retrievalmarket.DealProposal
-	StoreID              *multistore.StoreID
+	StoreID              *uint64
 	ChannelID            datatransfer.ChannelID
 	LastPaymentRequested bool
 	AllBlocksReceived    bool
@@ -43,7 +42,7 @@ type ClientDealState1 struct {
 // Version 1 of the ProviderDealState
 type ProviderDealState1 struct {
 	retrievalmarket.DealProposal
-	StoreID         multistore.StoreID
+	StoreID         uint64
 	ChannelID       datatransfer.ChannelID
 	PieceInfo       *piecestore.PieceInfo
 	Status          retrievalmarket.DealStatus

--- a/retrievalmarket/migrations/maptypes/maptypes_cbor_gen.go
+++ b/retrievalmarket/migrations/maptypes/maptypes_cbor_gen.go
@@ -10,7 +10,6 @@ import (
 
 	piecestore "github.com/filecoin-project/go-fil-markets/piecestore"
 	retrievalmarket "github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	multistore "github.com/filecoin-project/go-multistore"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
@@ -49,7 +48,7 @@ func (t *ClientDealState1) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 	if len("StoreID") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"StoreID\" was too long")
 	}
@@ -440,7 +439,7 @@ func (t *ClientDealState1) UnmarshalCBOR(r io.Reader) error {
 				}
 
 			}
-			// t.StoreID (multistore.StoreID) (uint64)
+			// t.StoreID (uint64) (uint64)
 		case "StoreID":
 
 			{
@@ -460,7 +459,7 @@ func (t *ClientDealState1) UnmarshalCBOR(r io.Reader) error {
 					if maj != cbg.MajUnsignedInt {
 						return fmt.Errorf("wrong type for uint64 field")
 					}
-					typed := multistore.StoreID(extra)
+					typed := uint64(extra)
 					t.StoreID = &typed
 				}
 
@@ -760,7 +759,7 @@ func (t *ProviderDealState1) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 	if len("StoreID") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"StoreID\" was too long")
 	}
@@ -979,7 +978,7 @@ func (t *ProviderDealState1) UnmarshalCBOR(r io.Reader) error {
 				}
 
 			}
-			// t.StoreID (multistore.StoreID) (uint64)
+			// t.StoreID (uint64) (uint64)
 		case "StoreID":
 
 			{
@@ -991,7 +990,7 @@ func (t *ProviderDealState1) UnmarshalCBOR(r io.Reader) error {
 				if maj != cbg.MajUnsignedInt {
 					return fmt.Errorf("wrong type for uint64 field")
 				}
-				t.StoreID = multistore.StoreID(extra)
+				t.StoreID = uint64(extra)
 
 			}
 			// t.ChannelID (datatransfer.ChannelID) (struct)

--- a/retrievalmarket/migrations/migrations.go
+++ b/retrievalmarket/migrations/migrations.go
@@ -2,14 +2,13 @@ package migrations
 
 import (
 	"github.com/ipfs/go-cid"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
 	cbg "github.com/whyrusleeping/cbor-gen"
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	versioning "github.com/filecoin-project/go-ds-versioning/pkg"
 	"github.com/filecoin-project/go-ds-versioning/pkg/versioned"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
 
@@ -30,7 +29,7 @@ type PaymentInfo0 struct {
 // ClientDealState0 is version 0 of ClientDealState
 type ClientDealState0 struct {
 	DealProposal0
-	StoreID              *multistore.StoreID
+	StoreID              *uint64
 	ChannelID            datatransfer.ChannelID
 	LastPaymentRequested bool
 	AllBlocksReceived    bool
@@ -54,7 +53,7 @@ type ClientDealState0 struct {
 // ProviderDealState0 is version 0 of ProviderDealState
 type ProviderDealState0 struct {
 	DealProposal0
-	StoreID         multistore.StoreID
+	StoreID         uint64
 	ChannelID       datatransfer.ChannelID
 	PieceInfo       *piecemigrations.PieceInfo0
 	Status          retrievalmarket.DealStatus

--- a/retrievalmarket/migrations/migrations_cbor_gen.go
+++ b/retrievalmarket/migrations/migrations_cbor_gen.go
@@ -10,7 +10,6 @@ import (
 
 	migrations "github.com/filecoin-project/go-fil-markets/piecestore/migrations"
 	retrievalmarket "github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	multistore "github.com/filecoin-project/go-multistore"
 	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -827,7 +826,7 @@ func (t *ClientDealState0) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -983,7 +982,7 @@ func (t *ClientDealState0) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	{
 
@@ -1002,7 +1001,7 @@ func (t *ClientDealState0) UnmarshalCBOR(r io.Reader) error {
 			if maj != cbg.MajUnsignedInt {
 				return fmt.Errorf("wrong type for uint64 field")
 			}
-			typed := multistore.StoreID(extra)
+			typed := uint64(extra)
 			t.StoreID = &typed
 		}
 
@@ -1251,7 +1250,7 @@ func (t *ProviderDealState0) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajUnsignedInt, uint64(t.StoreID)); err != nil {
 		return err
@@ -1344,7 +1343,7 @@ func (t *ProviderDealState0) UnmarshalCBOR(r io.Reader) error {
 		}
 
 	}
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	{
 
@@ -1355,7 +1354,7 @@ func (t *ProviderDealState0) UnmarshalCBOR(r io.Reader) error {
 		if maj != cbg.MajUnsignedInt {
 			return fmt.Errorf("wrong type for uint64 field")
 		}
-		t.StoreID = multistore.StoreID(extra)
+		t.StoreID = uint64(extra)
 
 	}
 	// t.ChannelID (datatransfer.ChannelID) (struct)

--- a/retrievalmarket/migrations/migrations_test.go
+++ b/retrievalmarket/migrations/migrations_test.go
@@ -12,7 +12,6 @@ import (
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	versionedfsm "github.com/filecoin-project/go-ds-versioning/pkg/fsm"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/go-statemachine/fsm"
@@ -30,7 +29,7 @@ func TestClientStateMigration(t *testing.T) {
 
 	// Create a v0 client deal state
 	dealID := retrievalmarket.DealID(1)
-	storeID := multistore.StoreID(1)
+	storeID := uint64(1)
 	dummyCid, err := cid.Parse("bafkqaaa")
 	require.NoError(t, err)
 	dealState := ClientDealState0{
@@ -136,7 +135,7 @@ func TestProviderStateMigration(t *testing.T) {
 
 	// Create a v0 provider deal state
 	dealID := retrievalmarket.DealID(1)
-	storeID := multistore.StoreID(1)
+	storeID := uint64(1)
 	dummyCid, err := cid.Parse("bafkqaaa")
 	require.NoError(t, err)
 	dealState := ProviderDealState0{

--- a/retrievalmarket/types.go
+++ b/retrievalmarket/types.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/paych"
@@ -46,7 +45,7 @@ type PaymentInfo struct {
 // of a retrieval client
 type ClientDealState struct {
 	DealProposal
-	StoreID *multistore.StoreID
+	StoreID *uint64
 	// Set when the data transfer is started
 	ChannelID            *datatransfer.ChannelID
 	LastPaymentRequested bool
@@ -77,7 +76,7 @@ func (deal *ClientDealState) NextInterval() uint64 {
 // of a retrieval provider
 type ProviderDealState struct {
 	DealProposal
-	StoreID multistore.StoreID
+	StoreID uint64
 
 	ChannelID       *datatransfer.ChannelID
 	PieceInfo       *piecestore.PieceInfo

--- a/retrievalmarket/types_cbor_gen.go
+++ b/retrievalmarket/types_cbor_gen.go
@@ -10,7 +10,6 @@ import (
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	piecestore "github.com/filecoin-project/go-fil-markets/piecestore"
-	multistore "github.com/filecoin-project/go-multistore"
 	paych "github.com/filecoin-project/specs-actors/actors/builtin/paych"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -1290,7 +1289,7 @@ func (t *ClientDealState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 	if len("StoreID") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"StoreID\" was too long")
 	}
@@ -1681,7 +1680,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 				}
 
 			}
-			// t.StoreID (multistore.StoreID) (uint64)
+			// t.StoreID (uint64) (uint64)
 		case "StoreID":
 
 			{
@@ -1701,7 +1700,7 @@ func (t *ClientDealState) UnmarshalCBOR(r io.Reader) error {
 					if maj != cbg.MajUnsignedInt {
 						return fmt.Errorf("wrong type for uint64 field")
 					}
-					typed := multistore.StoreID(extra)
+					typed := uint64(extra)
 					t.StoreID = &typed
 				}
 
@@ -2011,7 +2010,7 @@ func (t *ProviderDealState) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 	if len("StoreID") > cbg.MaxLength {
 		return xerrors.Errorf("Value in field \"StoreID\" was too long")
 	}
@@ -2230,7 +2229,7 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 				}
 
 			}
-			// t.StoreID (multistore.StoreID) (uint64)
+			// t.StoreID (uint64) (uint64)
 		case "StoreID":
 
 			{
@@ -2242,7 +2241,7 @@ func (t *ProviderDealState) UnmarshalCBOR(r io.Reader) error {
 				if maj != cbg.MajUnsignedInt {
 					return fmt.Errorf("wrong type for uint64 field")
 				}
-				t.StoreID = multistore.StoreID(extra)
+				t.StoreID = uint64(extra)
 
 			}
 			// t.ChannelID (datatransfer.ChannelID) (struct)

--- a/storagemarket/impl/client_test.go
+++ b/storagemarket/impl/client_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/filecoin-project/go-address"
 	cborutil "github.com/filecoin-project/go-cbor-util"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -61,7 +60,7 @@ func TestClient_Migrations(t *testing.T) {
 	messages := make([]string, numDeals)
 	publishMessages := make([]*cid.Cid, numDeals)
 	fastRetrievals := make([]bool, numDeals)
-	storeIDs := make([]*multistore.StoreID, numDeals)
+	storeIDs := make([]*uint64, numDeals)
 	fundsReserveds := make([]abi.TokenAmount, numDeals)
 	creationTimes := make([]cbg.CborTime, numDeals)
 
@@ -71,7 +70,7 @@ func TestClient_Migrations(t *testing.T) {
 		require.NoError(t, err)
 		proposalCids[i] = proposalNd.Cid()
 		payloadCids[i] = shared_testutil.GenerateCids(1)[0]
-		storeID := multistore.StoreID(rand.Uint64())
+		storeID := rand.Uint64()
 		storeIDs[i] = &storeID
 		messages[i] = string(shared_testutil.RandomBytes(20))
 		fundsReserveds[i] = big.NewInt(rand.Int63())

--- a/storagemarket/impl/provider_test.go
+++ b/storagemarket/impl/provider_test.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/exp/rand"
 
 	cborutil "github.com/filecoin-project/go-cbor-util"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/big"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -50,7 +49,7 @@ func TestProvider_Migrations(t *testing.T) {
 	messages := make([]string, numDeals)
 	publishCids := make([]*cid.Cid, numDeals)
 	fastRetrievals := make([]bool, numDeals)
-	storeIDs := make([]*multistore.StoreID, numDeals)
+	storeIDs := make([]*uint64, numDeals)
 	fundsReserveds := make([]abi.TokenAmount, numDeals)
 	creationTimes := make([]cbg.CborTime, numDeals)
 	availableForRetrievals := make([]bool, numDeals)
@@ -63,7 +62,7 @@ func TestProvider_Migrations(t *testing.T) {
 		require.NoError(t, err)
 		proposalCids[i] = proposalNd.Cid()
 		payloadCids[i] = shared_testutil.GenerateCids(1)[0]
-		storeID := multistore.StoreID(rand.Uint64())
+		storeID := rand.Uint64()
 		storeIDs[i] = &storeID
 		messages[i] = string(shared_testutil.RandomBytes(20))
 		fundsReserveds[i] = big.NewInt(rand.Int63())

--- a/storagemarket/migrations/migrations.go
+++ b/storagemarket/migrations/migrations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	versioning "github.com/filecoin-project/go-ds-versioning/pkg"
 	"github.com/filecoin-project/go-ds-versioning/pkg/versioned"
-	"github.com/filecoin-project/go-multistore"
 	"github.com/filecoin-project/go-state-types/abi"
 	"github.com/filecoin-project/go-state-types/crypto"
 	"github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -60,7 +59,7 @@ type MinerDeal0 struct {
 	SlashEpoch            abi.ChainEpoch
 	FastRetrieval         bool
 	Message               string
-	StoreID               *multistore.StoreID
+	StoreID               *uint64
 	FundsReserved         abi.TokenAmount
 	Ref                   *DataRef0
 	AvailableForRetrieval bool
@@ -85,7 +84,7 @@ type ClientDeal0 struct {
 	PollRetryCount uint64
 	PollErrorCount uint64
 	FastRetrieval  bool
-	StoreID        *multistore.StoreID
+	StoreID        *uint64
 	FundsReserved  abi.TokenAmount
 	CreationTime   cbg.CborTime
 }

--- a/storagemarket/migrations/migrations_cbor_gen.go
+++ b/storagemarket/migrations/migrations_cbor_gen.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 
 	filestore "github.com/filecoin-project/go-fil-markets/filestore"
-	multistore "github.com/filecoin-project/go-multistore"
 	abi "github.com/filecoin-project/go-state-types/abi"
 	crypto "github.com/filecoin-project/go-state-types/crypto"
 	market "github.com/filecoin-project/specs-actors/actors/builtin/market"
@@ -146,7 +145,7 @@ func (t *ClientDeal0) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -399,7 +398,7 @@ func (t *ClientDeal0) UnmarshalCBOR(r io.Reader) error {
 	default:
 		return fmt.Errorf("booleans are either major type 7, value 20 or 21 (got %d)", extra)
 	}
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	{
 
@@ -418,7 +417,7 @@ func (t *ClientDeal0) UnmarshalCBOR(r io.Reader) error {
 			if maj != cbg.MajUnsignedInt {
 				return fmt.Errorf("wrong type for uint64 field")
 			}
-			typed := multistore.StoreID(extra)
+			typed := uint64(extra)
 			t.StoreID = &typed
 		}
 
@@ -574,7 +573,7 @@ func (t *MinerDeal0) MarshalCBOR(w io.Writer) error {
 		return err
 	}
 
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	if t.StoreID == nil {
 		if _, err := w.Write(cbg.CborNull); err != nil {
@@ -803,7 +802,7 @@ func (t *MinerDeal0) UnmarshalCBOR(r io.Reader) error {
 
 		t.Message = string(sval)
 	}
-	// t.StoreID (multistore.StoreID) (uint64)
+	// t.StoreID (uint64) (uint64)
 
 	{
 
@@ -822,7 +821,7 @@ func (t *MinerDeal0) UnmarshalCBOR(r io.Reader) error {
 			if maj != cbg.MajUnsignedInt {
 				return fmt.Errorf("wrong type for uint64 field")
 			}
-			typed := multistore.StoreID(extra)
+			typed := uint64(extra)
 			t.StoreID = &typed
 		}
 


### PR DESCRIPTION
Farewell! Following the adoption of the dagstore, this library is no longer used.

`StoreID` fields have been kept for backwards compatibility and reset to uint64 (which should serialize identically to multistore.StoreID) but they're really unused.