### PR TITLE
Standardize definition of a recursive non-matching selector

### DIFF
--- a/retrievalmarket/impl/client.go
+++ b/retrievalmarket/impl/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	logging "github.com/ipfs/go-log/v2"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
@@ -418,7 +419,7 @@ func (c *clientDealEnvironment) Node() retrievalmarket.RetrievalClientNode {
 }
 
 func (c *clientDealEnvironment) OpenDataTransfer(ctx context.Context, to peer.ID, proposal *retrievalmarket.DealProposal, legacy bool) (datatransfer.ChannelID, error) {
-	sel := shared.AllSelector()
+	sel := selectorparse.CommonSelector_ExploreAllRecursively
 	if proposal.SelectorSpecified() {
 		var err error
 		sel, err = retrievalmarket.DecodeNode(proposal.Selector)

--- a/retrievalmarket/impl/client_test.go
+++ b/retrievalmarket/impl/client_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	dss "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +31,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/migrations"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
@@ -387,7 +387,7 @@ func TestMigrations(t *testing.T) {
 	selfPeer := tut.GeneratePeers(1)[0]
 
 	allSelectorBuf := new(bytes.Buffer)
-	err := dagcbor.Encode(shared.AllSelector(), allSelectorBuf)
+	err := dagcbor.Encode(selectorparse.CommonSelector_ExploreAllRecursively, allSelectorBuf)
 	require.NoError(t, err)
 	allSelectorBytes := allSelectorBuf.Bytes()
 

--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -19,6 +19,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +37,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
 	rmtesting "github.com/filecoin-project/go-fil-markets/retrievalmarket/testing"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/stores"
 )
@@ -232,7 +232,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			filesize:    410,
 			unsealPrice: abi.NewTokenAmount(100),
 			voucherAmts: []abi.TokenAmount{abi.NewTokenAmount(100), abi.NewTokenAmount(410100)},
-			selector:    shared.AllSelector(),
+			selector:    selectorparse.CommonSelector_ExploreAllRecursively,
 			paramsV1:    true,
 		},
 		{name: "1 block file retrieval succeeds with existing payment channel",
@@ -294,7 +294,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			filesize:    19000,
 			voucherAmts: []abi.TokenAmount{abi.NewTokenAmount(10174000), abi.NewTokenAmount(19958000)},
 			paramsV1:    true,
-			selector:    shared.AllSelector()},
+			selector:    selectorparse.CommonSelector_ExploreAllRecursively},
 		{name: "partial file retrieval succeeds with V1 params and selector recursion depth 1",
 			filename:    "lorem.txt",
 			filesize:    1024,
@@ -372,7 +372,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 			fs, err := stores.ReadOnlyFilestore(path)
 			require.NoError(t, err)
 
-			sc := car.NewSelectiveCar(bgCtx, fs, []car.Dag{{Root: payloadCID, Selector: shared.AllSelector()}})
+			sc := car.NewSelectiveCar(bgCtx, fs, []car.Dag{{Root: payloadCID, Selector: selectorparse.CommonSelector_ExploreAllRecursively}})
 			prepared, err := sc.Prepare()
 			require.NoError(t, err)
 			carBuf := new(bytes.Buffer)

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ipfs/go-datastore/namespace"
 	dss "github.com/ipfs/go-datastore/sync"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/migrations"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -1095,7 +1095,7 @@ func TestProviderMigrations(t *testing.T) {
 	offsets := make([]abi.PaddedPieceSize, numDeals)
 	lengths := make([]abi.PaddedPieceSize, numDeals)
 	allSelectorBuf := new(bytes.Buffer)
-	err := dagcbor.Encode(shared.AllSelector(), allSelectorBuf)
+	err := dagcbor.Encode(selectorparse.CommonSelector_ExploreAllRecursively, allSelectorBuf)
 	require.NoError(t, err)
 	allSelectorBytes := allSelectorBuf.Bytes()
 

--- a/retrievalmarket/impl/requestvalidation/requestvalidation.go
+++ b/retrievalmarket/impl/requestvalidation/requestvalidation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
@@ -18,7 +19,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/piecestore"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/migrations"
-	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 var allSelectorBytes []byte
@@ -27,7 +27,7 @@ var askTimeout = 5 * time.Second
 
 func init() {
 	buf := new(bytes.Buffer)
-	_ = dagcbor.Encode(shared.AllSelector(), buf)
+	_ = dagcbor.Encode(selectorparse.CommonSelector_ExploreAllRecursively, buf)
 	allSelectorBytes = buf.Bytes()
 }
 

--- a/retrievalmarket/impl/requestvalidation/requestvalidation_test.go
+++ b/retrievalmarket/impl/requestvalidation/requestvalidation_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/requestvalidation"
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket/migrations"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
@@ -28,7 +28,7 @@ func TestValidatePush(t *testing.T) {
 	sender := shared_testutil.GeneratePeers(1)[0]
 	voucher := shared_testutil.MakeTestDealProposal()
 	requestValidator := requestvalidation.NewProviderRequestValidator(fve)
-	voucherResult, err := requestValidator.ValidatePush(false, datatransfer.ChannelID{}, sender, &voucher, voucher.PayloadCID, shared.AllSelector())
+	voucherResult, err := requestValidator.ValidatePush(false, datatransfer.ChannelID{}, sender, &voucher, voucher.PayloadCID, selectorparse.CommonSelector_ExploreAllRecursively)
 	require.Equal(t, nil, voucherResult)
 	require.Error(t, err)
 }
@@ -77,7 +77,7 @@ func TestValidatePull(t *testing.T) {
 				GetPieceErr:                     errors.New("something went wrong"),
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: errors.New("something went wrong"),
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -92,7 +92,7 @@ func TestValidatePull(t *testing.T) {
 				GetPieceErr:                     retrievalmarket.ErrNotFound,
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: retrievalmarket.ErrNotFound,
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -106,7 +106,7 @@ func TestValidatePull(t *testing.T) {
 				CheckDealParamsError: errors.New("something went wrong"),
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: errors.New("something went wrong"),
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -120,7 +120,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicError: errors.New("something went wrong"),
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: errors.New("something went wrong"),
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -134,7 +134,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicFailReason: "something went wrong",
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: errors.New("something went wrong"),
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -149,7 +149,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicAccepted: true,
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: errors.New("everything is awful"),
 		},
@@ -158,7 +158,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicAccepted: true,
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &proposal,
 			expectedError: datatransfer.ErrPause,
 			expectedVoucherResult: &retrievalmarket.DealResponse{
@@ -171,7 +171,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicAccepted: true,
 			},
 			baseCid:       proposal.PayloadCID,
-			selector:      shared.AllSelector(),
+			selector:      selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:       &legacyProposal,
 			expectedError: datatransfer.ErrPause,
 			expectedVoucherResult: &migrations.DealResponse0{
@@ -185,7 +185,7 @@ func TestValidatePull(t *testing.T) {
 				RunDealDecisioningLogicAccepted: true,
 			},
 			baseCid:               proposal.PayloadCID,
-			selector:              shared.AllSelector(),
+			selector:              selectorparse.CommonSelector_ExploreAllRecursively,
 			voucher:               &proposal,
 			expectedError:         nil,
 			expectedVoucherResult: nil,

--- a/retrievalmarket/storage_retrieval_integration_test.go
+++ b/retrievalmarket/storage_retrieval_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ipld/go-car"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,6 @@ import (
 	retrievalimpl "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl"
 	testnodes2 "github.com/filecoin-project/go-fil-markets/retrievalmarket/impl/testnodes"
 	rmnet "github.com/filecoin-project/go-fil-markets/retrievalmarket/network"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
@@ -164,7 +164,7 @@ func TestOfflineStorageRetrieval(t *testing.T) {
 			shared_testutil.StartAndWaitForReady(ctx, t, sh.Client)
 
 			// Do a Selective CARv1 traversal on the CARv2 file to get a deterministic CARv1 that we can import on the miner side.
-			sc := car.NewSelectiveCar(ctx, sh.Data, []car.Dag{{Root: sh.PayloadCid, Selector: shared.AllSelector()}})
+			sc := car.NewSelectiveCar(ctx, sh.Data, []car.Dag{{Root: sh.PayloadCid, Selector: selectorparse.CommonSelector_ExploreAllRecursively}})
 			prepared, err := sc.Prepare()
 			require.NoError(t, err)
 			carBuf := new(bytes.Buffer)
@@ -581,7 +581,7 @@ func doRetrieve(t *testing.T, ctx context.Context, rh *retrievalHarness, sh *tes
 
 	// testing V1 only
 	rmParams, err := retrievalmarket.NewParamsV1(rh.RetrievalParams.PricePerByte, rh.RetrievalParams.PaymentInterval, rh.RetrievalParams.PaymentIntervalIncrease,
-		shared.AllSelector(), nil,
+		selectorparse.CommonSelector_ExploreAllRecursively, nil,
 		rh.RetrievalParams.UnsealPrice)
 	require.NoError(t, err)
 

--- a/retrievalmarket/types_test.go
+++ b/retrievalmarket/types_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ipld/go-ipld-prime/codec/dagcbor"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,14 +16,13 @@ import (
 	"github.com/filecoin-project/go-state-types/big"
 
 	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
-	"github.com/filecoin-project/go-fil-markets/shared"
 	tut "github.com/filecoin-project/go-fil-markets/shared_testutil"
 )
 
 func TestParamsMarshalUnmarshal(t *testing.T) {
 	pieceCid := tut.GenerateCids(1)[0]
 
-	allSelector := shared.AllSelector()
+	allSelector := selectorparse.CommonSelector_ExploreAllRecursively
 	params, err := retrievalmarket.NewParamsV1(abi.NewTokenAmount(123), 456, 789, allSelector, &pieceCid, big.Zero())
 	assert.NoError(t, err)
 

--- a/shared/selectors.go
+++ b/shared/selectors.go
@@ -2,15 +2,9 @@ package shared
 
 import (
 	"github.com/ipld/go-ipld-prime"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
-	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 )
 
-// entire DAG selector
-func AllSelector() ipld.Node {
-	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
-	return ssb.ExploreRecursive(selector.RecursionLimitNone(),
-		ssb.ExploreAll(ssb.ExploreRecursiveEdge())).
-		Node()
-}
+// AllSelector is a compatibility alias for an entire DAG non-matching-selector
+// Use selectorparse.CommonSelector_ExploreAllRecursively directly in new code
+func AllSelector() ipld.Node { return selectorparse.CommonSelector_ExploreAllRecursively }

--- a/shared_testutil/test_ipld_tree.go
+++ b/shared_testutil/test_ipld_tree.go
@@ -16,8 +16,7 @@ import (
 	"github.com/ipld/go-ipld-prime/fluent"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-
-	"github.com/filecoin-project/go-fil-markets/shared"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 )
 
 // TestIPLDTree is a set of IPLD Data that forms a tree spread across some blocks
@@ -130,7 +129,7 @@ func (tt TestIPLDTree) DumpToCar(out io.Writer, userOnNewCarBlocks ...car.OnNewC
 	sc := car.NewSelectiveCar(ctx, tt, []car.Dag{
 		{
 			Root:     tt.RootNodeLnk.(cidlink.Link).Cid,
-			Selector: shared.AllSelector(),
+			Selector: selectorparse.CommonSelector_ExploreAllRecursively,
 		},
 	})
 

--- a/shared_testutil/testchannel.go
+++ b/shared_testutil/testchannel.go
@@ -3,12 +3,11 @@ package shared_testutil
 import (
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/exp/rand"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-
-	"github.com/filecoin-project/go-fil-markets/shared"
 )
 
 // TestChannelParams are params for a new test data transfer channel
@@ -65,7 +64,7 @@ func NewTestChannel(params TestChannelParams) datatransfer.ChannelState {
 		selfPeer:       peers[0],
 		transferID:     datatransfer.TransferID(rand.Uint64()),
 		baseCID:        GenerateCids(1)[0],
-		selector:       shared.AllSelector(),
+		selector:       selectorparse.CommonSelector_ExploreAllRecursively,
 		sender:         peers[0],
 		recipient:      peers[1],
 		totalSize:      rand.Uint64(),

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"golang.org/x/xerrors"
 
@@ -15,7 +16,6 @@ import (
 	"github.com/filecoin-project/go-state-types/exitcode"
 	"github.com/filecoin-project/go-statemachine/fsm"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/requestvalidation"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/network"
@@ -165,7 +165,7 @@ func InitiateDataTransfer(ctx fsm.Context, environment ClientDealEnvironment, de
 		deal.Miner,
 		&requestvalidation.StorageDataTransferVoucher{Proposal: deal.ProposalCid},
 		deal.DataRef.Root,
-		shared.AllSelector(),
+		selectorparse.CommonSelector_ExploreAllRecursively,
 	)
 
 	if err != nil {

--- a/storagemarket/impl/clientutils/clientutils.go
+++ b/storagemarket/impl/clientutils/clientutils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ipfs/go-cid"
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/ipld/go-car"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/multiformats/go-multibase"
 	"golang.org/x/xerrors"
 
@@ -50,7 +51,7 @@ func CommP(ctx context.Context, bs bstore.Blockstore, data *storagemarket.DataRe
 	// defer fs.Close()
 
 	// do a CARv1 traversal with the DFS selector.
-	sc := car.NewSelectiveCar(ctx, bs, []car.Dag{{Root: data.Root, Selector: shared.AllSelector()}}, car.MaxTraversalLinks(maxTraversalLinks))
+	sc := car.NewSelectiveCar(ctx, bs, []car.Dag{{Root: data.Root, Selector: selectorparse.CommonSelector_ExploreAllRecursively}}, car.MaxTraversalLinks(maxTraversalLinks))
 	prepared, err := sc.Prepare()
 	if err != nil {
 		return cid.Undef, 0, xerrors.Errorf("failed to prepare CAR: %w", err)

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-car"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -20,7 +21,6 @@ import (
 	dtnet "github.com/filecoin-project/go-data-transfer/network"
 	"github.com/filecoin-project/go-state-types/big"
 
-	"github.com/filecoin-project/go-fil-markets/shared"
 	"github.com/filecoin-project/go-fil-markets/shared_testutil"
 	"github.com/filecoin-project/go-fil-markets/storagemarket"
 	"github.com/filecoin-project/go-fil-markets/storagemarket/impl/clientutils"
@@ -235,7 +235,7 @@ func TestMakeDealOffline(t *testing.T) {
 
 			// Do a selective CARv1 traversal on the CARv2 file to get a
 			// deterministic CARv1 that we can import on the miner side.
-			sc := car.NewSelectiveCar(ctx, h.Data, []car.Dag{{Root: h.PayloadCid, Selector: shared.AllSelector()}})
+			sc := car.NewSelectiveCar(ctx, h.Data, []car.Dag{{Root: h.PayloadCid, Selector: selectorparse.CommonSelector_ExploreAllRecursively}})
 			prepared, err := sc.Prepare()
 			require.NoError(t, err)
 			carBuf := new(bytes.Buffer)


### PR DESCRIPTION
In the spirit of https://github.com/filecoin-project/lotus/pull/7467

It was confirmed that [key order in this map](https://github.com/filecoin-project/lotus/pull/7467#issuecomment-937664000) is irrelevant, therefore this is a non-functional change.