### PR TITLE
better answer message on ErrNotFound

### DIFF
--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -59,6 +59,7 @@ func TestClientCanMakeQueryToProvider(t *testing.T) {
 	t.Run("when piece is not found, returns unavailable", func(t *testing.T) {
 		expectedQR.PieceCIDFound = retrievalmarket.QueryItemUnavailable
 		expectedQR.Status = retrievalmarket.QueryResponseUnavailable
+		expectedQR.Message = "piece info for cid not found (deal has not been added to a piece yet)"
 		expectedQR.Size = 0
 		actualQR, err := client.Query(bgCtx, retrievalPeer, missingPiece, retrievalmarket.QueryParams{})
 		actualQR.MaxPaymentInterval = expectedQR.MaxPaymentInterval

--- a/retrievalmarket/impl/provider.go
+++ b/retrievalmarket/impl/provider.go
@@ -344,6 +344,8 @@ func (p *Provider) HandleQueryStream(stream rmnet.RetrievalQueryStream) {
 		if !xerrors.Is(err, retrievalmarket.ErrNotFound) {
 			answer.Status = retrievalmarket.QueryResponseError
 			answer.Message = fmt.Sprintf("failed to fetch piece to retrieve from: %s", err)
+		} else {
+			answer.Message = "piece info for cid not found (deal has not been added to a piece yet)"
 		}
 
 		sendResp(answer)

--- a/retrievalmarket/impl/provider_test.go
+++ b/retrievalmarket/impl/provider_test.go
@@ -815,6 +815,7 @@ func TestHandleQueryStream(t *testing.T) {
 			expResp: retrievalmarket.QueryResponse{
 				Status:        retrievalmarket.QueryResponseUnavailable,
 				PieceCIDFound: retrievalmarket.QueryItemUnavailable,
+				Message:       "piece info for cid not found (deal has not been added to a piece yet)",
 			},
 			expectedPricePerByte:            big.Zero(),
 			expectedPaymentInterval:         0,
@@ -830,6 +831,7 @@ func TestHandleQueryStream(t *testing.T) {
 			expResp: retrievalmarket.QueryResponse{
 				Status:        retrievalmarket.QueryResponseUnavailable,
 				PieceCIDFound: retrievalmarket.QueryItemUnavailable,
+				Message:       "piece info for cid not found (deal has not been added to a piece yet)",
 			},
 			expectedPricePerByte:            big.Zero(),
 			expectedPaymentInterval:         0,


### PR DESCRIPTION
On `retrievalmarket.ErrNotFound`, `answer.Message` is "", which results in a rather obscure error message, namely:

```
retrieval query offer was unavailable:
```

This PR is adding an `answer.Message` so that we get the following error message, and make it clear that the mapping between data cid and piece is missing:

```
retrieval query offer was unavailable: piece info for cid not found (deal has not been added to a piece yet)
```