### PR TITLE
Include pieceinfo for deal decider

### DIFF
--- a/retrievalmarket/impl/integration_test.go
+++ b/retrievalmarket/impl/integration_test.go
@@ -208,7 +208,7 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 	}).Node()
 
 	var customDeciderRan bool
-
+	var customDeciderPiece cid.Cid
 	testCases := []struct {
 		name                    string
 		decider                 retrievalimpl.DealDecider
@@ -311,6 +311,9 @@ func TestClientCanMakeDealWithProvider(t *testing.T) {
 		{name: "succeeds when using a custom decider function",
 			decider: func(ctx context.Context, state retrievalmarket.ProviderDealState) (bool, string, error) {
 				customDeciderRan = true
+				if state.PieceInfo != nil {
+					customDeciderPiece = state.PieceInfo.PieceCID
+				}
 				return true, "", nil
 			},
 			filename:    "lorem_under_1_block.txt",
@@ -596,6 +599,7 @@ CurrentInterval: %d
 			// https://github.com/filecoin-project/go-fil-markets/issues/65
 			if testCase.decider != nil {
 				assert.True(t, customDeciderRan)
+				assert.Equal(t, pieceInfo.PieceCID, customDeciderPiece)
 			}
 			// verify that the nodes we interacted with behaved as expected
 			clientNode.VerifyExpectations(t)

--- a/retrievalmarket/impl/requestvalidation/requestvalidation.go
+++ b/retrievalmarket/impl/requestvalidation/requestvalidation.go
@@ -164,6 +164,8 @@ func (rv *ProviderRequestValidator) acceptDeal(deal *retrievalmarket.ProviderDea
 		return retrievalmarket.DealStatusErrored, err
 	}
 
+	deal.PieceInfo = &pieceInfo
+
 	ctx, cancel := context.WithTimeout(context.TODO(), askTimeout)
 	defer cancel()
 
@@ -186,8 +188,6 @@ func (rv *ProviderRequestValidator) acceptDeal(deal *retrievalmarket.ProviderDea
 	if !accepted {
 		return retrievalmarket.DealStatusRejected, errors.New(reason)
 	}
-
-	deal.PieceInfo = &pieceInfo
 
 	if deal.UnsealPrice.GreaterThan(big.Zero()) {
 		return retrievalmarket.DealStatusFundsNeededUnseal, nil


### PR DESCRIPTION
# Goal

A minor changes means that when custom deal decider is called, it includes deal.PieceInfo, which has the found piece CID when none is passed in the deal proposal