### PR TITLE
log failure to connect to full node without returning it

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -193,7 +193,7 @@ func (p *Provider) Start(ctx context.Context) error {
 
 	// connect the index provider node with the full node and protect that connection
 	if err := p.meshCreator.Connect(ctx); err != nil {
-		return fmt.Errorf("failed to connect index provider host with the full node: %w", err)
+		log.Errorf("failed to connect index provider host with the full node: %s", err)
 	}
 
 	go func() {


### PR DESCRIPTION
This PR is removing the `return err` when the markets node fails to connect to the fullnode, as this is not a critical error, and it should not prevent the markets node from booting up.

Relates to:
- https://github.com/filecoin-project/index-provider/issues/177