### PR TITLE
release: v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # go-fil-markets changelog
 
+# go-fil-markets v1.11.0
+
+- Remove go-multistore dependency
+- update go-data-transfer to v1.9.0
+- Revert "Pass deal proposal instead of deal ID to OnDealExpiredOrSlashed (#476) ([filecoin-project/go-fil-markets#476](https://github.com/filecoin-project/go-fil-markets/pull/476))"
+
 # go-fil-markets v1.9.0
 
 - "Pass deal proposal instead of deal ID to OnDealExpiredOrSlashed (#616) ([filecoin-project/go-fil-markets#616](https://github.com/filecoin-project/go-fil-markets/pull/616))"
@@ -7,7 +13,6 @@
 # go-fil-markets v1.8.0
 
 - Migrate to DAG store + CARv2 blockstores for storage and retrieval (#576) ([filecoin-project/go-fil-markets#576](https://github.com/filecoin-project/go-fil-markets/pull/576))
-- Revert "Pass deal proposal instead of deal ID to OnDealExpiredOrSlashed (#476) ([filecoin-project/go-fil-markets#476](https://github.com/filecoin-project/go-fil-markets/pull/476))"
 
 # go-fil-markets v1.7.0
 


### PR DESCRIPTION
# go-fil-markets v1.11.0

- Remove go-multistore dependency
- update go-data-transfer to v1.9.0
- Revert "Pass deal proposal instead of deal ID to OnDealExpiredOrSlashed (#476) ([filecoin-project/go-fil-markets#476](https://github.com/filecoin-project/go-fil-markets/pull/476))"
