### PR TITLE
Expose MaxTraversalLinks option for generating CommP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.3.0
 	github.com/ipfs/go-merkledag v0.3.2
 	github.com/ipfs/go-unixfs v0.2.6
-	github.com/ipld/go-car v0.3.1-0.20210601190600-f512dac51e8e
+	github.com/ipld/go-car v0.3.2-0.20211001225732-32d0d9933823
 	github.com/ipld/go-car/v2 v2.0.2
 	github.com/ipld/go-ipld-prime v0.12.3
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2
 github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZc0g37pY0=
 github.com/ipld/go-car v0.1.1-0.20200923150018-8cdef32e2da4/go.mod h1:xrMEcuSq+D1vEwl+YAXsg/JfA98XGpXDwnkIL4Aimqw=
 github.com/ipld/go-car v0.1.1-0.20201119040415-11b6074b6d4d/go.mod h1:2Gys8L8MJ6zkh1gktTSXreY63t4UbyvNp5JaudTyxHQ=
-github.com/ipld/go-car v0.3.1-0.20210601190600-f512dac51e8e h1:iTAJWTWEMe0Lx8JwRaIYrYgDuI9bVzkgogGz43Yv9Eo=
-github.com/ipld/go-car v0.3.1-0.20210601190600-f512dac51e8e/go.mod h1:wUxBdwOLA9/0HZBi3fnTBzla0MuwlqgJLyrhOg1XaKI=
+github.com/ipld/go-car v0.3.2-0.20211001225732-32d0d9933823 h1:8JMSJ0k71fU9lIUrpVwEdoX4KoxiTEX8cZG97v/hTDw=
+github.com/ipld/go-car v0.3.2-0.20211001225732-32d0d9933823/go.mod h1:jSlTph+i/q1jLFoiKKeN69KGG0fXpwrcD0izu5C1Tpo=
 github.com/ipld/go-car/v2 v2.0.0-beta1.0.20210721090610-5a9d1b217d25/go.mod h1:I2ACeeg6XNBe5pdh5TaR7Ambhfa7If9KXxmXgZsYENU=
 github.com/ipld/go-car/v2 v2.0.2 h1:R1oIAPwrGp26mEFzcGf5bfTZAAHDOkaVnZTEVebaWX4=
 github.com/ipld/go-car/v2 v2.0.2/go.mod h1:I2ACeeg6XNBe5pdh5TaR7Ambhfa7If9KXxmXgZsYENU=
@@ -505,6 +505,7 @@ github.com/ipld/go-ipld-prime v0.5.1-0.20201021195245-109253e8a018/go.mod h1:0xE
 github.com/ipld/go-ipld-prime v0.9.0/go.mod h1:KvBLMr4PX1gWptgkzRjVZCrLmSGcZCb/jioOQwCqZN8=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210930132912-0b3aef3ca569/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/ipld/go-ipld-prime v0.12.3 h1:furVobw7UBLQZwlEwfE26tYORy3PAK8VYSgZOSr3JMQ=
 github.com/ipld/go-ipld-prime v0.12.3/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/ipld/go-ipld-prime-proto v0.0.0-20200428191222-c1ffdadc01e1/go.mod h1:OAV6xBmuTLsPZ+epzKkPB1e25FHk/vCtyatkdHcArLs=

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -174,7 +174,7 @@ func TestOfflineStorageRetrieval(t *testing.T) {
 				// hacky but need it for now because if it's manual, we wont get a CommP.
 				TransferType: storagemarket.TTGraphsync,
 				Root:         sh.PayloadCid,
-			})
+			}, 2<<29)
 			require.NoError(t, err)
 
 			// propose deal

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -26,7 +26,7 @@ import (
 // We can't rely on the CARv1 payload in the given CARv2 file being deterministic as the client could have
 // written a "non-deterministic/unordered" CARv2 file.
 // So, we need to do a CARv1 traversal here by giving the traverser a random access CARv2 blockstore that wraps the given CARv2 file.
-func CommP(ctx context.Context, bs bstore.Blockstore, data *storagemarket.DataRef) (cid.Cid, abi.UnpaddedPieceSize, error) {
+func CommP(ctx context.Context, bs bstore.Blockstore, data *storagemarket.DataRef, maxTraversalLinks uint64) (cid.Cid, abi.UnpaddedPieceSize, error) {
 	// if we already have the PieceCid, there's no need to do anything here.
 	if data.PieceCid != nil {
 		return *data.PieceCid, data.PieceSize, nil
@@ -50,7 +50,7 @@ func CommP(ctx context.Context, bs bstore.Blockstore, data *storagemarket.DataRe
 	// defer fs.Close()
 
 	// do a CARv1 traversal with the DFS selector.
-	sc := car.NewSelectiveCar(ctx, bs, []car.Dag{{Root: data.Root, Selector: shared.AllSelector()}})
+	sc := car.NewSelectiveCar(ctx, bs, []car.Dag{{Root: data.Root, Selector: shared.AllSelector()}}, car.MaxTraversalLinks(maxTraversalLinks))
 	prepared, err := sc.Prepare()
 	if err != nil {
 		return cid.Undef, 0, xerrors.Errorf("failed to prepare CAR: %w", err)

--- a/storagemarket/impl/clientutils/clientutils_test.go
+++ b/storagemarket/impl/clientutils/clientutils_test.go
@@ -35,7 +35,7 @@ func TestCommP(t *testing.T) {
 			PieceCid:     pieceCid,
 			PieceSize:    pieceSize,
 		}
-		respcid, ressize, err := clientutils.CommP(ctx, nil, data)
+		respcid, ressize, err := clientutils.CommP(ctx, nil, data, 2<<29)
 		require.NoError(t, err)
 		require.Equal(t, respcid, *pieceCid)
 		require.Equal(t, ressize, pieceSize)
@@ -47,7 +47,7 @@ func TestCommP(t *testing.T) {
 			Root:         root,
 		}
 
-		respcid, _, err := clientutils.CommP(ctx, bs, data)
+		respcid, _, err := clientutils.CommP(ctx, bs, data, 2<<29)
 		require.NoError(t, err)
 		require.NotEqual(t, respcid, cid.Undef)
 		return respcid

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -200,7 +200,7 @@ func TestMakeDealOffline(t *testing.T) {
 				// hacky but need it for now because if it's manual, we wont get a CommP.
 				TransferType: storagemarket.TTGraphsync,
 				Root:         h.PayloadCid,
-			})
+			}, 2<<29)
 			require.NoError(t, err)
 
 			dataRef := &storagemarket.DataRef{


### PR DESCRIPTION
# Goals

Limit the depth of a DAG we're willing to process for CommP, expose this as
a configurable option via the public API.

Blockers:
- [x] tag go-ipld-prime v0.12.3 and update