### PR TITLE
fix: Ignore stream close error in ProposeDeal

### DIFF
--- a/shared_testutil/test_network_types.go
+++ b/shared_testutil/test_network_types.go
@@ -419,7 +419,6 @@ type TestStorageDealStream struct {
 	responseWriter StorageDealResponseWriter
 
 	CloseCount int
-	CloseError error
 }
 
 // TestStorageDealStreamParams are parameters used to setup a TestStorageDealStream.
@@ -485,7 +484,7 @@ func (tsds TestStorageDealStream) RemotePeer() peer.ID { return tsds.p }
 // Close closes the stream (does nothing for mocked stream)
 func (tsds *TestStorageDealStream) Close() error {
 	tsds.CloseCount += 1
-	return tsds.CloseError
+	return nil
 }
 
 // TrivialStorageDealProposalReader succeeds trivially, returning an empty proposal.

--- a/storagemarket/impl/clientstates/client_states.go
+++ b/storagemarket/impl/clientstates/client_states.go
@@ -106,7 +106,8 @@ func ProposeDeal(ctx fsm.Context, environment ClientDealEnvironment, deal storag
 
 	err = s.Close()
 	if err != nil {
-		return ctx.Trigger(storagemarket.ClientEventStreamCloseError, err)
+		// doesn't really matter but log the error
+		log.Debugw("failed to close deal stream", "error", err)
 	}
 
 	tok, _, err := environment.Node().GetChainHead(ctx.Context())

--- a/storagemarket/impl/clientstates/client_states_test.go
+++ b/storagemarket/impl/clientstates/client_states_test.go
@@ -157,17 +157,6 @@ func TestProposeDeal(t *testing.T) {
 			},
 		})
 	})
-	t.Run("closing the stream fails", func(t *testing.T) {
-		ds := tut.NewTestStorageDealStream(tut.TestStorageDealStreamParams{})
-		ds.CloseError = xerrors.Errorf("failed to close stream")
-		runAndInspect(t, storagemarket.StorageDealFundsReserved, clientstates.ProposeDeal, testCase{
-			envParams: envParams{dealStream: ds},
-			inspector: func(deal storagemarket.ClientDeal, env *fakeEnvironment) {
-				tut.AssertDealState(t, storagemarket.StorageDealError, deal.State)
-				assert.Equal(t, "error attempting to close stream: failed to close stream", deal.Message)
-			},
-		})
-	})
 	t.Run("getting chain head fails", func(t *testing.T) {
 		ds := tut.NewTestStorageDealStream(tut.TestStorageDealStreamParams{})
 		runAndInspect(t, storagemarket.StorageDealFundsReserved, clientstates.ProposeDeal, testCase{


### PR DESCRIPTION
Fix for the errors observed in https://github.com/filecoin-project/lotus/pull/10854

As far as I can tell this is the only place checking deal close errors