### PR TITLE
Lookup state of a deal

### DIFF
--- a/storagemarket/impl/provider.go
+++ b/storagemarket/impl/provider.go
@@ -463,6 +463,12 @@ func (p *Provider) ListLocalDeals() ([]storagemarket.MinerDeal, error) {
 	return out, nil
 }
 
+func (p *Provider) GetLocalDeal(propCid cid.Cid) (storagemarket.MinerDeal, error) {
+	var d storagemarket.MinerDeal
+	err := p.deals.Get(propCid).Get(&d)
+	return d, err
+}
+
 // SetAsk configures the storage miner's ask with the provided price,
 // duration, and options. Any previously-existing ask is replaced.
 func (p *Provider) SetAsk(price abi.TokenAmount, verifiedPrice abi.TokenAmount, duration abi.ChainEpoch, options ...storagemarket.StorageAskOption) error {

--- a/storagemarket/integration_test.go
+++ b/storagemarket/integration_test.go
@@ -166,6 +166,10 @@ func TestMakeDeal(t *testing.T) {
 				assert.True(t, pd.FastRetrieval)
 				shared_testutil.AssertDealState(t, storagemarket.StorageDealExpired, pd.State)
 
+				dl, err := h.Provider.GetLocalDeal(pd.ProposalCid)
+				require.NoError(t, err)
+				assert.True(t, dl.FastRetrieval)
+
 				// test out query protocol
 				status, err := h.Client.GetProviderDealState(ctx, proposalCid)
 				assert.NoError(t, err)

--- a/storagemarket/provider.go
+++ b/storagemarket/provider.go
@@ -39,6 +39,8 @@ type StorageProvider interface {
 	// ListLocalDeals lists deals processed by this storage provider
 	ListLocalDeals() ([]MinerDeal, error)
 
+	GetLocalDeal(propCid cid.Cid) (MinerDeal, error)
+
 	// AddStorageCollateral adds storage collateral
 	AddStorageCollateral(ctx context.Context, amount abi.TokenAmount) error
 


### PR DESCRIPTION
This is needed so the Boost index provider can lookup legacy deals to serve their CARv2 Index.