### PR TITLE
release: v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # go-fil-markets changelog
 
+# go-fil-markets v1.26.0
+ 
+- github.com/filecoin-project/go-fil-markets:
+  - refactor: add proposal cid parameter to PieceStore.AddDealForPiece (#768) ([filecoin-project/go-fil-markets#768](https://github.com/filecoin-project/go-fil-markets/pull/768))
+
+Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| dirkmc | 1 | +8/-7 | 5 |
+
 # go-fil-markets v1.25.3
 
 - github.com/filecoin-project/go-fil-markets:


### PR DESCRIPTION
# go-fil-markets v1.26.0
 
- github.com/filecoin-project/go-fil-markets:
  - refactor: add proposal cid parameter to PieceStore.AddDealForPiece (#768) ([filecoin-project/go-fil-markets#768](https://github.com/filecoin-project/go-fil-markets/pull/768))

Contributors

| Contributor | Commits | Lines ± | Files Changed |
|-------------|---------|---------|---------------|
| dirkmc | 1 | +8/-7 | 5 |
