### PR TITLE
Fix CI caching failure caused by invalid path to `go.mod`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run: sudo apt-get update
       - restore_cache:
           name: restore go mod cache
-          key: v1-go-deps-{{ arch }}-{{ checksum "/home/circleci/project/go-fil-markets/go.mod" }}
+          key: v1-go-deps-{{ arch }}-{{ checksum "/home/circleci/project/go.mod" }}
       - run:
           command: make build
       - store_artifacts:


### PR DESCRIPTION
Fix invalid path to `go.mod` in CircleCI build used for caching.