### PR TITLE
fix: store identity CIDs in CARs for online deals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/ipfs/go-merkledag v0.6.0
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipld/go-car v0.4.0
-	github.com/ipld/go-car/v2 v2.4.1
+	github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8
 	github.com/ipld/go-codec-dagpb v1.3.1
 	github.com/ipld/go-ipld-prime v0.17.0
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/ipfs/go-merkledag v0.6.0
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipld/go-car v0.4.0
-	github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8
+	github.com/ipld/go-car/v2 v2.5.0
 	github.com/ipld/go-codec-dagpb v1.3.1
 	github.com/ipld/go-ipld-prime v0.17.0
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,8 @@ github.com/ipld/go-car v0.3.2/go.mod h1:WEjynkVt04dr0GwJhry0KlaTeSDEiEYyMPOxDBQ1
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=
 github.com/ipld/go-car v0.4.0/go.mod h1:Uslcn4O9cBKK9wqHm/cLTFacg6RAPv6LZx2mxd2Ypl4=
 github.com/ipld/go-car/v2 v2.1.1/go.mod h1:+2Yvf0Z3wzkv7NeI69i8tuZ+ft7jyjPYIWZzeVNeFcI=
-github.com/ipld/go-car/v2 v2.4.1 h1:9S+FYbQzQJ/XzsdiOV13W5Iu/i+gUnr6csbSD9laFEg=
-github.com/ipld/go-car/v2 v2.4.1/go.mod h1:zjpRf0Jew9gHqSvjsKVyoq9OY9SWoEKdYCQUKVaaPT0=
+github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8 h1:bvUddbZEbZTzjHlailriBImnRP9jiHSXkA03ybkPztc=
+github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8/go.mod h1:zjpRf0Jew9gHqSvjsKVyoq9OY9SWoEKdYCQUKVaaPT0=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
 github.com/ipld/go-codec-dagpb v1.3.1 h1:yVNlWRQexCa54ln3MSIiUN++ItH7pdhBFhh0hSgZu1w=

--- a/go.sum
+++ b/go.sum
@@ -714,8 +714,8 @@ github.com/ipld/go-car v0.3.2/go.mod h1:WEjynkVt04dr0GwJhry0KlaTeSDEiEYyMPOxDBQ1
 github.com/ipld/go-car v0.4.0 h1:U6W7F1aKF/OJMHovnOVdst2cpQE5GhmHibQkAixgNcQ=
 github.com/ipld/go-car v0.4.0/go.mod h1:Uslcn4O9cBKK9wqHm/cLTFacg6RAPv6LZx2mxd2Ypl4=
 github.com/ipld/go-car/v2 v2.1.1/go.mod h1:+2Yvf0Z3wzkv7NeI69i8tuZ+ft7jyjPYIWZzeVNeFcI=
-github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8 h1:bvUddbZEbZTzjHlailriBImnRP9jiHSXkA03ybkPztc=
-github.com/ipld/go-car/v2 v2.4.2-0.20220902111941-7b1af9af7fe8/go.mod h1:zjpRf0Jew9gHqSvjsKVyoq9OY9SWoEKdYCQUKVaaPT0=
+github.com/ipld/go-car/v2 v2.5.0 h1:S9h7A6qBAJ+B1M1jIKtau+HPDe30UbM71vsyBzwvRIE=
+github.com/ipld/go-car/v2 v2.5.0/go.mod h1:jKjGOqoCj5zn6KjnabD6JbnCsMntqU2hLiU6baZVO3E=
 github.com/ipld/go-codec-dagpb v1.2.0/go.mod h1:6nBN7X7h8EOsEejZGqC7tej5drsdBAXbMHyBT+Fne5s=
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
 github.com/ipld/go-codec-dagpb v1.3.1 h1:yVNlWRQexCa54ln3MSIiUN++ItH7pdhBFhh0hSgZu1w=

--- a/stores/filestore.go
+++ b/stores/filestore.go
@@ -43,6 +43,7 @@ func ReadOnlyFilestore(path string) (ClosableBlockstore, error) {
 func ReadWriteFilestore(path string, roots ...cid.Cid) (ClosableBlockstore, error) {
 	rw, err := OpenReadWrite(path, roots,
 		carv2.ZeroLengthSectionAsEOF(true),
+		carv2.StoreIdentityCIDs(true),
 		blockstore.UseWholeCIDs(true),
 	)
 	if err != nil {

--- a/stores/rw_bstores.go
+++ b/stores/rw_bstores.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/ipfs/go-cid"
+	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 	"golang.org/x/xerrors"
 )
@@ -38,7 +39,7 @@ func (r *ReadWriteBlockstores) GetOrOpen(key string, path string, rootCid cid.Ci
 		return bs, nil
 	}
 
-	bs, err := blockstore.OpenReadWrite(path, []cid.Cid{rootCid}, blockstore.UseWholeCIDs(true))
+	bs, err := blockstore.OpenReadWrite(path, []cid.Cid{rootCid}, blockstore.UseWholeCIDs(true), carv2.StoreIdentityCIDs(true))
 	if err != nil {
 		return nil, xerrors.Errorf("failed to create read-write blockstore: %w", err)
 	}


### PR DESCRIPTION
Builds on #747 and relies on https://github.com/ipld/go-car/pull/332

This matches historical precedent, without doing this we get CommP failures where
deals are made with intermediate inline CIDs and the client stores them in
the CAR used to make CommP. car.SelectiveCar is the historical way of doing
this.

e.g. https://github.com/filecoin-project/lotus/blob/a843c52e38da13da489cbe6b290ea49b2660b3fb/node/impl/client/client.go#L1405-L1412

More discussion in https://github.com/ipld/go-car/pull/332, and I'll also open a Lotus PR to bring this in and test it there and will link back here from that.