### PR TITLE
add proposal cid parameter to PieceStore.AddDealForPiece

### DIFF
--- a/piecestore/impl/piecestore.go
+++ b/piecestore/impl/piecestore.go
@@ -83,7 +83,7 @@ func (ps *pieceStore) OnReady(ready shared.ReadyFunc) {
 }
 
 // Store `dealInfo` in the PieceStore with key `pieceCID`.
-func (ps *pieceStore) AddDealForPiece(pieceCID cid.Cid, dealInfo piecestore.DealInfo) error {
+func (ps *pieceStore) AddDealForPiece(pieceCID cid.Cid, _ cid.Cid, dealInfo piecestore.DealInfo) error {
 	return ps.mutatePieceInfo(pieceCID, func(pi *piecestore.PieceInfo) error {
 		for _, di := range pi.Deals {
 			if di == dealInfo {

--- a/piecestore/impl/piecestore_test.go
+++ b/piecestore/impl/piecestore_test.go
@@ -27,6 +27,7 @@ func TestStorePieceInfo(t *testing.T) {
 	ctx := context.Background()
 	pieceCid := shared_testutil.GenerateCids(1)[0]
 	pieceCid2 := shared_testutil.GenerateCids(1)[0]
+	payloadCid := shared_testutil.GenerateCids(1)[0]
 	initializePieceStore := func(t *testing.T, ctx context.Context) piecestore.PieceStore {
 		ps, err := piecestoreimpl.NewPieceStore(datastore.NewMapDatastore())
 		require.NoError(t, err)
@@ -47,7 +48,7 @@ func TestStorePieceInfo(t *testing.T) {
 			Offset:   abi.PaddedPieceSize(rand.Uint64()),
 			Length:   abi.PaddedPieceSize(rand.Uint64()),
 		}
-		err := ps.AddDealForPiece(pieceCid, dealInfo)
+		err := ps.AddDealForPiece(pieceCid, payloadCid, dealInfo)
 		assert.NoError(t, err)
 
 		pi, err := ps.GetPieceInfo(pieceCid)
@@ -71,7 +72,7 @@ func TestStorePieceInfo(t *testing.T) {
 			Offset:   abi.PaddedPieceSize(rand.Uint64()),
 			Length:   abi.PaddedPieceSize(rand.Uint64()),
 		}
-		err := ps.AddDealForPiece(pieceCid, dealInfo)
+		err := ps.AddDealForPiece(pieceCid, payloadCid, dealInfo)
 		assert.NoError(t, err)
 
 		pi, err := ps.GetPieceInfo(pieceCid)
@@ -79,7 +80,7 @@ func TestStorePieceInfo(t *testing.T) {
 		assert.Len(t, pi.Deals, 1)
 		assert.Equal(t, pi.Deals[0], dealInfo)
 
-		err = ps.AddDealForPiece(pieceCid, dealInfo)
+		err = ps.AddDealForPiece(pieceCid, payloadCid, dealInfo)
 		assert.NoError(t, err)
 
 		pi, err = ps.GetPieceInfo(pieceCid)

--- a/piecestore/types.go
+++ b/piecestore/types.go
@@ -61,7 +61,7 @@ func (pi PieceInfo) Defined() bool {
 type PieceStore interface {
 	Start(ctx context.Context) error
 	OnReady(ready shared.ReadyFunc)
-	AddDealForPiece(pieceCID cid.Cid, dealInfo DealInfo) error
+	AddDealForPiece(pieceCID cid.Cid, payloadCid cid.Cid, dealInfo DealInfo) error
 	AddPieceBlockLocations(pieceCID cid.Cid, blockLocations map[cid.Cid]BlockLocation) error
 	GetPieceInfo(pieceCID cid.Cid) (PieceInfo, error)
 	GetCIDInfo(payloadCID cid.Cid) (CIDInfo, error)

--- a/shared_testutil/test_piecestore.go
+++ b/shared_testutil/test_piecestore.go
@@ -96,7 +96,7 @@ func (tps *TestPieceStore) VerifyExpectations(t *testing.T) {
 }
 
 // AddDealForPiece returns a preprogrammed error
-func (tps *TestPieceStore) AddDealForPiece(pieceCID cid.Cid, dealInfo piecestore.DealInfo) error {
+func (tps *TestPieceStore) AddDealForPiece(pieceCID cid.Cid, _ cid.Cid, dealInfo piecestore.DealInfo) error {
 	return tps.addDealForPieceError
 }
 

--- a/storagemarket/impl/providerstates/provider_states.go
+++ b/storagemarket/impl/providerstates/provider_states.go
@@ -455,7 +455,7 @@ func recordPiece(environment ProviderDealEnvironment, deal storagemarket.MinerDe
 		return xerrors.Errorf("failed to add piece block locations: %s", err)
 	}
 
-	err := environment.PieceStore().AddDealForPiece(deal.Proposal.PieceCID, piecestore.DealInfo{
+	err := environment.PieceStore().AddDealForPiece(deal.Proposal.PieceCID, deal.ProposalCid, piecestore.DealInfo{
 		DealID:   deal.DealID,
 		SectorID: sectorID,
 		Offset:   offset,


### PR DESCRIPTION
For boost's piece store, we need a way to map between the the deal and the piece info.
So pass the deal proposal cid to AddDealForPiece